### PR TITLE
find_cudnn modified for cudnn installed a user directory.

### DIFF
--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -11,6 +11,6 @@ get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
 find_library(cudnn cudnn
     HINTS ${cudnn_hint_path} ENV CUDNN_LIBRARY_DIR  ENV CUDNN_HOME 
     PATHS /usr/local /usr/local/cuda ENV LD_LIBRARY_PATH
-    PATH_SUFFIXES lib64 lib
+    PATH_SUFFIXES lib64 lib x64
     )
 mark_as_advanced(cudnn cudnn_include)


### PR DESCRIPTION
I have tried the dlib 19.1 with Visual Studio 2015 Update 3, CUDA 8 and cuDNN 5.1. 
I failed configuration of CMake because cuDNN is not found when I installed cudnn in %USERPROFILE%/library/cuDNN/ .
Of course, I added the above path to CMAKE_PREFIX_PATH.

Unzipped cuDNN 5.1 has following directories and files.

(Root directory of cuDNN 5.1)
├─bin ─ cudnn64_5.dll
├─include ─ cudnn,h
└─lib ─ x64 ─ cudnn.lib

So, I added x64 to PATH_SUFFIXES on line 14 in its source code to solve this problem.
