### PR TITLE
Remove initializer lists support for Apple/libstdc < 4.02

### DIFF
--- a/dlib/assert.h
+++ b/dlib/assert.h
@@ -47,6 +47,10 @@
 #   define DLIB_HAS_INITIALIZER_LISTS
 #endif
 
+#if defined(__APPLE__) && defined(__GNUC_LIBSTD__) && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
+ // Apple has not updated libstdc++ in some time and anything under 4.02 does not have <initializer_list> for sure.
+#   undef DLIB_HAS_INITIALIZER_LISTS
+#endif
 
 // figure out if the compiler has static_assert. 
 #if defined(__clang__) 


### PR DESCRIPTION
Remove initializer lists support for Apple (libstdc++ version used does not include std::initializer_list). When compiling on Mac an older version of libstdc++ can be linked in that does not included std::initializer_list. Same issue can be seen with Qt (https://git.merproject.org/faenil/qtbase/commit/387f75c39bfad4439a6bd013089c2cd216cda5ea), basically the same fix.