### PR TITLE
Fix include issue when using libjpeg compiled outside of dlib ('INT32': redefinition; different basic types)

### DIFF
--- a/dlib/image_saver/save_jpeg.cpp
+++ b/dlib/image_saver/save_jpeg.cpp
@@ -10,14 +10,15 @@
 #include "../pixel.h"
 #include "save_jpeg.h"
 #include <stdio.h>
+#include <sstream>
+#include <setjmp.h>
+#include "image_saver.h"
+
 #ifdef DLIB_JPEG_STATIC
 #   include "../external/libjpeg/jpeglib.h"
 #else
 #   include <jpeglib.h>
 #endif
-#include <sstream>
-#include <setjmp.h>
-#include "image_saver.h"
 
 namespace dlib
 {


### PR DESCRIPTION
When compiling on windows and using libjpeg compiled outside of dlib you will get - 'INT32': redefinition; different basic types. This tracks back to the fact the jmorecfg.h in the libjpeg source defines INT32 (dlib's source for libjpeg does not included this define), later basetsd.h (from the windows kit) defines it differently. jmorecfg has a pre-processor check against _BASETSD_H_ defined in basetsd.h, however in this case jmorecfg.h gets included before basetsd.h in save_jpeg.cpp through jpeglib.h (includes jmorecfg.h)  and image_saver.h (includes basetsd.h). Swapping the order of the includes seems to fix the issue with no apparent issues created.