### PR TITLE
Travis CI Integration scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: cpp
+
+packages: &gcc5_pkgs
+  - gcc-5
+  - g++-5
+  - libstdc++6
+
+matrix:
+  include:
+    # build and run all tests
+    - compiler: gcc
+      env:
+        - GCC_VER=5
+        - ADDRESS_MODEL=64
+        - BUILD_SYSTEM=cmake
+        - PATH=$HOME/bin:$PATH
+        - VARIANT=test
+      addons: &ao_gcc5
+        apt:
+          sources: 
+            - ubuntu-toolchain-r-test
+          packages: *gcc5_pkgs
+    # build all examples
+    - compiler: gcc
+      env:
+        - GCC_VER=5
+        - ADDRESS_MODEL=64
+        - BUILD_SYSTEM=cmake
+        - PATH=$HOME/bin:$PATH
+        - VARIANT=examples
+      addons: *ao_gcc5
+          
+cache:
+  directories:
+    - cmake
+
+before_install:
+  - dlib/travis/before-install.sh
+
+install:
+    - if [ "$CXX" == "g++" ]; then export CXX=g++-$GCC_VER; export CC=gcc-$GCC_VER; fi
+    - if [ "$CXX" == "clang++" ]; then export CXX=clang++-$CLANG_VER; export CC=clang-$CLANG_VER; fi
+
+script:
+  - dlib/travis/build-and-test.sh
+
+
+notifications:
+  email:
+    false

--- a/dlib/travis/before-install.sh
+++ b/dlib/travis/before-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Exit if anything fails.
+set -eux
+
+## download CMAKE 3.5 to get colored output
+if [[ ! -x cmake/bin/cmake && -d cmake ]]; then
+    rm -rf cmake
+fi
+if [[ ! -d cmake ]]; then
+  CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz"
+  mkdir -v cmake 
+  wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+fi
+
+
+

--- a/dlib/travis/build-and-test.sh
+++ b/dlib/travis/build-and-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Exit if anything fails.
+set -eux
+
+# build dlib and tests
+mkdir build
+cd build
+if [ "$VARIANT" = "test" ]; then
+  ../cmake/bin/cmake ../dlib/test -DCMAKE_BUILD_TYPE=Release
+  ../cmake/bin/cmake --build . --target dtest -- -j 2
+  ./dtest --runall
+fi
+if [ "$VARIANT" = "examples" ]; then
+  ../cmake/bin/cmake ../examples -DCMAKE_BUILD_TYPE=Release
+  ../cmake/bin/cmake --build . -- -j 2
+fi
+
+cd ..


### PR DESCRIPTION
This PR introduces minimal Travis-CI integration scripts. This was earlier discussed here #118 and didn't got enough attention
I am now using Travis with one other project and I really see that it is usefull to see if incoming PR breaks code or not
Travis will make automatic compilation of dtest (and execute it with --runall) and all examples (no running - build only) on each incoming PR and PR change. Author of PR will show integration result immediately with no need to as Davis to check his code.
This does not replace existing way to test dlib on existing servers, but can be usefull as an additional automatic CI tool visible to PR authors

How to integrate:
1. register on https://travis-ci.org/ with using github account (Free for open-source)
2. "My repositiories" -> press "+" -> select repository (press switch) and press "settings" 
3. enable "Build only if .travis.yml is present" and "Build pull requests"
4. If you want to check direct pushes to a master branch - enable  "Build pushes"  too
5. test with sample PR

After that every new PR and changes on existing PR will get additional testing results information
Testing time is about 15 minutes long

I can extend this scripts to make automatic python and tools test-building too
Cuda is not supported now, but i think its possible to test cuda + cudnn compilation too. Running CUDA tests will not be possible
Its possible to add Clang compiler testing too
May be - mingw/linux
Visual Studio - now not possible, but may be in a future
Code coverage measurement - possible as next steps

If you will want to remove it in a future - delete .travis.yml file and dlib/travis directory