### PR TITLE
first check large number in elsif

### DIFF
--- a/dlib/assert.h
+++ b/dlib/assert.h
@@ -37,10 +37,10 @@
 #elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2)) && defined(__GXX_EXPERIMENTAL_CXX0X__) 
 #   define DLIB_HAS_RVALUE_REFERENCES
 #   define DLIB_HAS_INITIALIZER_LISTS
-#elif defined(_MSC_VER) && _MSC_VER >= 1600
-#   define DLIB_HAS_RVALUE_REFERENCES
 #elif defined(_MSC_VER) && _MSC_VER >= 1800
 #   define DLIB_HAS_INITIALIZER_LISTS
+#   define DLIB_HAS_RVALUE_REFERENCES
+#elif defined(_MSC_VER) && _MSC_VER >= 1600
 #   define DLIB_HAS_RVALUE_REFERENCES
 #elif defined(__INTEL_COMPILER) && defined(BOOST_INTEL_STDCXX0X)
 #   define DLIB_HAS_RVALUE_REFERENCES


### PR DESCRIPTION
This is to use initializer lists with MSVC 2015.
Also I wonder why [this commit](https://github.com/davisking/dlib/commit/48df23a0e065e01c5ba176d4999fffb0d9a29e02) disabled the C++11 with MSVC? It is quite capable of compiling C++14. 