### PR TITLE
Add capability to get detection confidences and weight index in python

### DIFF
--- a/python_examples/face_detector_scores_idx.py
+++ b/python_examples/face_detector_scores_idx.py
@@ -1,0 +1,13 @@
+
+from PIL import Image
+import numpy as np
+import dlib
+
+img = np.array(Image.open('../examples/faces/2008_002506.jpg'))
+detector = dlib.get_frontal_face_detector()
+
+dets, scores, idx = detector.run(img, 1)
+
+for i, d in enumerate(dets):
+    print d, scores[i], idx[i]
+

--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -354,6 +354,18 @@ ensures \n\
       detector.  If you don't know how many times you want to upsample then \n\
       don't provide a value for upsample_num_times and an appropriate \n\
       default will be used.")
+        .def("run", run_rect_detector, (arg("image"), arg("upsample_num_times")),
+"requires \n\
+    - image is a numpy ndarray containing either an 8bit grayscale or RGB \n\
+      image. \n\
+    - upsample_num_times >= 0 \n\
+ensures \n\
+    - This function runs the object detector on the input image and returns \n\
+      a tuple of (list of detections, list of scores, list of weight_indices).   \n\
+    - Upsamples the image upsample_num_times before running the basic \n\
+      detector.  If you don't know how many times you want to upsample then \n\
+      don't provide a value for upsample_num_times and an appropriate \n\
+      default will be used.")
         .def("save", save_simple_object_detector, (arg("detector_output_filename")), "Save a simple_object_detector to the provided path.")
         .def_pickle(serialize_pickle<type>());
     }
@@ -383,18 +395,6 @@ ensures \n\
 ensures \n\
     - This function runs the object detector on the input image and returns \n\
       a list of detections.")
-        .def("run", &type::run_detector3, (arg("image"), arg("upsample_num_times")),
-"requires \n\
-    - image is a numpy ndarray containing either an 8bit grayscale or RGB \n\
-      image. \n\
-    - upsample_num_times >= 0 \n\
-ensures \n\
-    - This function runs the object detector on the input image and returns \n\
-      a tuple of (list of detections, list of scores, list of weight_indices).   \n\
-    - Upsamples the image upsample_num_times before running the basic \n\
-      detector.  If you don't know how many times you want to upsample then \n\
-      don't provide a value for upsample_num_times and an appropriate \n\
-      default will be used.")
         .def("save", save_simple_object_detector_py, (arg("detector_output_filename")), "Save a simple_object_detector to the provided path.")
         .def_pickle(serialize_pickle<type>());
     }

--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -383,6 +383,18 @@ ensures \n\
 ensures \n\
     - This function runs the object detector on the input image and returns \n\
       a list of detections.")
+        .def("run", &type::run_detector3, (arg("image"), arg("upsample_num_times")),
+"requires \n\
+    - image is a numpy ndarray containing either an 8bit grayscale or RGB \n\
+      image. \n\
+    - upsample_num_times >= 0 \n\
+ensures \n\
+    - This function runs the object detector on the input image and returns \n\
+      a tuple of (list of detections, list of scores, list of weight_indices).   \n\
+    - Upsamples the image upsample_num_times before running the basic \n\
+      detector.  If you don't know how many times you want to upsample then \n\
+      don't provide a value for upsample_num_times and an appropriate \n\
+      default will be used.")
         .def("save", save_simple_object_detector_py, (arg("detector_output_filename")), "Save a simple_object_detector to the provided path.")
         .def_pickle(serialize_pickle<type>());
     }

--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -342,7 +342,7 @@ ensures \n\
 "Loads an object detector from a file that contains the output of the \n\
 train_simple_object_detector() routine or a serialized C++ object of type\n\
 object_detector<scan_fhog_pyramid<pyramid_down<6>>>.")
-        .def("__call__", run_detector_with_upscale, (arg("image"), arg("upsample_num_times")=0),
+        .def("__call__", run_detector_with_upscale2, (arg("image"), arg("upsample_num_times")=0),
 "requires \n\
     - image is a numpy ndarray containing either an 8bit grayscale or RGB \n\
       image. \n\

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -32,7 +32,8 @@ namespace dlib
         }
     }
 
-    inline std::vector<dlib::rectangle> run_detector_with_upscale (
+
+    inline std::vector<dlib::rectangle> run_detector_with_upscale1 (
         dlib::simple_object_detector& detector,
         boost::python::object img,
         const unsigned int upsampling_amount,
@@ -111,10 +112,23 @@ namespace dlib
         }
     }
 
