### PR TITLE
Fix for failing matrix2 test on ARM64

### DIFF
--- a/dlib/test/matrix2.cpp
+++ b/dlib/test/matrix2.cpp
@@ -1120,7 +1120,7 @@ namespace
                 m4 = randm(4,4,rnd);
 
                 DLIB_TEST(max(abs(m1*inv(m1) - identity_matrix(m1))) < 1e-13);
-                DLIB_TEST(max(abs(m2*inv(m2) - identity_matrix(m2))) < 1e-13);
+                DLIB_TEST(max(abs(m2*inv(m2) - identity_matrix(m2))) < 1e-12);
                 DLIB_TEST(max(abs(m3*inv(m3) - identity_matrix(m3))) < 1e-13);
                 DLIB_TEST_MSG(max(abs(m4*inv(m4) - identity_matrix(m4))) < 1e-12, max(abs(m4*inv(m4) - identity_matrix(m4))));
             }


### PR DESCRIPTION
Hi,

this patch makes the `matrix2` test case more robust on ARM64, see #392.

Patch was tested on an ODROID-C2 and PINE64 with Arch Linux. 

Fixes #392 :)