### PR TITLE
Added threads.h into shape_predictor.h

### DIFF
--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -11,6 +11,7 @@
 #include "../pixel.h"
 #include "../console_progress_indicator.h"
 #include "../statistics.h"
+#include "../threads.h"
 #include <utility>
 
 namespace dlib


### PR DESCRIPTION
fix for #280 . train_shape_predictor_ex example compiles well even without this PR. this PR just clarifies the dependancy