### PR TITLE
Python/Simple object detector trainer. Added upsample_limit option

### DIFF
--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -159,7 +159,15 @@ solver more accurate but might take longer to train.")
                                      &type::num_threads,
 "train_simple_object_detector() will use this many threads of \n\
 execution.  Set this to the number of CPU cores on your machine to \n\
-obtain the fastest training speed.");
+obtain the fastest training speed.")
+        .add_property("upsample_limit", &type::upsample_limit,
+                                        &type::upsample_limit,
+"train_simple_object_detector() will upsample images if needed \n\
+no more than upsample_limit times. Value 0 will forbid trainer to \n\
+upsample any images. If trainer is unable to fit all boxes with \n\
+required upsample_limit, exception will be thrown. Higher values \n\
+of upsample_limit exponentially increases memory requiremens. \n\
+Values higher than 2 (default) are not recommended.");
     }
     {
     typedef simple_test_results type;

--- a/tools/python/src/simple_object_detector.h
+++ b/tools/python/src/simple_object_detector.h
@@ -33,6 +33,7 @@ namespace dlib
             detection_window_size = 80*80;
             C = 1;
             epsilon = 0.01;
+            upsample_limit = 2;
         }
 
         bool be_verbose;
@@ -41,6 +42,7 @@ namespace dlib
         unsigned long detection_window_size;
         double C;
         double epsilon;
+        unsigned long upsample_limit;
     };
 
 // ----------------------------------------------------------------------------------------
@@ -175,7 +177,7 @@ namespace dlib
         // upsample the images at most two times to help make the boxes obtainable.
         std::vector<std::vector<rectangle> > temp(boxes), removed;
         removed = remove_unobtainable_rectangles(trainer, images, temp);
-        while (impl::contains_any_boxes(removed) && upsampling_amount < 2)
+        while (impl::contains_any_boxes(removed) && upsampling_amount < options.upsample_limit)
         {
             ++upsampling_amount;
             if (options.be_verbose)


### PR DESCRIPTION
When fine-tuning object detector, I need to run training may times. With some combination of options, trainer starts upsampling images 1-2 times that makes trainer to crash due to available RAM limitations.
Original trainer had hard-coded upsample limit value == 2. 
I changed this to options, with default value == 2

With this feature, we can control RAM usage limiting upsample function