### PR TITLE
namespace for numeric constants

### DIFF
--- a/dlib/geometry/point_transforms.h
+++ b/dlib/geometry/point_transforms.h
@@ -911,7 +911,7 @@ namespace dlib
             set_rowm(proj,2) = trans(Z);
 
             width = num_pixels/2.0;
-            dist_scale = width/std::tan(pi/180*camera_field_of_view/2);
+            dist_scale = width/std::tan(constants::pi/180*camera_field_of_view/2);
         }
 
         vector<double> get_camera_pos()         const { return camera_pos; }

--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -5932,7 +5932,7 @@ namespace dlib
             last = cur;
 
             const vector<double> radius = tform.get_camera_pos()-tform.get_camera_looking_at();
-            delta *= 2*pi*length(radius)/600.0;
+            delta *= 2*constants::pi*length(radius)/600.0;
             vector<double> tangent_x = tform.get_camera_up_direction().cross(radius).normalize();
             vector<double> tangent_y = radius.cross(tangent_x).normalize();
             vector<double> new_pos = tform.get_camera_pos() + tangent_x*delta.x() + tangent_y*-delta.y(); 
@@ -5955,7 +5955,7 @@ namespace dlib
             last = cur;
 
             const vector<double> radius = tform.get_camera_pos()-tform.get_camera_looking_at();
-            delta *= 2*pi*length(radius)/600.0;
+            delta *= 2*constants::pi*length(radius)/600.0;
             vector<double> tangent_x = tform.get_camera_up_direction().cross(radius).normalize();
             vector<double> tangent_y = radius.cross(tangent_x).normalize();
 

--- a/dlib/image_keypoint/hog.h
+++ b/dlib/image_keypoint/hog.h
@@ -311,7 +311,7 @@ namespace dlib
                             double grad_y = (long)top-(long)bottom;
 
                             // obtain the angle of the gradient.  Make sure it is scaled between 0 and 1.
-                            double angle = std::max(0.0, std::atan2(grad_y, grad_x)/pi + 1)/2;
+                            double angle = std::max(0.0, std::atan2(grad_y, grad_x)/constants::pi + 1)/2;
 
 
                             if (gradient_type == hog_unsigned_gradient)

--- a/dlib/image_keypoint/surf.h
+++ b/dlib/image_keypoint/surf.h
@@ -87,7 +87,7 @@ namespace dlib
             << "\n\t center:        " << center 
             << "\n\t scale:         " << scale 
         );
-
+        using namespace dlib::constants;
 
         std::vector<double> ang;
         std::vector<dlib::vector<double,2> > samples;

--- a/dlib/image_processing/correlation_tracker.h
+++ b/dlib/image_processing/correlation_tracker.h
@@ -42,8 +42,8 @@ namespace dlib
             const long max_level = get_num_scale_levels()/2;
             for (unsigned long k = 0; k < get_num_scale_levels(); ++k)
             {
-                double dist = std::abs((double)k-max_level)/max_level*pi/2;
-                dist = std::min(dist, pi/2);
+                double dist = std::abs((double)k-max_level)/max_level*constants::pi/2;
+                dist = std::min(dist, constants::pi/2);
                 scale_cos_mask[k] = std::cos(dist);
             }
         }
@@ -363,8 +363,8 @@ namespace dlib
                 for (long c = 0; c < temp.nc(); ++c)
                 {
                     point delta = point(c,r)-cent;
-                    double dist = length(delta)/(size/2.0)*(pi/2);
-                    dist = std::min(dist*1.0, pi/2);
+                    double dist = length(delta)/(size/2.0)*(constants::pi/2);
+                    dist = std::min(dist*1.0, constants::pi/2);
 
                     temp(r,c) = std::cos(dist);
                 }

--- a/dlib/image_transforms/fhog.h
+++ b/dlib/image_transforms/fhog.h
@@ -1060,6 +1060,7 @@ namespace dlib
             array2d<unsigned char> temp(w,w);
             for (unsigned long i = 0; i < bars.size(); ++i)
             {
+                using namespace dlib::constants;
                 assign_all_pixels(temp, 0);
                 draw_line(temp, point(w/2,0), point(w/2,w-1), 255);
                 rotate_image(temp, bars[i], i*-pi/bars.size());

--- a/dlib/image_transforms/hough_transform.h
+++ b/dlib/image_transforms/hough_transform.h
@@ -38,6 +38,7 @@ namespace dlib
             const double scale = 1<<16;
             for (unsigned long t = 0; t < size_; ++t)
             {
+                using namespace dlib::constants;
                 double theta = t*pi/even_size;
 
                 cos_theta[t] = scale*std::cos(theta)/sqrt_2;
@@ -86,8 +87,8 @@ namespace dlib
             const vect cent = center(box);
             double theta = p.x()-cent.x();
             double radius = p.y()-cent.y();
-            theta = theta*pi/even_size;
-            radius = radius*sqrt_2 + 0.5;
+            theta = theta*constants::pi/even_size;
+            radius = radius*constants::sqrt_2 + 0.5;
 
             // now make a line segment on the line.
             vect v1 = cent + vect(size()+1000,0) + vect(0,radius);

--- a/dlib/numeric_constants.h
+++ b/dlib/numeric_constants.h
@@ -5,6 +5,8 @@
 
 namespace dlib 
 {
+namespace constants
+{
 
     // pi -- Pi
     const double pi = 3.1415926535897932385;
@@ -47,6 +49,7 @@ namespace dlib
 
     // apery -- Apery's constant
     const double apery = 1.2020569031595942854;
+}
 }
 
 #endif //DLIB_NUMERIC_CONSTANTs_H_

--- a/examples/hough_transform_ex.cpp
+++ b/examples/hough_transform_ex.cpp
@@ -15,6 +15,7 @@
 #include <dlib/image_transforms.h>
 
 using namespace dlib;
+using namespace dlib::constants;
 
 int main()
 {

--- a/examples/integrate_function_adapt_simp_ex.cpp
+++ b/examples/integrate_function_adapt_simp_ex.cpp
@@ -20,6 +20,7 @@
 
 using namespace std;
 using namespace dlib;
+using namespace dlib::constants;
 
 // Here we the set of functions that we wish to integrate and comment in the domain of
 // integration.

--- a/examples/running_stats_ex.cpp
+++ b/examples/running_stats_ex.cpp
@@ -12,6 +12,7 @@
 
 using namespace std;
 using namespace dlib;
+using namespace dlib::constants;
 
 // Here we define the sinc function so that we may generate sample data. We compute the mean,
 // variance, skewness, and excess kurtosis of this sample data.


### PR DESCRIPTION
Initial attempt to enclose constants in namespace.
Used `constants::` when only few constants where needed, but `using` in the function when more needed. 
In the cpp files, using added to the top of the file.
