### PR TITLE
Make dlib compile with WIN32_LEAN_AND_MEAN defined

### DIFF
--- a/dlib/misc_api/misc_api_kernel_1.cpp
+++ b/dlib/misc_api/misc_api_kernel_1.cpp
@@ -11,6 +11,7 @@
 #include "misc_api_kernel_1.h"
 
 #include "../windows_magic.h"
+#include <mmsystem.h>
 #include <windows.h>
 
 // tell visual studio to link to the library needed to call timeGetTime() 


### PR DESCRIPTION
This is the only file that doesn't compile when `WIN32_LEAN_AND_MEAN` is defined. Since I define this flag project wide and just include `dlib/all/source.cpp`, it would be cool to make this work.