+    inline std::vector<dlib::rectangle> run_detector_with_upscale2 (
+        dlib::simple_object_detector& detector,
+        boost::python::object img,
+        const unsigned int upsampling_amount
+    )
+    {
+        std::vector<double> detection_confidences;
+        std::vector<double> weight_indices;
+
+        return run_detector_with_upscale1(detector, img, upsampling_amount,
+                                          detection_confidences, weight_indices);
+    }
+
     inline boost::python::tuple run_rect_detector (
-                                        dlib::simple_object_detector& detector,
-                                        boost::python::object img,
-                                        const unsigned int upsampling_amount)
+        dlib::simple_object_detector& detector,
+        boost::python::object img,
+        const unsigned int upsampling_amount)
     {
         boost::python::tuple t;
 
@@ -122,8 +136,8 @@ namespace dlib
         std::vector<double> weight_indices;
         std::vector<rectangle> rectangles;
 
-        rectangles = run_detector_with_upscale(detector, img, upsampling_amount,
-                                               detection_confidences, weight_indices);
+        rectangles = run_detector_with_upscale1(detector, img, upsampling_amount,
+                                                detection_confidences, weight_indices);
 
         return boost::python::make_tuple(rectangles,
                                          detection_confidences, weight_indices);
@@ -144,7 +158,7 @@ namespace dlib
             std::vector<double> detection_confidences;
             std::vector<double> weight_indices;
 
-            return run_detector_with_upscale(detector, img, upsampling_amount_,
+            return run_detector_with_upscale1(detector, img, upsampling_amount_,
                 detection_confidences, weight_indices);
         }
 
@@ -152,7 +166,8 @@ namespace dlib
         {
             std::vector<double> detection_confidences;
             std::vector<double> weight_indices;
-            return run_detector_with_upscale(detector, img, upsampling_amount,
+
+            return run_detector_with_upscale1(detector, img, upsampling_amount,
                 detection_confidences, weight_indices);
         }
 

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -17,7 +17,7 @@ namespace dlib
         std::vector<rect_detection>& rect_detections,
         std::vector<rectangle>& rectangles,
         std::vector<double>& detection_confidences,
-        std::vector<int>& weight_indices
+        std::vector<double>& weight_indices
     )
     {
         rectangles.clear();
@@ -37,7 +37,7 @@ namespace dlib
         boost::python::object img,
         const unsigned int upsampling_amount,
         std::vector<double>& detection_confidences,
-        std::vector<int>& weight_indices
+        std::vector<double>& weight_indices
     )
     {
         pyramid_down<2> pyr;
@@ -111,6 +111,24 @@ namespace dlib
         }
     }
 
+    inline boost::python::tuple run_rect_detector (
+                                        dlib::simple_object_detector& detector,
+                                        boost::python::object img,
+                                        const unsigned int upsampling_amount)
+    {
+        boost::python::tuple t;
+
+        std::vector<double> detection_confidences;
+        std::vector<double> weight_indices;
+        std::vector<rectangle> rectangles;
+
+        rectangles = run_detector_with_upscale(detector, img, upsampling_amount,
+                                               detection_confidences, weight_indices);
+
+        return boost::python::make_tuple(rectangles,
+                                         detection_confidences, weight_indices);
+    }
+
     struct simple_object_detector_py
     {
         simple_object_detector detector;
@@ -124,7 +142,7 @@ namespace dlib
                                                     const unsigned int upsampling_amount_)
         {
             std::vector<double> detection_confidences;
-            std::vector<int> weight_indices;
+            std::vector<double> weight_indices;
 
             return run_detector_with_upscale(detector, img, upsampling_amount_,
                 detection_confidences, weight_indices);
@@ -133,27 +151,12 @@ namespace dlib
         std::vector<dlib::rectangle> run_detector2 (boost::python::object img)
         {
             std::vector<double> detection_confidences;
-            std::vector<int> weight_indices;
+            std::vector<double> weight_indices;
             return run_detector_with_upscale(detector, img, upsampling_amount,
                 detection_confidences, weight_indices);
         }
 
 
-        boost::python::tuple run_detector3 (boost::python::object img,
-                                            const unsigned int upsampling_amount_)
-        {
-            boost::python::tuple t;
-
-            std::vector<double> detection_confidences;
-            std::vector<int> weight_indices;
-            std::vector<rectangle> rectangles;
-
-            rectangles = run_detector_with_upscale(detector, img, upsampling_amount,
-                                                   detection_confidences, weight_indices);
-
-            return boost::python::make_tuple(rectangles,
-                                             detection_confidences, weight_indices);
-        }
     };
 }
 

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -155,20 +155,12 @@ namespace dlib
         std::vector<dlib::rectangle> run_detector1 (boost::python::object img,
                                                     const unsigned int upsampling_amount_)
         {
-            std::vector<double> detection_confidences;
-            std::vector<double> weight_indices;
-
-            return run_detector_with_upscale1(detector, img, upsampling_amount_,
-                detection_confidences, weight_indices);
+            return run_detector_with_upscale2(detector, img, upsampling_amount_);
         }
 
         std::vector<dlib::rectangle> run_detector2 (boost::python::object img)
         {
-            std::vector<double> detection_confidences;
-            std::vector<double> weight_indices;
-
-            return run_detector_with_upscale1(detector, img, upsampling_amount,
-                detection_confidences, weight_indices);
+            return run_detector_with_upscale2(detector, img, upsampling_amount);
         }
 
 

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -13,20 +13,47 @@ namespace dlib
 {
     typedef object_detector<scan_fhog_pyramid<pyramid_down<6> > > simple_object_detector;
 
+    inline void split_rect_detections (
+        std::vector<rect_detection>& rect_detections,
+        std::vector<rectangle>& rectangles,
+        std::vector<double>& detection_confidences,
+        std::vector<int>& weight_indices
+    )
+    {
+        rectangles.clear();
+        detection_confidences.clear();
+        weight_indices.clear();
+
+        for (unsigned long i = 0; i < rect_detections.size(); ++i)
+        {
+            rectangles.push_back(rect_detections[i].rect);
+            detection_confidences.push_back(rect_detections[i].detection_confidence);
+            weight_indices.push_back(rect_detections[i].weight_index);
+        }
+    }
+
     inline std::vector<dlib::rectangle> run_detector_with_upscale (
         dlib::simple_object_detector& detector,
         boost::python::object img,
-        const unsigned int upsampling_amount
+        const unsigned int upsampling_amount,
+        std::vector<double>& detection_confidences,
+        std::vector<int>& weight_indices
     )
     {
         pyramid_down<2> pyr;
+
+        std::vector<rectangle> rectangles;
+        std::vector<rect_detection> rect_detections;
 
         if (is_gray_python_image(img))
         {
             array2d<unsigned char> temp;
             if (upsampling_amount == 0)
             {
-                return detector(numpy_gray_image(img));
+                detector(numpy_gray_image(img), rect_detections, 0.0);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+                return rectangles;
             }
             else
             {
@@ -38,10 +65,14 @@ namespace dlib
                     pyramid_up(temp);
                 }
 
-                std::vector<rectangle> res = detector(temp);
-                for (unsigned long i = 0; i < res.size(); ++i)
-                    res[i] = pyr.rect_down(res[i], upsampling_amount);
-                return res;
+                detector(temp, rect_detections, 0.0);
+                for (unsigned long i = 0; i < rect_detections.size(); ++i)
+                    rect_detections[i].rect = pyr.rect_down(rect_detections[i].rect,
+                                                            upsampling_amount);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+
+                return rectangles;
             }
         }
         else if (is_rgb_python_image(img))
@@ -49,7 +80,10 @@ namespace dlib
             array2d<rgb_pixel> temp;
             if (upsampling_amount == 0)
             {
-                return detector(numpy_rgb_image(img));
+                detector(numpy_rgb_image(img), rect_detections, 0.0);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+                return rectangles;
             }
             else
             {
@@ -61,10 +95,14 @@ namespace dlib
                     pyramid_up(temp);
                 }
 
-                std::vector<rectangle> res = detector(temp);
-                for (unsigned long i = 0; i < res.size(); ++i)
-                    res[i] = pyr.rect_down(res[i], upsampling_amount);
-                return res;
+                detector(temp, rect_detections, 0.0);
+                for (unsigned long i = 0; i < rect_detections.size(); ++i)
+                    rect_detections[i].rect = pyr.rect_down(rect_detections[i].rect,
+                                                            upsampling_amount);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+
+                return rectangles;
             }
         }
         else
