### PR TITLE
Added getter for trainer::train_one_step_calls

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -466,6 +466,12 @@ namespace dlib
             return learning_rate_shrink;
         }
 
+        unsigned long long get_train_one_step_calls (
+        ) const
+        {
+            return train_one_step_calls;
+        }
+
     private:
 
         void record_loss(double loss)

--- a/dlib/dnn/trainer_abstract.h
+++ b/dlib/dnn/trainer_abstract.h
@@ -295,6 +295,17 @@ namespace dlib
                   get_learning_rate_shrink_factor() to 1.
         !*/
 
+        unsigned long long get_train_one_step_calls (
+        ) const;
+        /*!
+            requires
+                - training process should be done with #train_one_step()
+            ensures
+                - Each #train_one_step() call increases this counter. It can be used to understand the training
+                  stage to make some additional processing like snapshotting or extra testing
+                - This value is serialized/deserialized via synchronization file
+        !*/
+
         void be_verbose (
         );
         /*!


### PR DESCRIPTION
When training with train_one_step(), I want to make some extra testing every 1000 calls (example value). I want to use counter provided by trainer, because it is serialized into syncronization file and restored from it if process is restarted