### PR TITLE
POWER8 VSX Optimization

### DIFF
--- a/dlib/cmake
+++ b/dlib/cmake
@@ -53,8 +53,9 @@ elseif ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
         (";${powerpc_archs};"      MATCHES ";${CMAKE_SYSTEM_PROCESSOR};"))
     option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
     if(USE_VSX_INSTRUCTIONS)
-            add_definitions(-maltivec)
-            message(STATUS "Enabling VSX instructions")
+    	add_definitions(-maltivec)
+	set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} -latomic) # Fixes undefined references to __atomic_* functions
+        message(STATUS "Enabling VSX instructions")
     endif()
 elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 
     # Use SSE2 by default when using Visual Studio.

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -53,10 +53,7 @@ elseif ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
         (";${powerpc_archs};"      MATCHES ";${CMAKE_SYSTEM_PROCESSOR};"))
     option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
     if(USE_VSX_INSTRUCTIONS)
-	add_definitions(-maltivec) 	
-	if ("Clang" MATCHES ${CMAKE_CXX_COMPILER_ID})
-    		add_definitions(-faltivec) # For support of "vector int expressions"
-	endif()
+	add_definitions(-maltivec -mvsx) 	
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -latomic") # Fixes undefined references to __atomic_* functions
         message(STATUS "Enabling VSX instructions")
     endif()

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -48,9 +48,9 @@ if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
     elseif(USE_SSE2_INSTRUCTIONS)
         add_definitions(-msse2)
         message(STATUS "Enabling SSE2 instructions")
-    if(USE_VSX_INSTRUCTIONS)
-            add_definitions(-maltivec)
-            message(STATUS "Enabling VSX instructions")
+    elseif(USE_VSX_INSTRUCTIONS)
+        add_definitions(-maltivec)
+        message(STATUS "Enabling VSX instructions")
     endif()
 elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 
     # Use SSE2 by default when using Visual Studio.

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -53,8 +53,11 @@ elseif ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
         (";${powerpc_archs};"      MATCHES ";${CMAKE_SYSTEM_PROCESSOR};"))
     option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
     if(USE_VSX_INSTRUCTIONS)
-    	add_definitions(-maltivec)
-	set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} -latomic) # Fixes undefined references to __atomic_* functions
+	add_definitions(-maltivec) 	
+	if ("Clang" MATCHES ${CMAKE_CXX_COMPILER_ID})
+    		add_definitions(-faltivec) # For support of "vector int expressions"
+	endif()
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -latomic") # Fixes undefined references to __atomic_* functions
         message(STATUS "Enabling VSX instructions")
     endif()
 elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -31,14 +31,14 @@ endif()
 
 set(gcc_like_compilers GNU Clang  Intel)
 set(intel_archs x86_64 i386 i686)
+set(powerpc_archs ppc64 ppc64le)
 
-# Setup some options to allow a user to enable SSE and AVX instruction use.  
+# Setup some options to allow a user to enable SSE, AVX and VSX instruction use.
 if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
     (";${intel_archs};"        MATCHES ";${CMAKE_SYSTEM_PROCESSOR};"))
     option(USE_SSE2_INSTRUCTIONS "Compile your program with SSE2 instructions" OFF)
     option(USE_SSE4_INSTRUCTIONS "Compile your program with SSE4 instructions" OFF)
     option(USE_AVX_INSTRUCTIONS  "Compile your program with AVX instructions"  OFF)
-    option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
     if(USE_AVX_INSTRUCTIONS)
         add_definitions(-mavx)
         message(STATUS "Enabling AVX instructions")
@@ -48,9 +48,13 @@ if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
     elseif(USE_SSE2_INSTRUCTIONS)
         add_definitions(-msse2)
         message(STATUS "Enabling SSE2 instructions")
-    elseif(USE_VSX_INSTRUCTIONS)
-        add_definitions(-maltivec)
-        message(STATUS "Enabling VSX instructions")
+    endif()
+elseif ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
+        (";${powerpc_archs};"      MATCHES ";${CMAKE_SYSTEM_PROCESSOR};"))
+    option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
+    if(USE_VSX_INSTRUCTIONS)
+            add_definitions(-maltivec)
+            message(STATUS "Enabling VSX instructions")
     endif()
 elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 
     # Use SSE2 by default when using Visual Studio.

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -38,6 +38,7 @@ if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
     option(USE_SSE2_INSTRUCTIONS "Compile your program with SSE2 instructions" OFF)
     option(USE_SSE4_INSTRUCTIONS "Compile your program with SSE4 instructions" OFF)
     option(USE_AVX_INSTRUCTIONS  "Compile your program with AVX instructions"  OFF)
