### PR TITLE
added --working-dir argument for imgtool

### DIFF
--- a/tools/imglab/src/cluster.cpp
+++ b/tools/imglab/src/cluster.cpp
@@ -140,7 +140,9 @@ int cluster_dataset(
     image_dataset_metadata::dataset data;
 
     image_dataset_metadata::load_image_dataset_metadata(data, parser[0]);
-    set_current_dir(get_parent_directory(file(parser[0])));
+    
+    const string working_dir = get_option(parser, "working-dir", get_parent_directory(file(parser[0])).full_name());
+    set_current_dir(working_dir);
 
     const double aspect_ratio = mean_aspect_ratio(data);
 

--- a/tools/imglab/src/convert_pascal_v1.cpp
+++ b/tools/imglab/src/convert_pascal_v1.cpp
@@ -148,10 +148,9 @@ void convert_pascal_v1(
     dlib::image_dataset_metadata::image img;
 
     const std::string filename = parser.option("c").argument();
-    // make sure the file exists so we can use the get_parent_directory() command to
-    // figure out it's parent directory.
+    // make sure the file exists so we could use it as a working directory
     make_empty_file(filename);
-    const std::string parent_dir = get_parent_directory(file(filename)).full_name();
+    const string working_dir = get_option(parser, "working-dir", get_parent_directory(file(filename)).full_name());
 
     for (unsigned long i = 0; i < parser.number_of_arguments(); ++i)
     {
@@ -160,7 +159,7 @@ void convert_pascal_v1(
             parse_annotation_file(parser[i], img, name);
 
             dataset.name = name;
-            img.filename = strip_path(figure_out_full_path_to_image(parser[i], img.filename), parent_dir);
+            img.filename = strip_path(figure_out_full_path_to_image(parser[i], img.filename), working_dir);
             dataset.images.push_back(img);
 
         }

--- a/tools/imglab/src/convert_pascal_xml.cpp
+++ b/tools/imglab/src/convert_pascal_xml.cpp
@@ -209,10 +209,9 @@ void convert_pascal_xml(
     dlib::image_dataset_metadata::image img;
 
     const std::string filename = parser.option("c").argument();
-    // make sure the file exists so we can use the get_parent_directory() command to
-    // figure out it's parent directory.
+    // make sure the file exists so we can use get its relative directory
     make_empty_file(filename);
-    const std::string parent_dir = get_parent_directory(file(filename)).full_name();
+    const string working_dir = get_option(parser, "working-dir", get_parent_directory(file(filename)).full_name());
 
     for (unsigned long i = 0; i < parser.number_of_arguments(); ++i)
     {
@@ -223,7 +222,7 @@ void convert_pascal_xml(
             const string img_path = root + directory::get_separator() + "JPEGImages" + directory::get_separator();
 
             dataset.name = name;
-            img.filename = strip_path(img_path + img.filename,  parent_dir);
+            img.filename = strip_path(img_path + img.filename,  working_dir);
             dataset.images.push_back(img);
 
         }

--- a/tools/imglab/src/metadata_editor.cpp
+++ b/tools/imglab/src/metadata_editor.cpp
@@ -42,6 +42,7 @@ rgb_alpha_pixel string_to_color(
 
 metadata_editor::
 metadata_editor(
+    const std::string& working_dir,
     const std::string& filename_
 ) : 
     mbar(*this),
@@ -55,10 +56,8 @@ metadata_editor(
 {
     file metadata_file(filename_);
     filename = metadata_file.full_name();
-    // Make our current directory be the one that contains the metadata file.  We 
-    // do this because that file might contain relative paths to the image files
-    // we are supposed to be loading.
-    set_current_dir(get_parent_directory(metadata_file).full_name());
+    // Set current directory to working_dir, so that we can get images by their relative path
+    set_current_dir(working_dir);
 
     load_image_dataset_metadata(metadata, filename);
 

--- a/tools/imglab/src/metadata_editor.h
+++ b/tools/imglab/src/metadata_editor.h
@@ -12,6 +12,7 @@ class metadata_editor : public dlib::drawable_window
 {
 public:
     metadata_editor(
+        const std::string& working_dir,
         const std::string& filename_
     );
 


### PR DESCRIPTION
Using `--working-dir` user can store "xml descriptor" separately from image folder or even mix and match different image folders and "xml descriptor" files.