### PR TITLE
Decode message only if encoding is known

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,8 @@ def enqueue_output(out, queue):
 def _log_buf(buf):
     if not buf:
         return
-    buf = buf.decode(sys.stdout.encoding)
+    if sys.stdout.encoding:
+        buf = buf.decode(sys.stdout.encoding)
     buf = buf.rstrip()
     lines = buf.splitlines()
     for line in lines:


### PR DESCRIPTION
When python does not know the encoding of stdout, sys.stdout.encoding
is None.  Then calling decode(None) raises an exception.  We just
skip decoding when the encoding is unknown.