### PR TITLE
Removes link to sourceforge mercurial repository

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -2,8 +2,8 @@ This "package" is just a copy of the stuff I use to generate the documentation
 for the dlib library.  It contains a copy of the XSLT and XML I use to 
 generate the HTML documentation.
 
-The current version of these files can be obtained from the dlib Mercurial 
-repository at: http://dclib.hg.sourceforge.net:8000/hgroot/dclib/dclib 
+The current version of these files can be obtained from the dlib GitHub 
+repository at: https://github.com/davisking/dlib
 
 ======================== Overview  ========================
 


### PR DESCRIPTION
This MR removes the link to the (old and inaccessible) sourceforge mercurial repository and uses the new GitHub address.