### PR TITLE
dets cleared twice in evaluate_detectors of scan_fhog_pyramid.h

### DIFF
--- a/dlib/image_processing/scan_fhog_pyramid.h
+++ b/dlib/image_processing/scan_fhog_pyramid.h
@@ -1306,7 +1306,6 @@ namespace dlib
 
 
         // Do non-max suppression
-        dets.clear();
         if (detectors.size() > 1)
             std::sort(dets_accum.rbegin(), dets_accum.rend());
         for (unsigned long i = 0; i < dets_accum.size(); ++i)


### PR DESCRIPTION
already cleared at the beginning