### PR TITLE
Allow MINGW OpenBLAS usage

### DIFF
--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -26,7 +26,7 @@ SET(found_intel_mkl 0)
 SET(found_intel_mkl_headers 0)
 
 
-if (UNIX)
+if (UNIX OR MINGW)
     message(STATUS "Searching for BLAS and LAPACK")
 
     if (BUILDING_MATLAB_MEX_FILE)


### PR DESCRIPTION
This will allow linking to OpenBLAS when compiling with MinGW.
For example, on my system OpenBLAS is located in d:\lib directory. And compiling this way:
```
cmake .. -G"MinGW Makefiles" -DCMAKE_PREFIX_PATH=d:\lib
```
gives me dlib compiled with OpenBLAS

This PR only modified one line and everything works. Do you prefer moving MINGW into separate if-branch of CMakeLists.txt for clearer code?