### PR TITLE
Expose python binding for running multiple detectors at once

### DIFF
--- a/tools/python/src/object_detection.cpp
+++ b/tools/python/src/object_detection.cpp
@@ -340,6 +340,20 @@ ensures \n\
       detector.  If you don't know how many times you want to upsample then \n\
       don't provide a value for upsample_num_times and an appropriate \n\
       default will be used.")
+        .def("run_multiple", run_multiple_rect_detectors,(arg("detectors"),  arg("image"), arg("upsample_num_times")=0, arg("adjust_threshold")=0.0),
+"requires \n\
+    - detectors is a list of detectors. \n\
+    - image is a numpy ndarray containing either an 8bit grayscale or RGB \n\
+      image. \n\
+    - upsample_num_times >= 0 \n\
+ensures \n\
+    - This function runs the list of object detectors at once on the input image and returns \n\
+      a tuple of (list of detections, list of scores, list of weight_indices).   \n\
+    - Upsamples the image upsample_num_times before running the basic \n\
+      detector.  If you don't know how many times you want to upsample then \n\
+      don't provide a value for upsample_num_times and an appropriate \n\
+      default will be used.")
+        .staticmethod("run_multiple")
         .def("save", save_simple_object_detector, (arg("detector_output_filename")), "Save a simple_object_detector to the provided path.")
         .def_pickle(serialize_pickle<type>());
     }

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -12,8 +12,7 @@
 namespace dlib
 {
     typedef object_detector<scan_fhog_pyramid<pyramid_down<6> > > simple_object_detector;
-    typedef scan_fhog_pyramid<pyramid_down<6> > image_scanner_type;
-    
+
     inline void split_rect_detections (
         std::vector<rect_detection>& rect_detections,
         std::vector<rectangle>& rectangles,
@@ -115,7 +114,7 @@ namespace dlib
     }
 
     inline std::vector<dlib::rectangle> run_detectors_with_upscale1 (
-        std::vector<object_detector<image_scanner_type> >& detectors,
+        std::vector<simple_object_detector >& detectors,
         boost::python::object img,
         const unsigned int upsampling_amount,
         const double adjust_threshold,
@@ -238,12 +237,12 @@ namespace dlib
     {
         boost::python::tuple t;
 
-        std::vector<object_detector<image_scanner_type> > vector_detectors;
+        std::vector<simple_object_detector > vector_detectors;
         const unsigned long num_detectors = len(detectors);
         // Now copy the data into dlib based objects.
         for (unsigned long i = 0; i < num_detectors; ++i)
         {
-            vector_detectors.push_back(boost::python::extract<object_detector<image_scanner_type > >(detectors[i]));
+            vector_detectors.push_back(boost::python::extract<simple_object_detector >(detectors[i]));
         }
         
         std::vector<double> detection_confidences;

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -12,7 +12,8 @@
 namespace dlib
 {
     typedef object_detector<scan_fhog_pyramid<pyramid_down<6> > > simple_object_detector;
-
+    typedef scan_fhog_pyramid<pyramid_down<6> > image_scanner_type;
+    
     inline void split_rect_detections (
         std::vector<rect_detection>& rect_detections,
         std::vector<rectangle>& rectangles,
@@ -113,6 +114,86 @@ namespace dlib
         }
     }
 
+    inline std::vector<dlib::rectangle> run_detectors_with_upscale1 (
+        std::vector<object_detector<image_scanner_type> >& detectors,
+        boost::python::object img,
+        const unsigned int upsampling_amount,
+        const double adjust_threshold,
+        std::vector<double>& detection_confidences,
+        std::vector<double>& weight_indices
+    )
+    {
+        pyramid_down<2> pyr;
+
+        std::vector<rectangle> rectangles;
+        std::vector<rect_detection> rect_detections;
+
+        if (is_gray_python_image(img))
+        {
+            array2d<unsigned char> temp;
+            if (upsampling_amount == 0)
+            {
+                evaluate_detectors(detectors, numpy_gray_image(img), rect_detections, adjust_threshold);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+                return rectangles;
+            }
+            else
+            {
+                pyramid_up(numpy_gray_image(img), temp, pyr);
+                unsigned int levels = upsampling_amount-1;
+                while (levels > 0)
+                {
+                    levels--;
+                    pyramid_up(temp);
+                }
+
+                evaluate_detectors(detectors, temp, rect_detections, adjust_threshold);
+                for (unsigned long i = 0; i < rect_detections.size(); ++i)
+                    rect_detections[i].rect = pyr.rect_down(rect_detections[i].rect,
+                                                            upsampling_amount);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+
+                return rectangles;
+            }
+        }
+        else if (is_rgb_python_image(img))
+        {
+            array2d<rgb_pixel> temp;
+            if (upsampling_amount == 0)
+            {
+                evaluate_detectors(detectors, numpy_rgb_image(img), rect_detections, adjust_threshold);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+                return rectangles;
+            }
+            else
+            {
+                pyramid_up(numpy_rgb_image(img), temp, pyr);
+                unsigned int levels = upsampling_amount-1;
+                while (levels > 0)
+                {
+                    levels--;
+                    pyramid_up(temp);
+                }
+
+                evaluate_detectors(detectors, temp, rect_detections, adjust_threshold);
+                for (unsigned long i = 0; i < rect_detections.size(); ++i)
+                    rect_detections[i].rect = pyr.rect_down(rect_detections[i].rect,
+                                                            upsampling_amount);
+                split_rect_detections(rect_detections, rectangles,
+                                      detection_confidences, weight_indices);
+
+                return rectangles;
+            }
+        }
+        else
+        {
+            throw dlib::error("Unsupported image type, must be 8bit gray or RGB image.");
+        }
+    }
+
     inline std::vector<dlib::rectangle> run_detector_with_upscale2 (
         dlib::simple_object_detector& detector,
         boost::python::object img,
@@ -148,6 +229,36 @@ namespace dlib
         return boost::python::make_tuple(rectangles,
                                          detection_confidences, weight_indices);
     }
+
+    inline boost::python::tuple run_multiple_rect_detectors (
+        boost::python::list& detectors,
+        boost::python::object img,
+        const unsigned int upsampling_amount,
+        const double adjust_threshold)
+    {
+        boost::python::tuple t;
+
+        std::vector<object_detector<image_scanner_type> > vector_detectors;
+        const unsigned long num_detectors = len(detectors);
+        // Now copy the data into dlib based objects.
+        for (unsigned long i = 0; i < num_detectors; ++i)
+        {
+            vector_detectors.push_back(boost::python::extract<object_detector<image_scanner_type > >(detectors[i]));
+        }
+        
+        std::vector<double> detection_confidences;
+        std::vector<double> weight_indices;
+        std::vector<rectangle> rectangles;
+
+        rectangles = run_detectors_with_upscale1(vector_detectors, img, upsampling_amount,
+                                                adjust_threshold,
+                                                detection_confidences, weight_indices);
+
+        return boost::python::make_tuple(rectangles,
+                                         detection_confidences, weight_indices);
+    }
+
+
 
     struct simple_object_detector_py
     {


### PR DESCRIPTION
This exposes a static method `run_multiple` on `dlib.fhog_object_detector` that accepts a list (python list) of detectors

The results have the same form as for the `run` method

Example:
```python
detector_1= dlib.fhog_object_detector("object_detector1.svm")
detector2 = dlib.fhog_object_detector("object_detector2.svm")
detectors = [detector1, detector2]
retval = dlib.fhog_object_detector.run_multiple(
    detectors, 
    image, 
    upsample_num_times=0,  
    adjust_threshold=0.0)
```