### PR TITLE
Made active_learning test more robust on ARM64

### DIFF
--- a/dlib/test/active_learning.cpp
+++ b/dlib/test/active_learning.cpp
@@ -150,7 +150,7 @@ namespace
 
             // When we pick the best/front ranked element then the active learning method
             // shouldn't do much worse than random selection (and often much better).
-            DLIB_TEST(test_rank_unlabeled_training_samples(samples, labels, max_min_margin, 25, true) >= 0.97);
+            DLIB_TEST(test_rank_unlabeled_training_samples(samples, labels, max_min_margin, 35, true) >= 0.97);
             DLIB_TEST(test_rank_unlabeled_training_samples(samples, labels, ratio_margin, 25, true) >= 0.96);
             // However, picking the worst ranked element should do way worse than random
             // selection.


### PR DESCRIPTION
As described in #313 the `active_learning` tests fails on ARM64. 

This PR increases the number of iterations to make the test more robost.

Closes #313 