### PR TITLE
unicode: Disable misleading-indentation warnings with GCC pragma

### DIFF
--- a/dlib/unicode/unicode.h
+++ b/dlib/unicode/unicode.h
@@ -289,7 +289,10 @@ namespace dlib
     }
 
 // ----------------------------------------------------------------------------------------
-
+#if defined(__GNUC__) && __GNUC__ >= 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif
     template <typename T>
     bool is_combining_char(
         const T ch_
@@ -478,6 +481,9 @@ namespace dlib
         if ( ch < 0xE0100 )return false;if ( ch < 0xE01F0 )return true;
         return false;
     }
+#if defined(__GNUC__) && __GNUC__ >= 6
+#pragma GCC diagnostic pop
+#endif
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces a GCC pragma for disabling misleading-indentation warnings in the `is_combining_char()` method in `unicode.h`.

On GCC >= 6 the `-Wmisleading-indentation` option was added to `-Wall` and this would cause about 19880 warnings in `unicode.h`.

As discussed in #337 it is ok to disable these warnings via a special GCC `#pragma`.