+    option(USE_VSX_INSTRUCTIONS  "Compile your program with VSX instructions"  OFF)
     if(USE_AVX_INSTRUCTIONS)
         add_definitions(-mavx)
         message(STATUS "Enabling AVX instructions")
@@ -47,6 +48,9 @@ if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};") AND
     elseif(USE_SSE2_INSTRUCTIONS)
         add_definitions(-msse2)
         message(STATUS "Enabling SSE2 instructions")
+    if(USE_VSX_INSTRUCTIONS)
+            add_definitions(-maltivec)
+            message(STATUS "Enabling VSX instructions")
     endif()
 elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 
     # Use SSE2 by default when using Visual Studio.

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -121,7 +121,7 @@ namespace dlib
         inline vector float get_x() const { return x; }
 
         // truncate to 32bit integers
-        inline operator vector int () const { return vec_trunc(x); }
+        inline operator vector int () const { return vec_cts(x,0); }
 
         inline void load_aligned(const type* ptr)  { x = vec_ld(0,ptr); }
         inline void store_aligned(type* ptr) const { vec_st(x,0,ptr); }
@@ -149,21 +149,20 @@ namespace dlib
         typedef float type;
 
         inline simd4f_bool() {}
-        inline simd4f_bool(const vector float &val):x(val) {}
+        inline simd4f_bool(const vector bool int &val):x(val) {}
 
-        inline simd4f_bool& operator=(const vector float &val)
+        inline simd4f_bool& operator=(const vector bool int &val)
         {
             x = val;
             return *this;
         }
 
-        inline operator vector float() const { return x; }
-	inline vector float get_x() const { return x; }
-	inline vector int get_x_trunc() const { return vec_trunc(x) ; }
+        inline operator vector bool int() const { return x; }
+	inline vector bool int get_x() const { return x; }
 
 
     private:
-        vector float x;
+        vector bool int x;
     };
 #else
     class simd4f