@@ -82,11 +120,40 @@ namespace dlib
         simple_object_detector_py(simple_object_detector& _detector, unsigned int _upsampling_amount) :
             detector(_detector), upsampling_amount(_upsampling_amount) {}
 
-        std::vector<dlib::rectangle> run_detector1 (boost::python::object img, const unsigned int upsampling_amount_)
-        { return run_detector_with_upscale(detector, img, upsampling_amount_); }
+        std::vector<dlib::rectangle> run_detector1 (boost::python::object img,
+                                                    const unsigned int upsampling_amount_)
+        {
+            std::vector<double> detection_confidences;
+            std::vector<int> weight_indices;
+
+            return run_detector_with_upscale(detector, img, upsampling_amount_,
+                detection_confidences, weight_indices);
+        }
 
         std::vector<dlib::rectangle> run_detector2 (boost::python::object img)
-        { return run_detector_with_upscale(detector, img, upsampling_amount); }
+        {
+            std::vector<double> detection_confidences;
+            std::vector<int> weight_indices;
+            return run_detector_with_upscale(detector, img, upsampling_amount,
+                detection_confidences, weight_indices);
+        }
+
+
+        boost::python::tuple run_detector3 (boost::python::object img,
+                                            const unsigned int upsampling_amount_)
+        {
+            boost::python::tuple t;
+
+            std::vector<double> detection_confidences;
+            std::vector<int> weight_indices;
+            std::vector<rectangle> rectangles;
+
+            rectangles = run_detector_with_upscale(detector, img, upsampling_amount,
+                                                   detection_confidences, weight_indices);
+
+            return boost::python::make_tuple(rectangles,
+                                             detection_confidences, weight_indices);
+        }
     };
 }
 


### PR DESCRIPTION
- Added a second version of `run_detector_with_upscale()` so it can return additional vectors (via pass by reference)
- Modified the code that actually runs the detector -- I call the version that returns rect_detections
- Added code to split rect_detections into three vectors: rectangles, scores, and weight_indices
- Added a python example program that shows how to use the new bindings
 - Rather than loading the image with skimage, I used Pillow because Pillow does not depend on scipy which takes a long time to build.