### PR TITLE
detect OS X, and query sysconfig for libdir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -466,6 +466,19 @@ class build(_build):
         if sys.version_info >= (3, 0):
             cmake_extra_arch += ['-DPYTHON3=yes']
 
+        log.info("Detected platform: %s" % sys.platform)
+        if sys.platform == "darwin":
+            # build on OS X
+            inc_dir = get_python_inc()
+            cmake_extra_arch += ['-DPYTHON_INCLUDE_DIR={inc}'.format(inc=inc_dir)]
+
+            # by default, cmake will choose the system python lib in /usr/lib
+            # this checks the sysconfig and will correctly pick up a brewed python lib
+            # e.g. in /usr/local/Cellar
+            py_ver = get_python_version()
+            py_lib = os.path.join(get_config_var('LIBDIR'), 'libpython'+py_ver+'.dylib')
+            cmake_extra_arch += ['-DPYTHON_LIBRARY={lib}'.format(lib=py_lib)]
+
         if platform_arch == '64bit' and sys.platform == "win32":
             # 64bit build on Windows
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from distutils.command.build_ext import build_ext as _build_ext
 from distutils.command.build import build as _build
 from distutils.errors import DistutilsSetupError
 from distutils.spawn import find_executable
-from distutils.sysconfig import get_python_inc, get_python_version
+from distutils.sysconfig import get_python_inc, get_python_version, get_config_var
 from distutils import log
 import os
 import sys


### PR DESCRIPTION
I was having trouble getting `python setup.py install` to build a usable library on OS X. Loading the shared object would seg fault. I use a brewed Python, but cmake would default to using the system python lib under /usr/lib. Forcing a non-default -DPYTHON_LIBRARY is one solution that seems to work. There may be other, better ways to accomplish this but this change works for me.