@@ -361,7 +360,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_cmpneq_ps(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
-    return vec_xor(vec_cmpeq(lhs.get_x(),rhs.get_x()),(vector int){0,0,0,0});
+        return vec_xor(vec_cmpeq(lhs.get_x(),rhs.get_x()),(vector bool int){0,0,0,0});
 #else
         return simd4f_bool(lhs[0]!=rhs[0],
                            lhs[1]!=rhs[1],
@@ -592,7 +591,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_SSE2)
         return _mm_or_ps(_mm_and_ps(cmp,a) , _mm_andnot_ps(cmp,b));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sel(a.get_x(),b.get_x(),cmp.get_x_trunc());
+        return vec_sel(b.get_x(),a.get_x(),cmp.get_x());
 #else
         return simd4f(cmp[0]?a[0]:b[0],
                       cmp[1]?a[1]:b[1],

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -90,7 +90,7 @@ namespace dlib
         typedef float type;
 
         inline simd4f() {}
-        inline simd4f(float f) { x = (vector float){f,f,f,f}; }
+        inline simd4f(float f) { x = vec_splats(f); }
         inline simd4f(float r0, float r1, float r2, float r3) { x = (vector float){r0,r1,r2,r3} }
         inline simd4f(const vector float &val):x(val) {}
         inline simd4f(const simd4i& val):x(vec_ctf(val.get_x(),0)) {}

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -90,7 +90,7 @@ namespace dlib
         typedef float type;
 
         inline simd4f() {}
-        inline simd4f(float f) { x = vec_splat((vector float){0,0,0,0},f); }
+        inline simd4f(float f) { x = (vector float){f,f,f,f}; }
         inline simd4f(float r0, float r1, float r2, float r3) { x = (vector float){r0,r1,r2,r3} }
         inline simd4f(const vector float &val):x(val) {}
         inline simd4f(const simd4i& val):x(vec_ctf(val.get_x(),0)) {}

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -57,7 +57,7 @@ namespace dlib
         typedef int32 type;
 
         inline simd4i() {}
-        inline simd4i(int32 f) { x = (vector int){f,f,f,f}; }
+        inline simd4i(int32 f) { x = vec_splat_s32(f); }
         inline simd4i(int32 r0, int32 r1, int32 r2, int32 r3)
         {
             x = (vector int){r0,r1,r2,r3};
@@ -92,18 +92,11 @@ namespace dlib
         inline unsigned int size() const { return 4; }
         inline int32 operator[](unsigned int idx) const
         {
-            int32 temp[4];
-            store(temp);
-            return temp[idx];
+            return (int32) vec_extract(x,(signed int)idx);
         }
 
     private:
         vector int x;
-
-        /* Returns amount of bytes till previous 16-byte aligned value  */
-        inline size_t getAlignOffset(const void *p) const {
-            return ((size_t) p) % 16;
-        }
     };
 #else
 

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -57,7 +57,7 @@ namespace dlib
         typedef int32 type;
 
         inline simd4i() {}
-        inline simd4i(int32 f) { x = vec_splat_s32(f); }
+        inline simd4i(int32 f) { x = vec_splats(f); }
         inline simd4i(int32 r0, int32 r1, int32 r2, int32 r3)
         {
             x = (vector int){r0,r1,r2,r3};

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -6,8 +6,8 @@
 #include "simd_check.h"
 #include "../uintn.h"
 
-#ifdef DLIB_HAVE_VSX
-#warning "Undefed DLIB_HAVE_VSX"
+#ifndef DLIB_HAVE_VSX
+#warning "Undefined DLIB_HAVE_VSX"
 #undef DLIB_HAVE_VSX
 #endif
 
@@ -80,13 +80,11 @@ namespace dlib
         inline void load_aligned(const type* ptr)  { x = vec_ld(0,ptr); }
         inline void store_aligned(type* ptr) const { vec_st(x,0,ptr); }
         inline void load(const type* ptr) {
-            const size_t offset = getAlignOffset(ptr);
-            x = vec_ld(offset, ptr - offset);
+            x = vec_vsx_ld(0, ptr);
         }
         inline void store(type* ptr) const
         {
-            const size_t offset = getAlignOffset(ptr);
-            vec_st(x,offset,ptr - offset);
+            vec_vsx_st(x,0,ptr);
         }
 
         inline unsigned int size() const { return 4; }
@@ -287,7 +285,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_xor_si128(lhs, _mm_set1_epi32(0xFFFFFFFF)); 
 #elif defined(DLIB_HAVE_VSX)
-        return vec_xor(lhs.get_x(),(vector int) {0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF});
+        return vec_xor((vector unsigned int)lhs.get_x(),(vector unsigned int) {0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF});
 #else
         return simd4i(~lhs[0],
                       ~lhs[1],
@@ -303,7 +301,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_sll_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sl(lhs.get_x(),(vector int){rhs,rhs,rhs,rhs}});
+        return vec_sl(lhs.get_x(),vec_splats(rhs));
 #else
         return simd4i(lhs[0]<<rhs,
                       lhs[1]<<rhs,
@@ -321,7 +319,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_sra_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sr(lhs.get_x(),(vector int){rhs,rhs,rhs,rhs}});
+        return vec_sr(lhs.get_x(),vec_splats(rhs));
 #else
         return simd4i(lhs[0]>>rhs,
                       lhs[1]>>rhs,
@@ -487,7 +485,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_SSE2)
         return ((cmp&a) | _mm_andnot_si128(cmp,b));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sel(a.get_x(),b_get_x(),cmp.get_x());
+        return vec_sel(a.get_x(),b.get_x(),cmp.get_x());
 #else
         return ((cmp&a) | (~cmp&b));
 #endif

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -63,6 +63,7 @@ namespace dlib
             x = (vector int){r0,r1,r2,r3};
         }
         inline simd4i(const vector int &val):x(val) {}
+        inline simd4i(const vector bool int &val):x((vector int)val) {}
 
         inline simd4i& operator=(const vector int &val)
         {
@@ -213,7 +214,7 @@ namespace dlib
                       _lhs[2]*_rhs[2],
                       _lhs[3]*_rhs[3]);
 #elif defined(DLIB_HAVE_VSX)
-        return vec_mul(lhs.get_x(),rhs.get_x());
+        return vec_cts(vec_mul(vec_ctf(lhs.get_x(),0),vec_ctf(rhs.get_x(),0)),0);
 #else
         return simd4i(lhs[0]*rhs[0],
                       lhs[1]*rhs[1],
@@ -285,7 +286,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_xor_si128(lhs, _mm_set1_epi32(0xFFFFFFFF)); 
 #elif defined(DLIB_HAVE_VSX)
-        return vec_xor((vector unsigned int)lhs.get_x(),(vector unsigned int) {0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF});
+        return (vector int)vec_xor((vector unsigned int)lhs.get_x(),(vector unsigned int) {0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF});
 #else
         return simd4i(~lhs[0],
                       ~lhs[1],
@@ -301,7 +302,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_sll_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sl(lhs.get_x(),vec_splats(rhs));
+        return vec_sl(lhs.get_x(),vec_splat_u32(rhs));
 #else
         return simd4i(lhs[0]<<rhs,
                       lhs[1]<<rhs,
@@ -319,7 +320,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_sra_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sr(lhs.get_x(),vec_splats(rhs));
+        return vec_sr(lhs.get_x(),vec_splat_u32(rhs));
 #else
         return simd4i(lhs[0]>>rhs,
                       lhs[1]>>rhs,
@@ -392,7 +393,7 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return ~(lhs > rhs); 
 #elif defined(DLIB_HAVE_VSX)
-        return vec_cmple(lhs.get_x(),rhs.get_x());
+        return ~(lhs > rhs);
 #else
         return simd4i(lhs[0]<=rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]<=rhs[1] ? 0xFFFFFFFF : 0,
@@ -485,7 +486,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_SSE2)
         return ((cmp&a) | _mm_andnot_si128(cmp,b));
 #elif defined(DLIB_HAVE_VSX)
-        return vec_sel(a.get_x(),b.get_x(),cmp.get_x());
+        return vec_sel(b.get_x(),a.get_x(),(vector unsigned int)cmp.get_x());
 #else
         return ((cmp&a) | (~cmp&b));
 #endif

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -83,7 +83,7 @@
 #endif
 
 #ifdef DLIB_HAVE_VSX
-    #include <simd_vsx.h>
+    #include "simd_vsx.h"
 #endif
 
 #endif // DLIB_SIMd_CHECK_Hh_

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -83,7 +83,7 @@
 #endif
 
 #ifdef DLIB_HAVE_VSX
-    #include <altivec.h> // VSX
+    #include <simd_vsx.h>
 #endif
 
 #endif // DLIB_SIMd_CHECK_Hh_

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -51,7 +51,7 @@
                 #define DLIB_HAVE_AVX2
             #endif
         #endif
-        #ifdef __ALTIVEC__
+        #if defined(__ALTIVEC__) && defined(__VSX__)
             #ifndef DLIB_HAVE_VSX
                 #define DLIB_HAVE_VSX
             #endif

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -51,6 +51,11 @@
                 #define DLIB_HAVE_AVX2
             #endif
         #endif
+        #ifdef __ALTIVEC__
+            #ifndef DLIB_HAVE_VSX
+                #define DLIB_HAVE_VSX
+            #endif
+        #endif
     #endif
 #endif
 
@@ -75,6 +80,10 @@
 #ifdef DLIB_HAVE_AVX2
     #include <immintrin.h> // AVX
 //    #include <avx2intrin.h>
+#endif
+
+#ifdef DLIB_HAVE_VSX
+    #include <altivec.h> // VSX
 #endif
 
 #endif // DLIB_SIMd_CHECK_Hh_

--- a/dlib/simd/simd_vsx.h
+++ b/dlib/simd/simd_vsx.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 /* Returns amount of bytes till previous 16-byte aligned value  */
-inline size_t getAlignOffset(const void *p) const {
+inline size_t vsx_getAlignOffset(const void *p) {
     return ((size_t) p) % 16;
 }
 

--- a/dlib/simd/simd_vsx.h
+++ b/dlib/simd/simd_vsx.h
@@ -1,0 +1,12 @@
+#ifndef DLIB_sIMD_VSX_Hh_
+#define DLIB_sIMD_VSX_Hh_
+
+#include <altivec.h> // VSX
+#include <stdlib.h>
+
+/* Returns amount of bytes till previous 16-byte aligned value  */
+inline size_t getAlignOffset(const void *p) const {
+    return ((size_t) p) & 0x0f;// This is optimised variant of ((size_t) p) % 16
+}
+
+#endif //DLIB_sIMD_VSX_Hh_

--- a/examples/dnn_introduction2_ex.cpp
+++ b/examples/dnn_introduction2_ex.cpp
@@ -105,7 +105,7 @@ template <typename SUBNET> using ares_down = relu<residual_down<block,8,affine,S
 
 // Now that we have these convenient aliases, we can define a residual network
 // without a lot of typing.  Note the use of a repeat layer.  This special layer
-// type allows us to type repeat<9,res<SUBNET>> instead of
+// type allows us to type repeat<9,res,SUBNET> instead of
 // res<res<res<res<res<res<res<res<res<SUBNET>>>>>>>>>.  It will also prevent
 // the compiler from complaining about super deep template nesting when creating
 // large networks.


### PR DESCRIPTION
@davisking 
Resolves #397 
Code can be compiled with gcc or clang in similar to SSE way:
```
cd dlib/test
mkdir build
cd build
cmake ..  -DUSE_VSX_INSTRUCTIONS=1
cmake --build . --config Release
./dtest --runall
```

### Current problems:
- [x] "hash" test fails on either optimized or not optimized version (but for x86 everything is ok). I will fix it.
- [x] I don't know how measure profit of optimisation. Is  there some profiler tool or something else for that purpose in dlib? Any help is appreciated