### PR TITLE
base_window::get_pos on windows don't accounted titlebar, converting …

### DIFF
--- a/dlib/gui_core/gui_core_kernel_1.cpp
+++ b/dlib/gui_core/gui_core_kernel_1.cpp
@@ -1937,13 +1937,11 @@ namespace dlib
         if (has_been_destroyed == true)
             return;
 
-        POINT p;
-        p.x = 0;
-        p.y = 0;
-        ClientToScreen(hwnd,&p);
+        RECT rcWnd;
+        GetWindowRect(hwnd,&rcWnd);
 
-        x_ = p.x;
-        y_ = p.y;
+        x_ = rcWnd.left;
+        y_ = rcWnd.top;
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
base_window::get_pos on windows don't accounted titlebar, converting the client area to screen coordinates. Now, using GetWindowRect, position is returned correctly.