### PR TITLE
Add option --rm-other-labels to imglab

### DIFF
--- a/tools/imglab/src/main.cpp
+++ b/tools/imglab/src/main.cpp
@@ -890,20 +890,23 @@ int main(int argc, char** argv)
             dlib::image_dataset_metadata::dataset data;
             load_image_dataset_metadata(data, parser[0]);
 
-            const auto label = parser.option("rm-other-labels").argument();
-
+            const auto labels = parser.option("rm-other-labels").argument();
+            // replace comma by dash to form the file name
+            std::string strlabels = labels;
+            std::replace(strlabels.begin(), strlabels.end(), ',', '-');
+            std::vector<string> all_labels = split(labels, ",");
             for (auto&& img : data.images)
             {
                 std::vector<dlib::image_dataset_metadata::box> boxes;
                 for (auto&& b : img.boxes)
                 {
-                    if (b.label == label)
+                    if (std::find(all_labels.begin(), all_labels.end(), b.label) != all_labels.end())
                         boxes.push_back(b);
                 }
                 img.boxes = boxes;
             }
 
-            save_image_dataset_metadata(data, parser[0] + ".rm-other-labels-"+label+".xml");
+            save_image_dataset_metadata(data, parser[0] + ".rm-other-labels-"+ strlabels +".xml");
             return EXIT_SUCCESS;
         }
 


### PR DESCRIPTION
fixes #321
This PR adds a new `--rm-other-labels` to imglab
The option accepts its argument as:
* either a single string 
* or a comma separated list of labels to keep

Example:
```bash
imglab --rm-other-labels product1 testing.xml
imglab --rm-other-labels "product1,product2" testing.xml
```

> Note
> when using commas, the resulting file name will replace them with dashes
```
imglab --rm-other-labels "product1,product2" testing.xml
``` 
> will generate `tesing.xml-rm-other-labels-product1-product2.xml`
