### PR TITLE
Adding Python-binding for find_candidate_object_locations

### DIFF
--- a/python_examples/find_candidate_object_locations.py
+++ b/python_examples/find_candidate_object_locations.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+# This example shows how to use find_candidate_object_locations()
+
+import dlib
+from skimage import io
+
+image_file = '../examples/faces/2009_004587.jpg'
+img = io.imread(image_file)
+
+# Locations of candidate objects will be saved into rects
+rects = []
+dlib.find_candidate_object_locations(img, rects, min_size=500)
+
+windows = []
+for d in rects:
+    windows.append([d.top(), d.left(), d.bottom(), d.right()])
+
+print len(windows)
+print (image_file, windows)

--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -199,13 +199,17 @@ obtain the fastest training speed.");
         .def_pickle(serialize_pickle<type>());
     }
 
+    // Here, pykvals is actually the result of linspace(start, end, num) and it is different from kvals used
+    // in find_candidate_object_locations(). See dlib/image_transforms/segment_image_abstract.h for more details.
+    // TODO: Need to figure out how to allow specifying matrix_range_exp<double> kvals in Python
     def("find_candidate_object_locations", find_candidate_object_locations_py,
             (arg("image"), arg("rects"), arg("pykvals")=boost::python::make_tuple(50, 200, 3),
              arg("min_size")=20, arg("max_merging_iterations")=50),
 "Returns found candidate objects\n\
 requires\n\
     - image == an image object which is a numpy ndarray\n\
-    - kvals == a tuple with three elements for start, end, num.\n\
+    - is_vector(kvals) == true\n\
+    - kvals.size() > 0\n\
 ensures\n\
     - This function takes an input image and generates a set of candidate\n\
       rectangles which are expected to bound any objects in the image.  It does\n\


### PR DESCRIPTION
Hi Davis,
This PR is for adding find_candidate_object_locations() to dlib's Python API. An example of how to use it is also included. There are a couple of things that I'd like to mention:

1) As shown in the comment, pykvals in the Python API is different from kvals in the C++ code. pykvals is actually a Python tuple (start, end, num) for linspace(start, end, num). I'm not sure whether dlib provides a Python object for matrix_range_exp.

2) Locations of candidate objects (rects) should be the result of find_candidate_object_locations_py() rather than its argument. However, I think it's better to be consistent with dlib's C++ API.

Please take a look and let me know whether I need to change something.
Thanks.