### PR TITLE
add set_state to kalman filter for the case we know the initial state

### DIFF
--- a/dlib/filtering/kalman_filter.h
+++ b/dlib/filtering/kalman_filter.h
@@ -36,6 +36,13 @@ namespace dlib
         void set_process_noise     ( const matrix<double,states,states>& Q_) { Q = Q_; }
         void set_measurement_noise ( const matrix<double,measurements,measurements>& R_) { R = R_; }
         void set_estimation_error_covariance( const matrix<double,states,states>& P_) { P = P_; }
+        void set_state             ( const matrix<double,states,1>& xb_) {
+            xb = xb_;
+            if (!got_first_meas) {
+                x = xb_;
+                got_first_meas = true;
+            }
+        }
 
         const matrix<double,measurements,states>& get_observation_model (
         ) const { return H; }

--- a/dlib/filtering/kalman_filter_abstract.h
+++ b/dlib/filtering/kalman_filter_abstract.h
@@ -93,6 +93,18 @@ namespace dlib
                   understand what you are doing.)
         !*/
 
+        void set_state ( 
+            const matrix<double,states,1>& xb
+        ); 
+        /*!
+            ensures
+                - #get_predicted_next_state() == xb
+                - If update() is never called with a measurement
+                  #get_current_state() == get_predicted_next_state()
+            (Can be used when the initial state is known, or if the state needs to be corrected
+            before the next update())
+        !*/
+
         const matrix<double,measurements,states>& get_observation_model (
         ) const;
         /*!


### PR DESCRIPTION
Sometimes initial state is known, also sometimes the state should be corrected (like if the model has known boundaries). 
