### PR TITLE
Made probability weighting in gibbs sampler dependent on parents prob…

### DIFF
--- a/dlib/bayes_utils/bayes_utils.h
+++ b/dlib/bayes_utils/bayes_utils.h
@@ -1137,8 +1137,8 @@ namespace dlib
                     set_node_value(bn, n, i);
                     samples(i) = node_probability(bn, n);
 
-                    for (unsigned long j = 0; j < bn.node(n).number_of_children(); ++j)
-                        samples(i) *= node_probability(bn, bn.node(n).child(j).index());
+                    for (unsigned long j = 0; j < bn.node(n).number_of_parents(); ++j)
+                        samples(i) *= node_probability(bn, bn.node(n).parent(j).index());
                 }
 
                 //normalize samples


### PR DESCRIPTION
…abilities instead of the children's

To be honest, I'm not 100% sure, but I think it makes more sense to use the parent nodes' probabilities for weighting the result as they values are used to look up the probability for the current node in the probability table.

Please correct me if I am wrong as I use this modified version for a university project.