### PR TITLE
removing deprecated IplImage to support opencv3

### DIFF
--- a/dlib/opencv/cv_image.h
+++ b/dlib/opencv/cv_image.h
@@ -4,7 +4,6 @@
 #define DLIB_CvIMAGE_H_
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/core/types_c.h>
 #include "cv_image_abstract.h"
 #include "../algs.h"
 #include "../pixel.h"
@@ -26,7 +25,7 @@ namespace dlib
         cv_image (const cv::Mat img) 
         {
             DLIB_CASSERT(img.depth() == cv::DataType<typename pixel_traits<pixel_type>::basic_pixel_type>::depth &&
-                         img.channels() == pixel_traits<pixel_type>::num, 
+                         img.channels() == pixel_traits<pixel_type>::num,
                          "The pixel type you gave doesn't match pixel used by the open cv Mat object."
                          << "\n\t img.depth():    " << img.depth() 
                          << "\n\t img.cv::DataType<typename pixel_traits<pixel_type>::basic_pixel_type>::depth: " 
@@ -34,18 +33,7 @@ namespace dlib
                          << "\n\t img.channels(): " << img.channels() 
                          << "\n\t img.pixel_traits<pixel_type>::num: " << pixel_traits<pixel_type>::num 
                          );
-            IplImage temp = img;
-            init(&temp);
-        }
-
-        cv_image (const IplImage img) 
-        {
             init(&img);
-        }
-
-        cv_image (const IplImage* img) 
-        {
-            init(img);
         }
 
         cv_image() : _data(0), _widthStep(0), _nr(0), _nc(0) {}
@@ -93,37 +81,20 @@ namespace dlib
             return *this;
         }
 
-        cv_image& operator=( const IplImage* img)
-        {
-            init(img);
-            return *this;
-        }
-
-        cv_image& operator=( const IplImage img)
+        cv_image& operator=( const cv::Mat img)
         {
             init(&img);
             return *this;
         }
 
-        cv_image& operator=( const cv::Mat img)
-        {
-            IplImage temp = img;
-            init(&temp);
-            return *this;
-        }
-
     private:
 
-        void init (const IplImage* img) 
+        void init (const cv::Mat* img)
         {
-            DLIB_CASSERT( img->dataOrder == 0, "Only interleaved color channels are supported with cv_image"); 
-            DLIB_CASSERT((img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type), 
-                         "The pixel type you gave doesn't match the size of pixel used by the open cv image struct");
-
-            _data = img->imageData;
-            _widthStep = img->widthStep;
-            _nr = img->height;
-            _nc = img->width;
+            _data = (char*) img->data;
+            _widthStep = img->step;
+            _nr = img->rows;
+            _nc = img->cols;
 
         }
 

--- a/dlib/opencv/cv_image_abstract.h
+++ b/dlib/opencv/cv_image_abstract.h
@@ -4,7 +4,6 @@
 #ifdef DLIB_OPENCV_IMAGE_AbSTRACT_H_
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/core/types_c.h>
 #include "../algs.h"
 #include "../pixel.h"
 
@@ -25,7 +24,7 @@ namespace dlib
 
             WHAT THIS OBJECT REPRESENTS
                 This object is meant to be used as a simple wrapper around the OpenCV
-                IplImage struct or Mat object.  Using this class template you can turn
+                Mat object.  Using this class template you can turn
                 an OpenCV image into something that looks like a normal dlib style 
                 image object.
 
@@ -44,40 +43,6 @@ namespace dlib
     public:
         typedef pixel_type type;
         typedef default_memory_manager mem_manager_type;
-
-        cv_image (
-            const IplImage* img
-        );
-        /*!
-            requires
-                - img->dataOrder == 0
-                  (i.e. Only interleaved color channels are supported with cv_image)
-                - (img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type)
-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
-                  inside the OpenCV image)
-            ensures
-                - #nr() == img->height
-                  #nc() == img->width
-                - using the operator[] on this object you will be able to access the pixels
-                  inside this OpenCV image.
-        !*/
-
-        cv_image (
-            const IplImage img
-        );
-        /*!
-            requires
-                - img.dataOrder == 0
-                  (i.e. Only interleaved color channels are supported with cv_image)
-                - (img.depth&0xFF)/8*img.nChannels == sizeof(pixel_type)
-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
-                  inside the OpenCV image)
-            ensures
-                - #nr() == img.height
-                  #nc() == img.width
-                - using the operator[] on this object you will be able to access the pixels
-                  inside this OpenCV image.
-        !*/
 
         cv_image (
             const cv::Mat img
@@ -163,42 +128,6 @@ namespace dlib
         /*!
             ensures
                 - #*this is an identical copy of item
-                - returns #*this
-        !*/
-
-        cv_image& operator=( 
-            const IplImage* img
-        );
-        /*!
-            requires
-                - img->dataOrder == 0
-                  (i.e. Only interleaved color channels are supported with cv_image)
-                - (img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type)
-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
-                  inside the OpenCV image)
-            ensures
-                - #nr() == img->height
-                  #nc() == img->width
-                - using the operator[] on this object you will be able to access the pixels
-                  inside this OpenCV image.
-                - returns #*this
-        !*/
-
-        cv_image& operator=( 
-            const IplImage img
-        );
-        /*!
-            requires
-                - img->dataOrder == 0
-                  (i.e. Only interleaved color channels are supported with cv_image)
-                - (img->depth&0xFF)/8*img->nChannels == sizeof(pixel_type)
-                  (i.e. The size of the pixel_type needs to match the size of the pixels 
-                  inside the OpenCV image)
-            ensures
-                - #nr() == img->height
-                  #nc() == img->width
-                - using the operator[] on this object you will be able to access the pixels
-                  inside this OpenCV image.
                 - returns #*this
         !*/
 


### PR DESCRIPTION
The new stable openCV version only have very limited IplImage support. I removed the IplImage dependency completely.
It is quite a hard cut but I think it is necessary if new openCV versions should be supported. 