### PR TITLE
Add MKL DFTI FFT bindings.

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -451,8 +451,8 @@ if (NOT TARGET dlib)
       endif()
 
 
-      if (DLIB_USE_BLAS OR DLIB_USE_LAPACK)
-         # Try to find BLAS and LAPACK 
+      if (DLIB_USE_BLAS OR DLIB_USE_LAPACK OR DLIB_USE_MKL_FFT)
+          # Try to find BLAS, LAPACK and MKL
          include(cmake_utils/cmake_find_blas.txt)
 
          if (DLIB_USE_BLAS)
@@ -472,13 +472,16 @@ if (NOT TARGET dlib)
                toggle_preprocessor_switch(DLIB_USE_LAPACK)
             endif()
          endif()
-      endif()
 
-      if (found_intel_mkl)
-         include_directories(${mkl_include_dir})
-      else()
-         set(DLIB_USE_MKL_FFT OFF CACHE STRING ${DLIB_USE_MKL_FFT_STR} FORCE )
-         toggle_preprocessor_switch(DLIB_USE_MKL_FFT)
+         if (DLIB_USE_MKL_FFT)
+            if (found_intel_mkl)
+               set (dlib_needed_libraries ${dlib_needed_libraries} ${mkl_libraries})
+               include_directories(${mkl_include_dir})
+            else()
+               set(DLIB_USE_MKL_FFT OFF CACHE STRING ${DLIB_USE_MKL_FFT_STR} FORCE )
+               toggle_preprocessor_switch(DLIB_USE_MKL_FFT)
+            endif()
+         endif()
       endif()
 
 

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -474,7 +474,7 @@ if (NOT TARGET dlib)
          endif()
 
          if (DLIB_USE_MKL_FFT)
-            if (found_intel_mkl)
+            if (found_intel_mkl AND found_intel_mkl_headers)
                set (dlib_needed_libraries ${dlib_needed_libraries} ${mkl_libraries})
                include_directories(${mkl_include_dir})
             else()

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -84,6 +84,8 @@ if (NOT TARGET dlib)
    set (DLIB_LINK_WITH_SQLITE3_STR
    "Disable this if you don't want to link against sqlite3" )
    #set (DLIB_USE_FFTW_STR "Disable this if you don't want to link against fftw" )
+   set (DLIB_USE_MKL_FFT_STR
+   "Disable this is you don't want to use the MKL DFTI FFT implementation" )
 
    option(DLIB_ISO_CPP_ONLY ${DLIB_ISO_CPP_ONLY_STR} OFF)
    toggle_preprocessor_switch(DLIB_ISO_CPP_ONLY)
@@ -125,6 +127,7 @@ if (NOT TARGET dlib)
       option(DLIB_PNG_SUPPORT ${DLIB_PNG_SUPPORT_STR} OFF)
       option(DLIB_GIF_SUPPORT ${DLIB_GIF_SUPPORT_STR} OFF)
       #option(DLIB_USE_FFTW ${DLIB_USE_FFTW_STR} OFF)
+      option(DLIB_USE_MKL_FFT ${DLIB_USE_MKL_FFT_STR} OFF)
    else()
       option(DLIB_JPEG_SUPPORT ${DLIB_JPEG_SUPPORT_STR} ON)
       option(DLIB_LINK_WITH_SQLITE3 ${DLIB_LINK_WITH_SQLITE3_STR} ON)
@@ -134,6 +137,7 @@ if (NOT TARGET dlib)
       option(DLIB_PNG_SUPPORT ${DLIB_PNG_SUPPORT_STR} ON)
       option(DLIB_GIF_SUPPORT ${DLIB_GIF_SUPPORT_STR} ON)
       #option(DLIB_USE_FFTW ${DLIB_USE_FFTW_STR} ON)
+      option(DLIB_USE_MKL_FFT ${DLIB_USE_MKL_FFT_STR} ON)
    endif()
    toggle_preprocessor_switch(DLIB_JPEG_SUPPORT)
    toggle_preprocessor_switch(DLIB_USE_BLAS)
