### PR TITLE
Change relative path of configure files in CMakeLists.

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -432,11 +432,11 @@ if (NOT TARGET dlib)
                REGEX "${CMAKE_CURRENT_BINARY_DIR}" EXCLUDE)
 
 
-       configure_file(${CMAKE_SOURCE_DIR}/../dlib/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+             configure_file(${PROJECT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
        # overwrite config.h with the configured one
        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION include/dlib)
 
-       configure_file(${CMAKE_SOURCE_DIR}/../dlib/revision.h.in ${CMAKE_CURRENT_BINARY_DIR}/revision.h)
+       configure_file(${PROJECT_SOURCE_DIR}/revision.h.in ${CMAKE_CURRENT_BINARY_DIR}/revision.h)
        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/revision.h DESTINATION include/dlib)
 
        install(FILES "LICENSE.txt" DESTINATION share/doc/dlib)


### PR DESCRIPTION
Using CMAKE_PROJECT_DIR instead of CMAKE_SOURCE_DIR/../dlib
makes the build process more portable.

1. If dlib is used as subdirectory of another project CMAKE_SOURCE_DIR will point to a different path then expected in the original code. 

2. If for some reason the dlib directory is renamed configuring would break which is at least more restrictive than necessary.