### PR TITLE
Fix dlib tests for c++11

### DIFF
--- a/dlib/test/pipe.cpp
+++ b/dlib/test/pipe.cpp
@@ -22,7 +22,7 @@ namespace
     namespace pipe_kernel_test_helpers
     {
         const unsigned long proc1_count = 10000;
-        mutex m;
+        dlib::mutex m;
         signaler s(m);
         unsigned long threads_running = 0;
         bool found_error;

--- a/dlib/test/read_write_mutex.cpp
+++ b/dlib/test/read_write_mutex.cpp
@@ -42,7 +42,7 @@ namespace
 
         read_write_mutex m;
 
-        mutex mut;
+        dlib::mutex mut;
         int num_write;
         int num_read;
         int max_read;

--- a/dlib/test/timer.cpp
+++ b/dlib/test/timer.cpp
@@ -23,7 +23,7 @@ namespace
     class timer_test_helper
     {
     public:
-        mutex m;
+        dlib::mutex m;
         int count;
         dlib::uint64 timestamp;
         dlib::timestamper ts;


### PR DESCRIPTION
c++11 std::mutex clashes with dlib::mutex when:

using namespace std;
using namespace dlib;