### PR TITLE
Fix for failing max_cost_assignment test on ARM/ARM64

### DIFF
--- a/dlib/test/max_cost_assignment.cpp
+++ b/dlib/test/max_cost_assignment.cpp
@@ -120,7 +120,7 @@ namespace
             T true_eval = assignment_cost(cost, assign);
             assign = max_cost_assignment(cost);
             DLIB_TEST(assignment_cost(cost,assign) == true_eval);
-            assign = max_cost_assignment(matrix_cast<char>(cost));
+            assign = max_cost_assignment(matrix_cast<signed char>(cost));
             DLIB_TEST(assignment_cost(cost,assign) == true_eval);
 
 


### PR DESCRIPTION
The ARM ABI defines a `char` as an unsigned byte, see [ARM spec](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0375g/chr1359124944415.html).

That's the reason why the `max_cost_assignment` test fails on this condition:

```cpp
assign = max_cost_assignment(matrix_cast<char>(cost));
DLIB_TEST(assignment_cost(cost,assign) == true_eval);
```

By changing the `matrix_cast<char>(cost)` declaration to `matrix_cast<signed char>(cost)` the test will succeed.