### PR TITLE
Update Travis CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dlib C++ library ![Travis Status](https://travis-ci.org/davisking/dlib.svg?branch=master)
+# dlib C++ library [![Travis Status](https://travis-ci.org/davisking/dlib.svg?branch=master)](https://travis-ci.org/davisking/dlib)
 
 Dlib is a modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++ to solve real world problems. See [http://dlib.net](http://dlib.net) for the main project documentation and API reference.
 
@@ -11,10 +11,10 @@ Go into the examples folder and type:
 ```bash
 mkdir build; cd build; cmake .. ; cmake --build .
 ```
-   
-That will build all the examples.  
+
+That will build all the examples.
 If you have a CPU that supports AVX instructions then turn them on like this:
-    
+
 ```bash
 mkdir build; cd build; cmake .. -DUSE_AVX_INSTRUCTIONS=1; cmake --build .
 ```
@@ -25,7 +25,7 @@ Doing so will make some things run faster.
 
 ## Compiling dlib Python API
 
-Before you can run the Python example programs you must compile dlib. Type: 
+Before you can run the Python example programs you must compile dlib. Type:
 
 ```bash
 python setup.py install
@@ -36,8 +36,8 @@ or type
 ```bash
 python setup.py install --yes USE_AVX_INSTRUCTIONS
 ```
-   
-if you have a CPU that supports AVX instructions, since this makes some things run faster.  
+
+if you have a CPU that supports AVX instructions, since this makes some things run faster.
 
 
 
@@ -60,5 +60,5 @@ This library is licensed under the Boost Software License, which can be found in
 
 ## dlib sponsors
 
-This research is based in part upon work supported by the Office of the Director of National Intelligence (ODNI), Intelligence Advanced Research Projects Activity (IARPA) under contract number 2014-14071600010. The views and conclusions contained herein are those of the authors and should not be interpreted as necessarily representing the official policies or endorsements, either expressed or implied, of ODNI, IARPA, or the U.S. Government.  
+This research is based in part upon work supported by the Office of the Director of National Intelligence (ODNI), Intelligence Advanced Research Projects Activity (IARPA) under contract number 2014-14071600010. The views and conclusions contained herein are those of the authors and should not be interpreted as necessarily representing the official policies or endorsements, either expressed or implied, of ODNI, IARPA, or the U.S. Government.
 


### PR DESCRIPTION
This PR updates the Travic CI status badge in `README.md`: Link on CI status badge points to the [Travis CI](https://travis-ci.org/davisking/dlib) page for `dlib` now.

Closes #309