### PR TITLE
Fix building on win32 with 32bit architecture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -518,18 +518,12 @@ class build(_build):
             py_lib = os.path.join(get_config_var('LIBDIR'), 'libpython'+py_ver+'.dylib')
             cmake_extra_arch += ['-DPYTHON_LIBRARY={lib}'.format(lib=py_lib)]
 
-        if platform_arch == '64bit' and sys.platform == "win32":
-            # 64bit build on Windows
-
-            if not generator_set:
-                # see if we can deduce the 64bit default generator
+        if sys.platform == "win32":
+            if platform_arch == '64bit' and  not generator_set:
                 cmake_extra_arch += get_msvc_win64_generator()
 
-            # help cmake to find Python library in 64bit Python in Windows
-            #  because cmake is 32bit and cannot find PYTHON_LIBRARY from registry.
             inc_dir = get_python_inc()
             cmake_extra_arch += ['-DPYTHON_INCLUDE_DIR={inc}'.format(inc=inc_dir)]
-
             # this imitates cmake in path resolution
             py_ver = get_python_version()
             for ext in [py_ver.replace(".", "") + '.lib', py_ver + 'mu.lib', py_ver + 'm.lib', py_ver + 'u.lib']:


### PR DESCRIPTION
Now PYTHON_INCLUDE_DIR and PYTHON_LIBRARY setting up correctly for both 32/64 bit architectures