### PR TITLE
pass CUDA_HOST_COMPILER variable to cuda cmake tests

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -481,6 +481,7 @@ if (NOT TARGET dlib)
                            CMAKE_FLAGS "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
                                        "-DCMAKE_INCLUDE_PATH=${CMAKE_INCLUDE_PATH}"
                                        "-DCMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH}"
+                                       "-DCUDA_HOST_COMPILER=${CUDA_HOST_COMPILER}"
                            )
                if (NOT cuda_test_compile_worked)
                   message(STATUS "*** CUDA was found but your compiler failed to compile a simple CUDA program so dlib isn't going to use CUDA. ***")
@@ -491,6 +492,7 @@ if (NOT TARGET dlib)
                               CMAKE_FLAGS "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
                                           "-DCMAKE_INCLUDE_PATH=${CMAKE_INCLUDE_PATH}"
                                           "-DCMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH}"
+                                          "-DCUDA_HOST_COMPILER=${CUDA_HOST_COMPILER}"
                                           )
                   if (cudnn_test_compile_worked)
                      message(STATUS "Found cuDNN: " ${cudnn})


### PR DESCRIPTION
In Arch Linux I had the problem that the default gcc (v6.2.1) was too new and incompatible with CUDA 8. There is an official gcc5 package, which is compatible with cuda. But the host compiler flag was not passed to the cmake cuda tests, so it always reported, that the cuda tests could not be compiled.
