### PR TITLE
Add pragma guards around deprecated auto_ptr to prevent GCC warnings

### DIFF
--- a/dlib/smart_pointers/shared_ptr.h
+++ b/dlib/smart_pointers/shared_ptr.h
@@ -294,6 +294,8 @@ namespace dlib
             shared_node->ref_count += 1;
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         template<typename Y>
         explicit shared_ptr(
             std::auto_ptr<Y>& r
@@ -308,6 +310,7 @@ namespace dlib
             shared_node->del = new default_deleter;
             data = r.release();
         }
+#pragma GCC diagnostic pop
 
         shared_ptr& operator= (
             const shared_ptr& r
@@ -326,6 +329,8 @@ namespace dlib
             return *this;
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         template<typename Y> 
         shared_ptr& operator= (
             std::auto_ptr<Y>& r
@@ -343,6 +348,7 @@ namespace dlib
             data = r.release();
             return *this;
         }
+#pragma GCC diagnostic pop
 
         void reset()
         {

--- a/dlib/smart_pointers/shared_ptr_thread_safe.h
+++ b/dlib/smart_pointers/shared_ptr_thread_safe.h
@@ -257,7 +257,8 @@ namespace dlib
             }
         }
 
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         template<typename Y>
         explicit shared_ptr_thread_safe(
             std::auto_ptr<Y>& r
@@ -271,6 +272,7 @@ namespace dlib
             shared_node = new shared_ptr_thread_safe_node;
             data = r.release();
         }
+#pragma GCC diagnostic push
 
         shared_ptr_thread_safe& operator= (
             const shared_ptr_thread_safe& r
@@ -289,6 +291,8 @@ namespace dlib
             return *this;
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         template<typename Y> 
         shared_ptr_thread_safe& operator= (
             std::auto_ptr<Y>& r
@@ -305,6 +309,7 @@ namespace dlib
             data = r.release();
             return *this;
         }
+#pragma GCC diagnostic push
 
         void reset()
         {


### PR DESCRIPTION
Fixes #67