### PR TITLE
fix shape_predictor dlib::searialize and dlib::desearialize error

### DIFF
--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -398,26 +398,9 @@ namespace dlib
             return full_object_detection(rect, parts);
         }
 
-        friend void serialize (const shape_predictor& item, std::ostream& out)
-        {
-            int version = 1;
-            dlib::serialize(version, out);
-            dlib::serialize(item.initial_shape, out);
-            dlib::serialize(item.forests, out);
-            dlib::serialize(item.anchor_idx, out);
-            dlib::serialize(item.deltas, out);
-        }
-        friend void deserialize (shape_predictor& item, std::istream& in)
-        {
-            int version = 0;
-            dlib::deserialize(version, in);
-            if (version != 1)
-                throw serialization_error("Unexpected version found while deserializing dlib::shape_predictor.");
-            dlib::deserialize(item.initial_shape, in);
-            dlib::deserialize(item.forests, in);
-            dlib::deserialize(item.anchor_idx, in);
-            dlib::deserialize(item.deltas, in);
-        }
+        friend void serialize (const shape_predictor& item, std::ostream& out);
+
+        friend void deserialize (shape_predictor& item, std::istream& in);
 
     private:
         matrix<float,0,1> initial_shape;
@@ -426,6 +409,27 @@ namespace dlib
         std::vector<std::vector<dlib::vector<float,2> > > deltas;
     };
 
+    void serialize (const shape_predictor& item, std::ostream& out)
+    {
+        int version = 1;
+        dlib::serialize(version, out);
+        dlib::serialize(item.initial_shape, out);
+        dlib::serialize(item.forests, out);
+        dlib::serialize(item.anchor_idx, out);
+        dlib::serialize(item.deltas, out);
+    }
+
+    void deserialize (shape_predictor& item, std::istream& in)
+    {
+        int version = 0;
+        dlib::deserialize(version, in);
+        if (version != 1)
+            throw serialization_error("Unexpected version found while deserializing dlib::shape_predictor.");
+        dlib::deserialize(item.initial_shape, in);
+        dlib::deserialize(item.forests, in);
+        dlib::deserialize(item.anchor_idx, in);
+        dlib::deserialize(item.deltas, in);
+    }
 // ----------------------------------------------------------------------------------------
 
     class shape_predictor_trainer

--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -398,9 +398,9 @@ namespace dlib
             return full_object_detection(rect, parts);
         }
 
-        friend inline void serialize (const shape_predictor& item, std::ostream& out);
+        friend void serialize (const shape_predictor& item, std::ostream& out);
 
-        friend inline void deserialize (shape_predictor& item, std::istream& in);
+        friend void deserialize (shape_predictor& item, std::istream& in);
 
     private:
         matrix<float,0,1> initial_shape;
@@ -409,7 +409,7 @@ namespace dlib
         std::vector<std::vector<dlib::vector<float,2> > > deltas;
     };
 
-    void serialize (const shape_predictor& item, std::ostream& out)
+    inline void serialize (const shape_predictor& item, std::ostream& out)
     {
         int version = 1;
         dlib::serialize(version, out);
@@ -419,7 +419,7 @@ namespace dlib
         dlib::serialize(item.deltas, out);
     }
 
-    void deserialize (shape_predictor& item, std::istream& in)
+    inline void deserialize (shape_predictor& item, std::istream& in)
     {
         int version = 0;
         dlib::deserialize(version, in);

--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -398,9 +398,9 @@ namespace dlib
             return full_object_detection(rect, parts);
         }
 
-        friend void serialize (const shape_predictor& item, std::ostream& out);
+        friend inline void serialize (const shape_predictor& item, std::ostream& out);
 
-        friend void deserialize (shape_predictor& item, std::istream& in);
+        friend inline void deserialize (shape_predictor& item, std::istream& in);
 
     private:
         matrix<float,0,1> initial_shape;


### PR DESCRIPTION
move friend method searialize and desearialize implement outside the shape_predictor, so that we can use the  not only `desearialize` but also `dlib::desearialize`.

in fact, in the current master branch, if use as follow:

```cpp
istringstream in("model_string");
dlib::deserialize(sp, in);
```

The compiler will report ` error: no matching function for call to ‘deserialize(dlib::shape_predictor&, std::istringstream&)’` error.

this pull request fix this bug.