### PR TITLE
Replace add_definitions with CMAKE_CXX_FLAGS in cmake file

### DIFF
--- a/dlib/cmake
+++ b/dlib/cmake
@@ -15,8 +15,8 @@ string(REGEX REPLACE "cmake$" "" dlib_path ${CMAKE_CURRENT_LIST_FILE})
 if (CMAKE_COMPILER_IS_GNUCXX)
     # By default, g++ won't warn or error if you forget to return a value in a
     # function which requires you to do so.  This option makes it give a warning
-    # for doing this. 
-    add_definitions("-Wreturn-type")
+    # for doing this.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wreturn-type") 
 endif()
 
 # Setup some options to allow a user to enable SSE and AVX instruction use.  


### PR DESCRIPTION
When using add_definitions erroneous flags are passed to dll resource compiler under MinGW. This breaks the build for anything linked to dlib, using a dll rc and MinGW.

The proper way is to append to CMAKE_CXX_FLAGS. For a discussion on this see:

http://www.cmake.org/pipermail/cmake/2011-July/045532.html

For CMake 2.8.12 and higher the proper way is add_compile_options(-Wreturn-type) OR target_compile_options(dlib PRIVATE -Wreturn-type)