### PR TITLE
Add upsampling functionality

### DIFF
--- a/dlib/dnn/cpu_dlib.cpp
+++ b/dlib/dnn/cpu_dlib.cpp
@@ -1602,7 +1602,7 @@ namespace dlib
     // ------------------------------------------------------------------------------------
 
         upsampling::upsampling (
-        ) : repeat_height(1),repeat_width(1),do_block_upsampling(true)
+        ) : repeat_height(1),repeat_width(1)
         {
         }
 
@@ -1625,7 +1625,6 @@ namespace dlib
 
             repeat_height = repeat_height_;
             repeat_width = repeat_width_;
-            do_block_upsampling = true;
         }
 
         void upsampling::
@@ -1651,25 +1650,22 @@ namespace dlib
             }
 
             auto d = dest.host();
-            if (does_block_upsampling())
+            for (long n = 0; n < dest.num_samples(); ++n)
             {
-                for (long n = 0; n < dest.num_samples(); ++n)
+                for (long k = 0; k < dest.k(); ++k)
                 {
-                    for (long k = 0; k < dest.k(); ++k)
-                    {
-                        auto simg = image_plane(src,n,k);
-                        auto dimg = d + (n*dest.k() + k)*dest.nr()*dest.nc();
+                    auto simg = image_plane(src,n,k);
+                    auto dimg = d + (n*dest.k() + k)*dest.nr()*dest.nc();
 
-                        for (long r = 0; r < src.nr(); ++r)
+                    for (long r = 0; r < src.nr(); ++r)
+                    {
+                        for (long c = 0; c < src.nc(); ++c)
                         {
-                            for (long c = 0; c < src.nc(); ++c)
+                            for (long y = 0; y < repeat_height; ++y)
                             {
-                                for (long y = 0; y < repeat_height; ++y)
+                                for (long x = 0; x < repeat_width; ++x)
                                 {
-                                    for (long x = 0; x < repeat_width; ++x)
-                                    {
-                                        dimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)] = simg(r*src.nc() + c);
-                                    }
+                                    dimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)] = simg(r*src.nc() + c);
                                 }
                             }
                         }
@@ -1695,27 +1691,24 @@ namespace dlib
 
             auto gi = gradient_input.host();
             auto g = grad.host();
-            if (does_block_upsampling())
+            for (long n = 0; n < dest.num_samples(); ++n)
             {
-                for (long n = 0; n < dest.num_samples(); ++n)
+                for (long k = 0; k < dest.k(); ++k)
                 {
-                    for (long k = 0; k < dest.k(); ++k)
-                    {
-                        auto simg = image_plane(src,n,k);
-                        auto gimg = g + (n*grad.k() + k)*grad.nr()*grad.nc();
-                        auto giimg = gi + (n*dest.k() + k)*dest.nr()*dest.nc();
-                        auto imgbox = get_rect(simg);
+                    auto simg = image_plane(src,n,k);
+                    auto gimg = g + (n*grad.k() + k)*grad.nr()*grad.nc();
+                    auto giimg = gi + (n*dest.k() + k)*dest.nr()*dest.nc();
+                    auto imgbox = get_rect(simg);
 
-                        for (long r = 0; r < src.nr(); ++r)
+                    for (long r = 0; r < src.nr(); ++r)
+                    {
+                        for (long c = 0; c < src.nc(); ++c)
                         {
-                            for (long c = 0; c < src.nc(); ++c)
+                            for (long y = 0; y < repeat_height; ++y)
                             {
-                                for (long y = 0; y < repeat_height; ++y)
+                                for (long x = 0; x < repeat_width; ++x)
                                 {
-                                    for (long x = 0; x < repeat_width; ++x)
-                                    {
-                                        gimg[r*src.nc() + c] += giimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)];
-                                    }
+                                    gimg[r*src.nc() + c] += giimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)];
                                 }
                             }
                         }

--- a/dlib/dnn/cpu_dlib.cpp
+++ b/dlib/dnn/cpu_dlib.cpp
@@ -1595,8 +1595,134 @@ namespace dlib
                     }
                 }
             }
-
         }
