### PR TITLE
optimization - poly_min_extrap fixed for a specific case

### DIFF
--- a/dlib/optimization/optimization_line_search.h
+++ b/dlib/optimization/optimization_line_search.h
@@ -212,7 +212,7 @@ namespace dlib
         double temp = aa2*aa1*(x1-x2);
 
         // just take a guess if this happens
-        if (temp == 0)
+        if (temp == 0 || std::fpclassify(temp) == FP_SUBNORMAL)
         {
             return x1/2.0;
         }


### PR DESCRIPTION
If temp is nonzero but a subnormal then temp2 matrix may contain infinities which may cause temp assignment in line 225 to be a NaN (as a difference of two positive infinities).