### PR TITLE
orthogonalize does not work with fixed-sized matrices

### DIFF
--- a/dlib/matrix/matrix_qr.h
+++ b/dlib/matrix/matrix_qr.h
@@ -62,8 +62,9 @@ namespace dlib
         const matrix_type get_q (
         ) const;
 
+        template <typename T, long R, long C, typename MM, typename L>
         void get_q (
-            matrix_type& Q
+            matrix<T,R,C,MM,L>& Q
         ) const;
 
         template <typename EXP>
@@ -270,9 +271,10 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename matrix_exp_type>
+    template <typename T, long R, long C, typename MM, typename L>
     void qr_decomposition<matrix_exp_type>::
     get_q(
-        matrix_type& X
+        matrix<T,R,C,MM,L>& X
     ) const
     {
 #ifdef DLIB_USE_LAPACK

--- a/dlib/test/matrix4.cpp
+++ b/dlib/test/matrix4.cpp
@@ -631,6 +631,16 @@ namespace
                 3,3,3;
             DLIB_TEST(upperbound(m,3) == M);
         }
+        
+        {
+            matrix<double,9,5> A = randm(9,5);
+            matrix<double> B = A;
+            
+            orthogonalize(A);
+            orthogonalize(B);
+            
+            DLIB_TEST(equal(A,B));
+        }
     }
 
 


### PR DESCRIPTION
Dear Davis,

The code

~~~
dlib::matrix<double,5,5> M;
...
dlib::orthogonalize(M);
~~~

generates the following compilation error:

~~~
dlib/matrix/matrix_la.h:833: error: no matching member function for call to 'get_q'
        qr_decomposition<matrix<T,NR,NC,MM,L> >(m).get_q(m);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
...
dlib/matrix/matrix_qr.h:65: candidate function not viable: no known conversion from 'matrix<double, 5L, 5L, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>' to 'matrix_type &' (aka 'matrix<type, 0, 0, mem_manager_type, layout_type> &') for 1st argument
        void get_q (
             ^
~~~

The code in this pull request attempts to resolve the aforementioned issue.

Best regards,

Ernesto.