### PR TITLE
Spport to discontiguous Numpy arrays

### DIFF
--- a/dlib/python/numpy.h
+++ b/dlib/python/numpy.h
@@ -7,12 +7,14 @@
 #include <dlib/error.h>
 #include <dlib/algs.h>
 #include <dlib/string.h>
+#include <dlib/array.h>
+#include <dlib/pixel.h>
 
 // ----------------------------------------------------------------------------------------
 
 template <typename T>
 void validate_numpy_array_type (
-    boost::python::object& obj
+    const boost::python::object& obj
 )
 {
     using namespace boost::python;
@@ -30,26 +32,23 @@ void validate_numpy_array_type (
 
 // ----------------------------------------------------------------------------------------
 
-template <typename T, int dims>
-void get_numpy_ndarray_parts (
-    boost::python::object& obj,
-    T*& data,
+template <int dims>
+void get_numpy_ndarray_shape (
+    const boost::python::object& obj,
     long (&shape)[dims]
 )
 /*!
     ensures
-        - extracts the pointer to the data from the given numpy ndarray.  Stores the shape
-          of the array into #shape.
+        - stores the shape of the array into #shape.
+        - the dimension of the given numpy array is not greater than #dims.
 !*/
 {
     Py_buffer pybuf;
-    if (PyObject_GetBuffer(obj.ptr(), &pybuf, PyBUF_ND | PyBUF_WRITABLE ))
-        throw dlib::error("Expected contiguous and writable numpy.ndarray.");
+    if (PyObject_GetBuffer(obj.ptr(), &pybuf, PyBUF_STRIDES ))
+        throw dlib::error("Expected numpy.ndarray with shape set.");
 
     try
     {
-        validate_numpy_array_type<T>(obj);
-        data = (T*)pybuf.buf;
 
         if (pybuf.ndim > dims)
             throw dlib::error("Expected array with " + dlib::cast_to_string(dims) + " dimensions.");
@@ -74,34 +73,92 @@ void get_numpy_ndarray_parts (
 
 template <typename T, int dims>
 void get_numpy_ndarray_parts (
-    const boost::python::object& obj,
-    const T*& data,
+    boost::python::object& obj,
+    T*& data,
+    dlib::array<T>& contig_buf,
     long (&shape)[dims]
 )
 /*!
     ensures
         - extracts the pointer to the data from the given numpy ndarray.  Stores the shape
           of the array into #shape.
+        - the dimension of the given numpy array is not greater than #dims.
+        - #shape[#dims-1] == pixel_traits<T>::num when #dims is greater than 2
 !*/
 {
     Py_buffer pybuf;
-    if (PyObject_GetBuffer(obj.ptr(), &pybuf, PyBUF_ND ))
-        throw dlib::error("Expected contiguous numpy.ndarray.");
+    if (PyObject_GetBuffer(obj.ptr(), &pybuf, PyBUF_STRIDES | PyBUF_WRITABLE ))
+        throw dlib::error("Expected writable numpy.ndarray with shape set.");
 
     try
     {
         validate_numpy_array_type<T>(obj);
-        data = (const T*)pybuf.buf;
 
         if (pybuf.ndim > dims)
             throw dlib::error("Expected array with " + dlib::cast_to_string(dims) + " dimensions.");
+        get_numpy_ndarray_shape(obj, shape);
 
-        for (int i = 0; i < dims; ++i)
+        if (dlib::pixel_traits<T>::num > 1 && dlib::pixel_traits<T>::num != shape[dims-1])
+            throw dlib::error("Expected numpy.ndarray with " + dlib::cast_to_string(dlib::pixel_traits<T>::num) + " channels.");
+
+        if (PyBuffer_IsContiguous(&pybuf, 'C'))
+            data = (T*)pybuf.buf;
+        else
         {
-            if (i < pybuf.ndim)
-                shape[i] = pybuf.shape[i];
-            else
-                shape[i] = 1;
+            contig_buf.resize(pybuf.len);
+            if (PyBuffer_ToContiguous(&contig_buf[0], &pybuf, pybuf.len, 'C'))
+                throw dlib::error("Can't copy numpy.ndarray to a contiguous buffer.");
+            data = &contig_buf[0];
+        }
+    }
+    catch(...)
+    {
+        PyBuffer_Release(&pybuf);
+        throw;
+    }
+    PyBuffer_Release(&pybuf);
+}
+
+// ----------------------------------------------------------------------------------------
+
+template <typename T, int dims>
+void get_numpy_ndarray_parts (
+    const boost::python::object& obj,
+    const T*& data,
+    dlib::array<T>& contig_buf,
+    long (&shape)[dims]
+)
+/*!
+    ensures
+        - extracts the pointer to the data from the given numpy ndarray.  Stores the shape
+          of the array into #shape.
+        - the dimension of the given numpy array is not greater than #dims.
+        - #shape[#dims-1] == pixel_traits<T>::num when #dims is greater than 2
+!*/
+{
+    Py_buffer pybuf;
+    if (PyObject_GetBuffer(obj.ptr(), &pybuf, PyBUF_STRIDES ))
+        throw dlib::error("Expected numpy.ndarray with shape set.");
+
+    try
+    {
+        validate_numpy_array_type<T>(obj);
+
+        if (pybuf.ndim > dims)
+            throw dlib::error("Expected array with " + dlib::cast_to_string(dims) + " dimensions.");
+        get_numpy_ndarray_shape(obj, shape);
+
+        if (dlib::pixel_traits<T>::num > 1 && dlib::pixel_traits<T>::num != shape[dims-1])
+            throw dlib::error("Expected numpy.ndarray with " + dlib::cast_to_string(dlib::pixel_traits<T>::num) + " channels.");
+
+        if (PyBuffer_IsContiguous(&pybuf, 'C'))
+            data = (const T*)pybuf.buf;
+        else
+        {
+            contig_buf.resize(pybuf.len);
+            if (PyBuffer_ToContiguous(&contig_buf[0], &pybuf, pybuf.len, 'C'))
+                throw dlib::error("Can't copy numpy.ndarray to a contiguous buffer.");
+            data = &contig_buf[0];
         }
     }
     catch(...)

--- a/dlib/python/numpy_image.h
+++ b/dlib/python/numpy_image.h
@@ -6,6 +6,7 @@
 #include "numpy.h"
 #include <dlib/pixel.h>
 #include <dlib/matrix.h>
+#include <dlib/array.h>
 
 
 // ----------------------------------------------------------------------------------------
@@ -18,7 +19,7 @@ public:
     numpy_gray_image (boost::python::object& img) 
     {
         long shape[2];
-        get_numpy_ndarray_parts(img, _data, shape);
+        get_numpy_ndarray_parts(img, _data, _contig_buf, shape);
         _nr = shape[0];
         _nc = shape[1];
     }
@@ -32,6 +33,7 @@ public:
 private:
 
     unsigned char* _data;
+    dlib::array<unsigned char> _contig_buf;
     long _nr;
     long _nc;
 };
@@ -51,7 +53,8 @@ inline bool is_gray_python_image (boost::python::object& img)
 {
     try
     {
-        numpy_gray_image temp(img);
+        long shape[2];
+        get_numpy_ndarray_shape(img, shape);
         return true;
     }
     catch (dlib::error&)
@@ -70,7 +73,7 @@ public:
     numpy_rgb_image (boost::python::object& img) 
     {
         long shape[3];
-        get_numpy_ndarray_parts(img, _data, shape);
+        get_numpy_ndarray_parts(img, _data, _contig_buf, shape);
         _nr = shape[0];
         _nc = shape[1];
         if (shape[2] != 3)
@@ -87,6 +90,7 @@ public:
 private:
 
     dlib::rgb_pixel* _data;
+    dlib::array<dlib::rgb_pixel> _contig_buf;
     long _nr;
     long _nc;
 };
@@ -107,8 +111,11 @@ inline bool is_rgb_python_image (boost::python::object& img)
 {
     try
     {
-        numpy_rgb_image temp(img);
-        return true;
+        long shape[3];
+        get_numpy_ndarray_shape(img, shape);
+        if (shape[2] == 3)
+            return true;
+        return false;
     }
     catch (dlib::error&)
     {


### PR DESCRIPTION
One problem is the function name `get_numpy_ndarray_parts` suggests that its a generic function. While I have to check for pixel type's consistency where  I assume the array to be no more than 3-D before copying the data. Otherwise, Python core dumps.  I know we could assign the pointer outside the function but that means we need to change the function prototype. So is this PR acceptable?