### PR TITLE
Added the C++11 noexcept specifier to the matrix class for C++11 conformant compilers.

### DIFF
--- a/dlib/matrix/matrix.h
+++ b/dlib/matrix/matrix.h
@@ -1605,7 +1605,18 @@ namespace dlib
 
             literal_assign_helper(const literal_assign_helper& item) : m(item.m), r(item.r), c(item.c), has_been_used(false) {}
             explicit literal_assign_helper(matrix* m_): m(m_), r(0), c(0),has_been_used(false) {next();}
-            ~literal_assign_helper() throw (std::exception)
+            ~literal_assign_helper()
+// If C++11 or later.
+// Reference: http://www.stroustrup.com/C++11FAQ.html#11
+#if __cplusplus > 199711L
+				// In C++11 destructors are noexcept by default unless declared otherwise.
+				// Reference: http://en.cppreference.com/w/cpp/language/noexcept_spec
+				noexcept(false)
+// C++98 or earlier. Note that partly conforming compilers will take this path too. E.g., MSVC14 and earlier.
+#else
+				// Use the now deprecated throw specifier
+				throw(std::exception)
+#endif
             {
                 DLIB_CASSERT(!has_been_used || r == m->nr(),
                              "You have used the matrix comma based assignment incorrectly by failing to\n"


### PR DESCRIPTION
**Rationale:** The `throw` exception specifier is [deprecated in C++11](http://en.cppreference.com/w/cpp/language/except_spec).

**Breaking Changes:** None as far as I can see. I've added an `#if #else` statement to maintain backwards compatibility with C++98.

Note that I haven't checked the remaining library. There may be other places in dlib where you can use the same approach. The logic can easily be hidden in a macro.