### PR TITLE
Fix for #281

### DIFF
--- a/dlib/threads/async.cpp
+++ b/dlib/threads/async.cpp
@@ -9,6 +9,7 @@
 #include "async.h"
 #include <stdlib.h>
 #include "../string.h"
+#include <thread>
 
 namespace dlib
 {


### PR DESCRIPTION
Added `#include <thread>`. This can help to exclude possible misunderstanding of MinGW x86 comiplation problems in a future