@@ -142,6 +146,7 @@ if (NOT TARGET dlib)
    toggle_preprocessor_switch(DLIB_PNG_SUPPORT) 
    toggle_preprocessor_switch(DLIB_GIF_SUPPORT) 
    #toggle_preprocessor_switch(DLIB_USE_FFTW)
+   toggle_preprocessor_switch(DLIB_USE_MKL_FFT)
 
 
    set(source_files 
@@ -467,6 +472,13 @@ if (NOT TARGET dlib)
                toggle_preprocessor_switch(DLIB_USE_LAPACK)
             endif()
          endif()
+      endif()
+
+      if (found_intel_mkl)
+         include_directories(${mkl_include_dir})
+      else()
+         set(DLIB_USE_MKL_FFT OFF CACHE STRING ${DLIB_USE_MKL_FFT_STR} FORCE )
+         toggle_preprocessor_switch(DLIB_USE_MKL_FFT)
       endif()
 
 

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -94,7 +94,6 @@ if (UNIX)
         message(STATUS "Found Intel MKL BLAS/LAPACK library")
     endif()
 
-
     if (NOT found_intel_mkl)
         # Search for the needed libraries from the MKL.  This time try looking for a different
         # set of MKL files and try to link against those.
@@ -115,6 +114,14 @@ if (UNIX)
         endif()
     endif()
 
+    # Get mkl_include_dir
+    if (found_intel_mkl)
+        set(mkl_include_search_path
+            /opt/intel/mkl/include
+            /opt/intel/include
+        )
+        find_path(mkl_include_dir mkl_version.h ${mkl_include_search_path})
+    endif()
 
    # try to find some other LAPACK libraries if we didn't find the MKL
    set(extra_paths

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -10,14 +10,18 @@
 #
 #  blas_found        - True if BLAS is available
 #  lapack_found      - True if LAPACK is available
+#  found_intel_mkl   - True is the the Intel MKL library is available
 #  blas_libraries    - link against these to use BLAS library 
 #  lapack_libraries  - link against these to use LAPACK library 
+#  mkl_libraries     - link against these to use the MKL library
+#  mkl_include_dir   - add to the include path to use the MKL library
 
 # setting this makes CMake allow normal looking if else statements
 SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 
 SET(blas_found 0)
 SET(lapack_found 0)
+SET(found_intel_mkl 0)
 
 
 if (UNIX)
@@ -79,13 +83,20 @@ if (UNIX)
 
    include(CheckLibraryExists)
 
+    # Get mkl_include_dir
+    set(mkl_include_search_path
+        /opt/intel/mkl/include
+        /opt/intel/include
+    )
+    find_path(mkl_include_dir mkl_version.h ${mkl_include_search_path})
 
     # Search for the needed libraries from the MKL.  We will try to link against the mkl_rt
     # file first since this way avoids linking bugs in some cases.
     find_library(mkl_rt mkl_rt ${mkl_search_path})
     mark_as_advanced(  mkl_rt )
     # if we found the MKL 
-    if ( mkl_rt)
+    if (mkl_include_dir AND mkl_rt)
+        set(mkl_libraries  ${mkl_rt} )
         set(blas_libraries  ${mkl_rt} )
         set(lapack_libraries  ${mkl_rt} )
         set(blas_found 1)
@@ -104,7 +115,8 @@ if (UNIX)
 
         mark_as_advanced( mkl_intel mkl_core mkl_thread mkl_iomp mkl_pthread)
         # If we found the MKL 
-        if (mkl_intel AND mkl_core AND mkl_thread AND mkl_iomp AND mkl_pthread)
+        if (mkl_include_dir AND mkl_intel AND mkl_core AND mkl_thread AND mkl_iomp AND mkl_pthread)
+            set(mkl_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
             set(blas_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
             set(lapack_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
             set(blas_found 1)
@@ -112,15 +124,6 @@ if (UNIX)
             set(found_intel_mkl 1)
             message(STATUS "Found Intel MKL BLAS/LAPACK library")
         endif()
-    endif()
-
-    # Get mkl_include_dir
-    if (found_intel_mkl)
-        set(mkl_include_search_path
-            /opt/intel/mkl/include
-            /opt/intel/include
-        )
-        find_path(mkl_include_dir mkl_version.h ${mkl_include_search_path})
     endif()
 
    # try to find some other LAPACK libraries if we didn't find the MKL

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -8,13 +8,14 @@
 # attempts to find some other BLAS and LAPACK libraries if you don't have 
 # the Intel MKL.
 #
-#  blas_found        - True if BLAS is available
-#  lapack_found      - True if LAPACK is available
-#  found_intel_mkl   - True is the the Intel MKL library is available
-#  blas_libraries    - link against these to use BLAS library 
-#  lapack_libraries  - link against these to use LAPACK library 
-#  mkl_libraries     - link against these to use the MKL library
-#  mkl_include_dir   - add to the include path to use the MKL library
+#  blas_found               - True if BLAS is available
+#  lapack_found             - True if LAPACK is available
+#  found_intel_mkl          - True if the Intel MKL library is available
+#  found_intel_mkl_headers  - True if Intel MKL headers are available
+#  blas_libraries           - link against these to use BLAS library 
+#  lapack_libraries         - link against these to use LAPACK library 
+#  mkl_libraries            - link against these to use the MKL library
+#  mkl_include_dir          - add to the include path to use the MKL library
 
 # setting this makes CMake allow normal looking if else statements
 SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
@@ -22,6 +23,7 @@ SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 SET(blas_found 0)
 SET(lapack_found 0)
 SET(found_intel_mkl 0)
+SET(found_intel_mkl_headers 0)
 
 
 if (UNIX)
@@ -95,7 +97,7 @@ if (UNIX)
     find_library(mkl_rt mkl_rt ${mkl_search_path})
     mark_as_advanced(  mkl_rt )
     # if we found the MKL 
-    if (mkl_include_dir AND mkl_rt)
+    if ( mkl_rt)
         set(mkl_libraries  ${mkl_rt} )
         set(blas_libraries  ${mkl_rt} )
         set(lapack_libraries  ${mkl_rt} )
@@ -115,7 +117,7 @@ if (UNIX)
 
         mark_as_advanced( mkl_intel mkl_core mkl_thread mkl_iomp mkl_pthread)
         # If we found the MKL 
-        if (mkl_include_dir AND mkl_intel AND mkl_core AND mkl_thread AND mkl_iomp AND mkl_pthread)
+        if (mkl_intel AND mkl_core AND mkl_thread AND mkl_iomp AND mkl_pthread)
             set(mkl_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
             set(blas_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
             set(lapack_libraries ${mkl_intel} ${mkl_core} ${mkl_thread} ${mkl_iomp} ${mkl_pthread})
@@ -124,6 +126,10 @@ if (UNIX)
             set(found_intel_mkl 1)
             message(STATUS "Found Intel MKL BLAS/LAPACK library")
         endif()
+    endif()
+
+    if (found_intel_mkl AND mkl_include_dir)
+        set(found_intel_mkl_headers 1)
     endif()
 
    # try to find some other LAPACK libraries if we didn't find the MKL

--- a/dlib/config.h.in
+++ b/dlib/config.h.in
@@ -23,3 +23,4 @@
 #cmakedefine DLIB_USE_BLAS
 #cmakedefine DLIB_USE_LAPACK
 #cmakedefine DLIB_USE_CUDA
+#cmakedefine DLIB_USE_MKL_FFT


### PR DESCRIPTION
Hi Davis,

I recently added bindings to the MKL DFTI library for FFT computation. I'm not 
sure if you want to add MKL specifics to DLIB, but if you're happy to do so, 
then I hope these will be useful. Using DFTI speeds things up for me when using
the correlation_tracker.

I've tested using the version of MKL that comes with Intel Parallel Studio 2017, 
on Ubuntu 16.04.

Tests all pass when built with either -DDLIB_USE_MKL_FFT=ON or -DDLIB_USE_MKL_FFT=OFF;

    (p) pal181@prodata-ub-ph:build (dunka/master) $ ./dtest --test_fft


    Testing Finished
    Total number of individual testing statements executed: 7732
    All tests completed successfully


Regards,
Duncan Palmer
