### PR TITLE
add support for loading of RGBA JPEG images

### DIFF
--- a/dlib/image_loader/jpeg_loader.cpp
+++ b/dlib/image_loader/jpeg_loader.cpp
@@ -62,6 +62,13 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    bool jpeg_loader::is_rgba() const
+    {
+        return (output_components_ == 4);
+    }
+
+// ----------------------------------------------------------------------------------------
+
     struct jpeg_loader_error_mgr 
     {
         jpeg_error_mgr pub;    /* "public" fields */
@@ -123,7 +130,8 @@ namespace dlib
         output_components_ = cinfo.output_components;
 
         if (output_components_ != 1 && 
-            output_components_ != 3)
+            output_components_ != 3 &&
+            output_components_ != 4)
         {
             fclose( fp );
             jpeg_destroy_decompress(&cinfo);

--- a/dlib/image_loader/jpeg_loader.h
+++ b/dlib/image_loader/jpeg_loader.h
@@ -23,6 +23,7 @@ namespace dlib
 
         bool is_gray() const;
         bool is_rgb() const;
+        bool is_rgba() const;
 
         template<typename T>
         void get_image( T& t_) const
@@ -37,7 +38,6 @@ namespace dlib
             COMPILE_TIME_ASSERT(sizeof(T) == 0);
 #endif
             image_view<T> t(t_);
-
             t.set_size( height_, width_ );
             for ( unsigned n = 0; n < height_;n++ )
             {
@@ -47,6 +47,14 @@ namespace dlib
                     if ( is_gray() )
                     {
                         unsigned char p = v[m];
+                        assign_pixel( t[n][m], p );
+                    }
+                    else if ( is_rgba() ) {
+                        rgb_alpha_pixel p;
+                        p.red = v[m*4];
+                        p.green = v[m*4+1];
+                        p.blue = v[m*4+2];
+                        p.alpha = v[m*4+3];
                         assign_pixel( t[n][m], p );
                     }
                     else // if ( is_rgb() )


### PR DESCRIPTION
Addresses the issue mentioned in #406 , i.e. dlib reports an error when libjpeg-turbo successfully loads a 4-plane RGBA JPEG image.