### PR TITLE
Shape predictor trainer optimizations

### DIFF
--- a/dlib/image_processing/shape_predictor_abstract.h
+++ b/dlib/image_processing/shape_predictor_abstract.h
@@ -148,6 +148,7 @@ namespace dlib
                 - #get_num_test_splits() == 20
                 - #get_feature_pool_region_padding() == 0
                 - #get_random_seed() == ""
+                - #get_num_threads() == 0
                 - This object will not be verbose
         !*/
 
@@ -365,6 +366,26 @@ namespace dlib
                 - num > 0
             ensures
                 - #get_num_test_splits() == num
+        !*/
+
+        unsigned long get_num_threads (
+        ) const;
+        /*!
+            ensures
+                - When running training process, it is possible to make some parts of it parallel
+                  using CPU threads with #parallel_for() extension and creating #thread_pool internally
+                  When get_num_threads() == 0, trainer will not create threads and all processing will
+                  be done in the calling thread
+        !*/
+
+        void set_num_threads (
+            unsigned long num
+        );
+        /*!
+            requires
+                - num >= 0
+            ensures
+                - #get_num_threads() == num
         !*/
 
         void be_verbose (

--- a/examples/train_shape_predictor_ex.cpp
+++ b/examples/train_shape_predictor_ex.cpp
@@ -39,7 +39,7 @@ std::vector<std::vector<double> > get_interocular_distances (
 // ----------------------------------------------------------------------------------------
 
 int main(int argc, char** argv)
-{  
+{
     try
     {
         // In this example we are going to train a shape_predictor based on the
@@ -108,6 +108,9 @@ int main(int argc, char** argv)
         trainer.set_nu(0.05);
         trainer.set_tree_depth(2);
 
+        // some parts of training process can be parellelized.
+        // Trainer will use this count of threads when possible
+        trainer.set_num_threads(2);
 
         // Tell the trainer to print status messages to the console so we can
         // see how long the training will take.


### PR DESCRIPTION
I need to train some shape predictor and I found that this process is very slow for me - up to 5-6 days with 64 GB RAM usage. Also training process uses a lot of RAM

With this PR I made this changes:
1. training_sample::feature_pixel_values was float-based. Now I am using the type provided by image_traits. In the most cases - it is unsigned char leading to lower RAM usage (about 15% less summary with all other changes). Train_shape_predictor_ex uses 400 features inside each sample (1600 bytes was, now - 400)
2. some parts of trainer uses the shape difference training_sample::target_shape - current shape. And this differenct is recalculated for the same sample many times. I made caching for it inside training_sample::diff_shape. This increases RAM usage a little (+68*2*4 = 544), and improves performance for about 20%
3. After caching differences I found that some parts are now easy to run parallel and I made it work with parallel_for. When I am running it with 8 threads on i7, about 70% of CPU is used (because not all parts are paralleled) and training time reduces 2-3x

It is also possible to remove caching the difference of shapes and use much less RAM (about 20-30% less) depending on the task. 

I have tested this with train_shape_predictor_ex with increasing oversampling_amount to 3000, but I think we need some more time for testing

What do you think? Will such kind of optimizations be usefull?