### PR TITLE
MSVC x64 SSE2 automatical support

### DIFF
--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -22,7 +22,7 @@
                 #define DLIB_HAVE_AVX
             #endif
         #endif
-        #if defined(_M_IX86_FP) && _M_IX86_FP >= 2 && !defined(DLIB_HAVE_SSE2)
+    #if (defined( _M_X64) || defined(_M_IX86_FP) && _M_IX86_FP >= 2) && !defined(DLIB_HAVE_SSE2)
             #define DLIB_HAVE_SSE2
         #endif
     #else

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -22,7 +22,7 @@
                 #define DLIB_HAVE_AVX
             #endif
         #endif
-    #if (defined( _M_X64) || defined(_M_IX86_FP) && _M_IX86_FP >= 2) && !defined(DLIB_HAVE_SSE2)
+        #if (defined( _M_X64) || defined(_M_IX86_FP) && _M_IX86_FP >= 2) && !defined(DLIB_HAVE_SSE2)
             #define DLIB_HAVE_SSE2
         #endif
     #else


### PR DESCRIPTION
Some processors (Atoms/Pentiums) does not support AVX but support SSE2
When I compile face detector with MSVC, x64 - compiler gives me SSE2 support
To enable it in Dlib, i need to put "DLIB_HAVE_SSE2" into preprocessor definitions, otherwise face detector will be 2-3x slow
When building samples with CMAKE, I have this definition by default, but I can forget about it in real project, and I didnt find dlib's documentation about enabling only SSE2 without AVX

With this PR I am enabling SSE2 support for all x64 builds in MSVC, even when AVX is not enabled
