### PR TITLE
Drectangle equality

### DIFF
--- a/dlib/geometry/drectangle.h
+++ b/dlib/geometry/drectangle.h
@@ -195,6 +195,19 @@ namespace dlib
             return *this;
         }
 
+        bool operator== (
+            const drectangle& rect
+        ) const
+        {
+            return (l == rect.l) && (t == rect.t) && (r == rect.r) && (b == rect.b);
+        }
+
+        bool operator!= (
+            const drectangle& rect
+        ) const
+        {
+            return !(*this == rect);
+        }
 
     private:
         double l;

--- a/dlib/geometry/drectangle_abstract.h
+++ b/dlib/geometry/drectangle_abstract.h
@@ -319,6 +319,25 @@ namespace dlib
                 - returns #*this
         !*/
 
+        bool operator== (
+            const drectangle& rect
+        ) const;
+        /*!
+            ensures
+                - if (top() == rect.top() && left() == rect.left() &&
+                      right() == rect.right() && bottom() == rect.bottom()) then
+                    - returns true
+                - else
+                    - returns false
+        !*/
+
+        bool operator!= (
+            const drectangle& rect
+        ) const;
+        /*!
+            ensures
+                - returns !(*this == rect)
+        !*/
     };
 
 // ----------------------------------------------------------------------------------------

--- a/tools/python/src/dlib.cpp
+++ b/tools/python/src/dlib.cpp
@@ -29,6 +29,8 @@ BOOST_PYTHON_MODULE(dlib)
     // since it is full of huge amounts of template clutter.
     boost::python::docstring_options options(true,true,false);
 
+    boost::python::scope().attr("__version__") = "18.18";
+
     bind_matrix();
     bind_vector();
     bind_svm_c_trainer();

--- a/tools/python/src/rectangles.cpp
+++ b/tools/python/src/rectangles.cpp
@@ -90,6 +90,8 @@ void bind_rectangles()
         .def("intersect", &::intersect<type>, (arg("rectangle")))
         .def("__str__", &::print_rectangle_str<type>)
         .def("__repr__", &::print_rectangle_repr<type>)
+        .def(self == self)
+        .def(self != self)
         .def_pickle(serialize_pickle<type>());
     }
     {
@@ -112,6 +114,8 @@ void bind_rectangles()
         .def("intersect", &::intersect<type>, (arg("rectangle")))
         .def("__str__", &::print_rectangle_str<type>)
         .def("__repr__", &::print_rectangle_repr<type>)
+        .def(self == self)
+        .def(self != self)
         .def_pickle(serialize_pickle<type>());
     }
     {

--- a/tools/python/src/shape_predictor.cpp
+++ b/tools/python/src/shape_predictor.cpp
@@ -210,7 +210,9 @@ void bind_shape_predictors()
                       e.g a padding of 0.5 would cause the algorithm to sample pixels from a box that was 2x2 pixels")
         .add_property("random_seed", &type::random_seed,
                                      &type::random_seed,
-                      "The random seed used by the internal random number generator");
+                      "The random seed used by the internal random number generator")
+        .def("__str__", &::print_shape_predictor_training_options)
+        .def_pickle(serialize_pickle<type>());
     }
     {
     typedef shape_predictor type;

--- a/tools/python/src/shape_predictor.h
+++ b/tools/python/src/shape_predictor.h
@@ -45,6 +45,75 @@ namespace dlib
         std::string random_seed;
     };
 
+    inline void serialize (
+        const shape_predictor_training_options& item,
+        std::ostream& out
+    )
+    {
+        try
+        {
+            serialize(item.be_verbose,out);
+            serialize(item.cascade_depth,out);
+            serialize(item.tree_depth,out);
+            serialize(item.num_trees_per_cascade_level,out);
+            serialize(item.nu,out);
+            serialize(item.oversampling_amount,out);
+            serialize(item.feature_pool_size,out);
+            serialize(item.lambda_param,out);
+            serialize(item.num_test_splits,out);
+            serialize(item.feature_pool_region_padding,out);
+            serialize(item.random_seed,out);
+        }
+        catch (serialization_error& e)
+        {
+            throw serialization_error(e.info + "\n   while serializing an object of type shape_predictor_training_options");
+        }
+    }
+
+    inline void deserialize (
+        shape_predictor_training_options& item,
+        std::istream& in
+    )
+    {
+        try
+        {
+            deserialize(item.be_verbose,in);
+            deserialize(item.cascade_depth,in);
+            deserialize(item.tree_depth,in);
+            deserialize(item.num_trees_per_cascade_level,in);
+            deserialize(item.nu,in);
+            deserialize(item.oversampling_amount,in);
+            deserialize(item.feature_pool_size,in);
+            deserialize(item.lambda_param,in);
+            deserialize(item.num_test_splits,in);
+            deserialize(item.feature_pool_region_padding,in);
+            deserialize(item.random_seed,in);
+        }
+        catch (serialization_error& e)
+        {
+            throw serialization_error(e.info + "\n   while deserializing an object of type shape_predictor_training_options");
+        }
+    }
+
+    string print_shape_predictor_training_options(const shape_predictor_training_options& o)
+    {
+        std::ostringstream sout;
+        sout << "shape_predictor_training_options("
+            << "be_verbose=" << o.be_verbose << ","
+            << "cascade_depth=" << o.cascade_depth << ","
+            << "tree_depth=" << o.tree_depth << ","
+            << "num_trees_per_cascade_level=" << o.num_trees_per_cascade_level << ","
+            << "nu=" << o.nu << ","
+            << "oversampling_amount=" << o.oversampling_amount << ","
+            << "feature_pool_size=" << o.feature_pool_size << ","
+            << "lambda_param=" << o.lambda_param << ","
+            << "num_test_splits=" << o.num_test_splits << ","
+            << "feature_pool_region_padding=" << o.feature_pool_region_padding << ","
+            << "random_seed=" << o.random_seed
+        << ")";
+        return sout.str();
+    }
+
 // ----------------------------------------------------------------------------------------
 
     namespace impl


### PR DESCRIPTION
Addresses #65. Simply added the `(self == self)` Macro syntax and add equality operators to `drectangle` in the main dlib source - copied from rectangle.

Also, sneak in two other changes:

  - Make `shape_predictor_training_options` serializable and printable.
  - Add `__version__` attribute to the dlib Python module to be compatible with PEP 396. Only issue is that the string is hard coded - maybe someone can think of a better way to read it from the `CMakelists.txt` at compile time (@davisking)