+
+    // ------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------------
+
+        upsampling::upsampling (
+        ) : repeat_height(1),repeat_width(1),do_block_upsampling(true)
+        {
+        }
+
+        void upsampling::
+        clear(
+        )
+        {
+            repeat_height = 1;
+            repeat_width = 1;
+        }
+
+        void upsampling::
+        setup_block_upsampling(
+            int repeat_height_,
+            int repeat_width_
+        )
+        {
+            DLIB_CASSERT(repeat_width_ > 0);
+            DLIB_CASSERT(repeat_height_ > 0);
+
+            repeat_height = repeat_height_;
+            repeat_width = repeat_width_;
+            do_block_upsampling = true;
+        }
+
+        void upsampling::
+        operator() (
+            resizable_tensor& dest,
+            const tensor& src
+        )
+        {
+            DLIB_CASSERT(repeat_width > 0);
+            DLIB_CASSERT(repeat_height > 0);
+
+            dest.set_size(
+                 src.num_samples(),
+                 src.k(),
+                 src.nr()*repeat_height,
+                 src.nc()*repeat_width
+                );
+
+            if (src.size() == 0)
+            {
+                dest = 0;
+                return;
+            }
+
+            auto d = dest.host();
+            if (does_block_upsampling())
+            {
+                for (long n = 0; n < dest.num_samples(); ++n)
+                {
+                    for (long k = 0; k < dest.k(); ++k)
+                    {
+                        auto simg = image_plane(src,n,k);
+                        auto dimg = d + (n*dest.k() + k)*dest.nr()*dest.nc();
+
+                        for (long r = 0; r < src.nr(); ++r)
+                        {
+                            for (long c = 0; c < src.nc(); ++c)
+                            {
+                                for (long y = 0; y < repeat_height; ++y)
+                                {
+                                    for (long x = 0; x < repeat_width; ++x)
+                                    {
+                                        dimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)] = simg(r*src.nc() + c);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void upsampling::get_gradient(
+            const tensor& gradient_input, 
+            const tensor& dest,
+            const tensor& src,
+            tensor& grad 
+        )
+        {
+            DLIB_CASSERT(have_same_dimensions(gradient_input,dest));
+            DLIB_CASSERT(have_same_dimensions(src,grad));
+
+            if (src.size() == 0)
+            {
+                return;
+            }
+
+            auto gi = gradient_input.host();
+            auto g = grad.host();
+            if (does_block_upsampling())
+            {
+                for (long n = 0; n < dest.num_samples(); ++n)
+                {
+                    for (long k = 0; k < dest.k(); ++k)
+                    {
+                        auto simg = image_plane(src,n,k);
+                        auto gimg = g + (n*grad.k() + k)*grad.nr()*grad.nc();
+                        auto giimg = gi + (n*dest.k() + k)*dest.nr()*dest.nc();
+                        auto imgbox = get_rect(simg);
+
+                        for (long r = 0; r < src.nr(); ++r)
+                        {
+                            for (long c = 0; c < src.nc(); ++c)
+                            {
+                                for (long y = 0; y < repeat_height; ++y)
+                                {
+                                    for (long x = 0; x < repeat_width; ++x)
+                                    {
+                                        gimg[r*src.nc() + c] += giimg[(repeat_height*r + y)*dest.nc() + (repeat_width*c + x)];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }        
 
     // ------------------------------------------------------------------------------------
     // ------------------------------------------------------------------------------------

--- a/dlib/dnn/cpu_dlib.h
+++ b/dlib/dnn/cpu_dlib.h
@@ -347,9 +347,6 @@ namespace dlib
         {
         public:
 
-            upsampling(const upsampling&) = delete;
-            upsampling& operator=(const upsampling&) = delete;
-
             upsampling (
             );
 
@@ -360,9 +357,6 @@ namespace dlib
                 int repeat_height,
                 int repeat_width
             );
-
-            bool does_block_upsampling(
-            ) const { return do_block_upsampling; }
 
             void operator() (
                 resizable_tensor& dest,
@@ -379,7 +373,6 @@ namespace dlib
         private:
             int repeat_height;
             int repeat_width;
-            bool do_block_upsampling;
         };
 
     // -----------------------------------------------------------------------------------

--- a/dlib/dnn/cpu_dlib.h
+++ b/dlib/dnn/cpu_dlib.h
@@ -341,6 +341,47 @@ namespace dlib
 
         };
 
+        // -----------------------------------------------------------------------------------
+
+        class upsampling
+        {
+        public:
+
+            upsampling(const upsampling&) = delete;
+            upsampling& operator=(const upsampling&) = delete;
+
+            upsampling (
+            );
+
+            void clear(
+            );
+
+            void setup_block_upsampling(
+                int repeat_height,
+                int repeat_width
+            );
+
+            bool does_block_upsampling(
+            ) const { return do_block_upsampling; }
+
+            void operator() (
+                resizable_tensor& dest,
+                const tensor& src
+            );
+
+            void get_gradient(
+                const tensor& gradient_input, 
+                const tensor& dest,
+                const tensor& src,
+                tensor& grad 
+            );
+
+        private:
+            int repeat_height;
+            int repeat_width;
+            bool do_block_upsampling;
+        };
+
     // -----------------------------------------------------------------------------------
 
         class tensor_conv

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -711,7 +711,6 @@ namespace dlib
         static_assert(_repeat_c >= 1, "The number of columns to repeat must be >= 1");
     public:
 
-
         block_upsample_(
         )
         {}
@@ -737,46 +736,21 @@ namespace dlib
             return p;
         }
 
-        block_upsample_ (
-            const block_upsample_& item
-        )
-        {
-            // this->bu is non-copyable so we have to write our own copy to avoid trying to
-            // copy it and getting an error.
-        }
-
-        block_upsample_& operator= (
-            const block_upsample_& item
-        )
-        {
-            if (this == &item)
-                return *this;
-
-            // this->bu is non-copyable so we have to write our own copy to avoid trying to
-            // copy it and getting an error.
-            return *this;
-        }
-
         template <typename SUBNET>
         void setup (const SUBNET& /*sub*/)
         {
+            bu.setup_block_upsampling(_repeat_r, _repeat_c);
         }
 
         template <typename SUBNET>
         void forward(const SUBNET& sub, resizable_tensor& output)
         {
-            bu.setup_block_upsampling(_repeat_r!=0?_repeat_r:sub.get_output().nr(), 
-                                    _repeat_c!=0?_repeat_c:sub.get_output().nc());
-
             bu(output, sub.get_output());
         } 
 
         template <typename SUBNET>
         void backward(const tensor& computed_output, const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
         {
-            bu.setup_block_upsampling(_repeat_r!=0?_repeat_r:sub.get_output().nr(), 
-                                    _repeat_c!=0?_repeat_c:sub.get_output().nc());
-
             bu.get_gradient(gradient_input, computed_output, sub.get_output(), sub.get_gradient_input());
         }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -770,7 +770,7 @@ namespace dlib
             deserialize(version, in);
             long repeat_r;
             long repeat_c;
-            if (version == "max_pool_1")
+            if (version == "block_upsample_1")
             {
                 deserialize(repeat_r, in);
                 deserialize(repeat_c, in);

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -701,6 +701,149 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <
+        long _repeat_r,
+        long _repeat_c
+        >
+    class block_upsample_
+    {
+        static_assert(_repeat_r >= 1, "The number of rows to repeat must be >= 1");
+        static_assert(_repeat_c >= 1, "The number of columns to repeat must be >= 1");
+    public:
+
+
+        block_upsample_(
+        )
+        {}
+
+        long repeat_r() const { return _repeat_r; }
+        long repeat_c() const { return _repeat_c; }
+
+        inline point map_input_to_output (
+            point p
+        ) const
+        {
+            p.x() = p.x()*repeat_c();
+            p.y() = p.y()*repeat_r();
+            return p;
+        }
+
+        inline point map_output_to_input (
+            point p
+        ) const
+        {
+            p.x() = p.x()/repeat_c();
+            p.y() = p.y()/repeat_r();
+            return p;
+        }
+
+        block_upsample_ (
+            const block_upsample_& item
+        )
+        {
+            // this->bu is non-copyable so we have to write our own copy to avoid trying to
+            // copy it and getting an error.
+        }
+
+        block_upsample_& operator= (
+            const block_upsample_& item
+        )
+        {
+            if (this == &item)
+                return *this;
+
+            // this->bu is non-copyable so we have to write our own copy to avoid trying to
+            // copy it and getting an error.
+            return *this;
+        }
+
+        template <typename SUBNET>
+        void setup (const SUBNET& /*sub*/)
+        {
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            bu.setup_block_upsampling(_repeat_r!=0?_repeat_r:sub.get_output().nr(), 
+                                    _repeat_c!=0?_repeat_c:sub.get_output().nc());
+
+            bu(output, sub.get_output());
+        } 
+
+        template <typename SUBNET>
+        void backward(const tensor& computed_output, const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
+        {
+            bu.setup_block_upsampling(_repeat_r!=0?_repeat_r:sub.get_output().nr(), 
+                                    _repeat_c!=0?_repeat_c:sub.get_output().nc());
+
+            bu.get_gradient(gradient_input, computed_output, sub.get_output(), sub.get_gradient_input());
+        }
+
+        const tensor& get_layer_params() const { return params; }
+        tensor& get_layer_params() { return params; }
+
+        friend void serialize(const block_upsample_& item, std::ostream& out)
+        {
+            serialize("block_upsample_1", out);
+            serialize(_repeat_r, out);
+            serialize(_repeat_c, out);
+        }
+
+        friend void deserialize(block_upsample_& item, std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            long repeat_r;
+            long repeat_c;
+            if (version == "max_pool_1")
+            {
+                deserialize(repeat_r, in);
+                deserialize(repeat_c, in);
+            }
+            else
+            {
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::block_upsample_.");
+            }
+
+            if (_repeat_r != repeat_r) throw serialization_error("Wrong repeat_r found while deserializing dlib::block_upsample_");
+            if (_repeat_c != repeat_c) throw serialization_error("Wrong repeat_c found while deserializing dlib::block_upsample_");
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const block_upsample_& item)
+        {
+            out << "block_upsample ("
+                << "repeat_r="<<_repeat_r
+                << ", repeat_c="<<_repeat_c
+                << ")";
+            return out;
+        }
+
+        friend void to_xml(const block_upsample_& item, std::ostream& out)
+        {
+            out << "<block_upsample"
+                << " repeat_r='"<<_repeat_r<<"'"
+                << " repeat_c='"<<_repeat_c<<"'"
+                << "/>\n";
+        }
+
+
+    private:
+
+
+        tt::upsampling bu;
+        resizable_tensor params;
+    };
+
+    template <
+        long repeat_r,
+        long repeat_c,
+        typename SUBNET
+        >
+    using block_upsample = add_layer<block_upsample_<repeat_r,repeat_c>, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
     enum layer_mode
     {
         CONV_MODE = 0,

--- a/dlib/dnn/tensor_tools.h
+++ b/dlib/dnn/tensor_tools.h
@@ -983,12 +983,9 @@ namespace dlib { namespace tt
         /*!
             WHAT THIS OBJECT REPRESENTS
                 The upsampling object is a tool for performing spatial upsampling (unpooling) over a tensor.
-                It can be configured to do block upsampling.
+                It performs block upsampling.
         !*/
     public:
-
-        upsampling(const upsampling&) = delete;
-        upsampling& operator=(const upsampling&) = delete;
 
         upsampling (
         ) = default;
@@ -1009,9 +1006,6 @@ namespace dlib { namespace tt
                   the given parameters.
         !*/
 
-        bool does_block_upsampling(
-        ) const { return impl.does_block_upsampling(); }
-
         void operator() (
             resizable_tensor& dest,
             const tensor& src
@@ -1023,12 +1017,11 @@ namespace dlib { namespace tt
             ensures
                 - #dest.num_samples() == src.num_samples()
                 - #dest.k() == src.k()
-                - #dest.nr() == src.nr() * window_height
-                - #dest.nc() == src.nc() * window_width
+                - #dest.nr() == src.nr() * repeat_height
+                - #dest.nc() == src.nc() * repeat_width
                 - for all valid s, k, r, and c:
-                    - if (does_block_upsampling()) then
-                        - for 0 <= i <= window_height, 0 <= j <= window_width:
-                            - image_plane(#dest,s,k)(r*window_height + j, c*window_width + i) == image_plane(src,s,k)(r,c)
+                    - for 0 <= i <= repeat_height, 0 <= j <= repeat_width:
+                        - image_plane(#dest,s,k)(r*repeat_height + j, c*repeat_width + i) == image_plane(src,s,k)(r,c)
         !*/
 
         void get_gradient(
@@ -1054,7 +1047,7 @@ namespace dlib { namespace tt
 
         private:
 // #ifdef DLIB_USE_CUDA
-//         cuda::pooling impl;
+//         cuda::upsampling impl;
 // #else
         cpu::upsampling impl;
 //#endif


### PR DESCRIPTION
Addresses half of Issue #288. I copied the `pooling` class to base this on and modified that. 

A couple considerations: 
- I'm not qualified to provide a GPU implementation, so that's not currently an option. What is the best way to handle this?
- I copied the idea behind the pooling class' `does_max_pooling` to allow easy modifications to add other upsampling techniques. I plan to add a "sparse" upsampling where the index of the max-pool value is set to the correct input value as in SegNet. This looks a little odd right now, but that was my motivation behind leaving it there.

Very small example using the class:

```
#include <dlib/dnn.h>
#include <iostream>

using namespace std;
using namespace dlib;

int main(int argc, char** argv) try
{
    matrix<float,2,2> sample_data;
    sample_data = 1.0, 2.0,
                  3.0, 4.0;
    block_upsample<2,3,input<matrix<float>>> upsample_tester;
    cout << sample_data << endl;
    cout << mat(upsample_tester(sample_data), 4, 6);
}
catch(std::exception& e)
{
    cout << e.what() << endl;
}
```

Running this should give the output:

```
1 2
3 4

1 1 1 2 2 2
1 1 1 2 2 2
3 3 3 4 4 4
3 3 3 4 4 4
```