### PR TITLE
Fixed issue with uninitialised variables in thread_pool_extension. 

### DIFF
--- a/dlib/statistics/running_gradient.h
+++ b/dlib/statistics/running_gradient.h
@@ -165,7 +165,7 @@ namespace dlib
                     return 0.5;
             }
             value = (value-mean)/stddev;
-            return 0.5 * erfc(-value / std::sqrt(2.0));
+            return 0.5 * std::erfc(-value / std::sqrt(2.0));
         }
 
         double n;

--- a/dlib/threads/thread_pool_extension.cpp
+++ b/dlib/threads/thread_pool_extension.cpp
@@ -189,7 +189,7 @@ namespace dlib
                 task = tasks[idx];
             }
 
-            std::exception_ptr eptr;
+            std::exception_ptr eptr = nullptr;
             try
             {
                 // now do the task

--- a/dlib/threads/thread_pool_extension.h
+++ b/dlib/threads/thread_pool_extension.h
@@ -411,7 +411,7 @@ namespace dlib
 
         struct task_state_type
         {
-            task_state_type() : is_being_processed(false), task_id(0), next_task_id(2), arg1(0), arg2(0) {}
+            task_state_type() : is_being_processed(false), task_id(0), next_task_id(2), arg1(0), arg2(0), eptr(nullptr) {}
 
             bool is_ready () const 
             /*!


### PR DESCRIPTION
Fixed issue with uninitialised variables. There are 2 places where std::exception_ptr eptr is not initialised. One in the CPP and one in the header file of thread_pool_extension.