### PR TITLE
DNN Samples modified for VS 2015 compilation

### DIFF
--- a/examples/dnn_imagenet_ex.cpp
+++ b/examples/dnn_imagenet_ex.cpp
@@ -47,15 +47,19 @@ using block  = BN<con<N,3,3,1,1,relu<BN<con<N,3,3,stride,stride,SUBNET>>>>>;
 template <int N, typename SUBNET> using ares      = relu<residual<block,N,affine,SUBNET>>;
 template <int N, typename SUBNET> using ares_down = relu<residual_down<block,N,affine,SUBNET>>;
 
+template <typename SUBNET> using level1 = ares<512,ares<512,ares_down<512,SUBNET>>>;
+template <typename SUBNET> using level2 = ares<256,ares<256,ares<256,ares<256,ares<256,ares_down<256,SUBNET>>>>>>;
+template <typename SUBNET> using level3 = ares<128,ares<128,ares<128,ares_down<128,SUBNET>>>>;
+template <typename SUBNET> using level4 = ares<64,ares<64,ares<64,SUBNET>>>;
 
 using anet_type = loss_multiclass_log<fc<1000,avg_pool_everything<
-                            ares<512,ares<512,ares_down<512,
-                            ares<256,ares<256,ares<256,ares<256,ares<256,ares_down<256,
-                            ares<128,ares<128,ares<128,ares_down<128,
-                            ares<64,ares<64,ares<64,
+                            level1<
+                            level2<
+                            level3<
+                            level4<
                             max_pool<3,3,2,2,relu<affine<con<64,7,7,2,2,
                             input_rgb_image_sized<227>
-                            >>>>>>>>>>>>>>>>>>>>>>>;
+                            >>>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_imagenet_train_ex.cpp
+++ b/examples/dnn_imagenet_train_ex.cpp
@@ -40,25 +40,36 @@ template <int N, typename SUBNET> using ares_down = relu<residual_down<block,N,a
 
 // ----------------------------------------------------------------------------------------
 
+template <typename SUBNET> using level1 = res<512,res<512,res_down<512,SUBNET>>>;
+template <typename SUBNET> using level2 = res<256,res<256,res<256,res<256,res<256,res_down<256,SUBNET>>>>>>;
+template <typename SUBNET> using level3 = res<128,res<128,res<128,res_down<128,SUBNET>>>>;
+template <typename SUBNET> using level4 = res<64,res<64,res<64,SUBNET>>>;
+
+template <typename SUBNET> using alevel1 = ares<512,ares<512,ares_down<512,SUBNET>>>;
+template <typename SUBNET> using alevel2 = ares<256,ares<256,ares<256,ares<256,ares<256,ares_down<256,SUBNET>>>>>>;
+template <typename SUBNET> using alevel3 = ares<128,ares<128,ares<128,ares_down<128,SUBNET>>>>;
+template <typename SUBNET> using alevel4 = ares<64,ares<64,ares<64,SUBNET>>>;
+
 // training network type
 using net_type = loss_multiclass_log<fc<1000,avg_pool_everything<
-                            res<512,res<512,res_down<512,
-                            res<256,res<256,res<256,res<256,res<256,res_down<256,
-                            res<128,res<128,res<128,res_down<128,
-                            res<64,res<64,res<64,
-                            max_pool<3,3,2,2,relu<bn_con<con<64,7,7,2,2,
+                            level1<
+                            level2<
+                            level3<
+                            level4<
+                            max_pool<3,3,2,2,relu<affine<con<64,7,7,2,2,
                             input_rgb_image_sized<227>
-                            >>>>>>>>>>>>>>>>>>>>>>>;
+                            >>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = loss_multiclass_log<fc<1000,avg_pool_everything<
-                            ares<512,ares<512,ares_down<512,
-                            ares<256,ares<256,ares<256,ares<256,ares<256,ares_down<256,
-                            ares<128,ares<128,ares<128,ares_down<128,
-                            ares<64,ares<64,ares<64,
+                            alevel1<
+                            alevel2<
+                            alevel3<
+                            alevel4<
                             max_pool<3,3,2,2,relu<affine<con<64,7,7,2,2,
                             input_rgb_image_sized<227>
-                            >>>>>>>>>>>>>>>>>>>>>>>;
+                            >>>>>>>>>>>;
+
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
With this changes I have successfully compiled ALL examples with VS 2015 Up3 with CUDA support. For training dnn_imagenet_train_ex i used x64 compiler, as x86 is not able to compile because of not enough heap size (C1002 error)

May be some renaming should be made