### PR TITLE
Augment build-system, allow for multilib installation, support pkg-config discovery

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -79,6 +79,7 @@ if (NOT TARGET dlib)
    set (DLIB_LINK_WITH_SQLITE3_STR
    "Disable this if you don't want to link against sqlite3" )
    #set (DLIB_USE_FFTW_STR "Disable this if you don't want to link against fftw" )
+   set (LIB_INSTALL_DIR lib CACHE STRING "Install location of libraries (e.g. lib32 or lib64 for multilib installations)")
 
    option(DLIB_ISO_CPP_ONLY ${DLIB_ISO_CPP_ONLY_STR} OFF)
    toggle_preprocessor_switch(DLIB_ISO_CPP_ONLY)
@@ -308,6 +309,7 @@ if (NOT TARGET dlib)
          if (PNG_FOUND AND LIBPNG_IS_GOOD)
             include_directories(${PNG_INCLUDE_DIR})
             set (dlib_needed_libraries ${dlib_needed_libraries} ${PNG_LIBRARY})
+            set(REQUIRES_LIBS " libpng")
          else()
             # If we can't find libpng then statically compile it in.
             include_directories(external/libpng external/zlib)
@@ -343,6 +345,7 @@ if (NOT TARGET dlib)
                external/zlib/uncompr.c
                external/zlib/zutil.c
                )
+            set(REQUIRES_LIBS "")
          endif()
          set(source_files ${source_files}
             image_loader/png_loader.cpp
@@ -575,8 +578,8 @@ if (NOT TARGET dlib)
            install(TARGETS dlib dlib_shared
                    EXPORT dlib 
                    RUNTIME DESTINATION bin # Windows (including cygwin) considers .dll to be runtime artifacts
-                   LIBRARY DESTINATION lib
-                   ARCHIVE DESTINATION lib)
+                   LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}")
        else()
            install(TARGETS dlib
                    EXPORT dlib 
@@ -601,7 +604,7 @@ if (NOT TARGET dlib)
 
        ## Config.cmake generation and installation
 
-       set(ConfigPackageLocation lib/cmake/dlib)
+       set(ConfigPackageLocation "${LIB_INSTALL_DIR}/cmake/dlib")
        install(EXPORT dlib
             NAMESPACE dlib::
             DESTINATION ${ConfigPackageLocation})
@@ -620,6 +623,13 @@ if (NOT TARGET dlib)
                     "${CMAKE_CURRENT_BINARY_DIR}/config/dlibConfig.cmake" 
                     "${CMAKE_CURRENT_BINARY_DIR}/config/dlibConfigVersion.cmake" 
                DESTINATION ${ConfigPackageLocation})
+
+       ## dlib-1.pc generation and installation
+
+       configure_file("dlib.pc.in" "dlib-1.pc" @ONLY)
+       install(FILES "${CMAKE_CURRENT_BINARY_DIR}/dlib-1.pc"
+           DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
+
    endif()
 
 endif()

--- a/dlib/cmake_find_blas.txt
+++ b/dlib/cmake_find_blas.txt
@@ -40,6 +40,20 @@ if (UNIX)
         return()
     endif()
 
+    # First, search for libraries via pkg-config, which is the cleanest path
+    find_package(PkgConfig)
+    pkg_check_modules(BLAS_REFERENCE cblas)
+    pkg_check_modules(LAPACK_REFERENCE lapack)
+    if (BLAS_REFERENCE_FOUND AND LAPACK_REFERENCE_FOUND)
+        set(blas_libraries "${BLAS_REFERENCE_LDFLAGS}")
+        set(lapack_libraries "${LAPACK_REFERENCE_LDFLAGS}")
+        set(blas_found 1)
+        set(lapack_found 1)
+        set(REQUIRES_LIBS "${REQUIRES_LIBS} cblas lapack")
+        message(STATUS "Found BLAS and LAPACK via pkg-config")
+        return()
+    endif()
+
     include(CheckTypeSize)
     check_type_size( "void*" SIZE_OF_VOID_PTR)
 

--- a/dlib/dlib.pc.in
+++ b/dlib/dlib.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: Numerical and networking C++ library
+Version: @VERSION@
+Libs: -L${libdir} -ldlib
+Cflags: -I${includedir}
+Requires:@REQUIRES_LIBS@

--- a/dlib/test/makefile
+++ b/dlib/test/makefile
@@ -5,14 +5,15 @@
 TARGET = dtest 
 
 # these are the compile time flags passed to gcc
-CFLAGS = -ggdb  -DDEBUG -DDLIB_NO_GUI_SUPPORT  -I ../..  -Wall
+CXXFLAGS ?= -ggdb -Wall
+CPPFLAGS ?= -DDEBUG -DDLIB_NO_GUI_SUPPORT -I../..
 
 # These are the link time flags passed to gcc
 LFLAGS = -lpthread   -lnsl 
 
 # The name of the compiler.  If you only have one version of
 # gcc installed then you probably want to change this to just g++ 
-CC = nice g++
+CXX ?= nice g++
 
 ####################################################
 ####################################################
@@ -165,12 +166,8 @@ OBJ = $(TMP:.c=.o)
 
 $(TARGET): $(OBJ) 
 	@echo Linking $@
-	@$(CC) $(OBJ) $(LFLAGS) -o $@
+	@$(CXX) $(LDFLAGS) $(OBJ) $(LFLAGS) -o $@
 	@echo Build Complete
-
-.cpp.o: $<
-	@echo Compiling $<
-	@$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
 	@rm -f $(OBJ) $(TARGET)


### PR DESCRIPTION
* Add **pkg-config** file, allowing for build-system agnostic dependencies
  This is important, as most build systems are not CMake and therefore asking users to employ CMake merely for one dependency is not optimal. In addition, I have versioned the .pc file, such that the library may be installed in parallel, should the API change substantially. This is considered good practice and done by all major libraries (GTK+ for instance). See also https://tecnocode.co.uk/2014/12/09/a-checklist-for-writing-pkg-config-files/

* Define `LIB_INSTALL_DIR` cache variable, allowing for multilib installations
  This is important for distributions like Gentoo, where we might install 32-bit and 64-bit libraries simultaneously. Nevertheless, the default remains `lib/`, so unless the user specifies `-DLIB_INSTALL_DIR`, nothing changes.

* Discover BLAS and LAPACK via pkg-config if possible
  This is more modern and more robust, but just the first attempt at detecting BLAS+LAPACK.

* Fix incorrect toolchain variables in "dlib/test/makefile"
  This fix has been carried for a while in the Gentoo tree, and we'd like to upstream it.

Thank you for a great library, and I hope you'll accept my changes, opening dlib for a much larger audience with the help of pkg-config.