### PR TITLE
fix unneeded reference for cblas_strsm and cblas_dtrsm when DLIB_USE_…

### DIFF
--- a/dlib/matrix/matrix_trsm.h
+++ b/dlib/matrix/matrix_trsm.h
@@ -9,6 +9,7 @@ namespace dlib
 {
     namespace blas_bindings
     {
+#ifdef DLIB_USE_BLAS
 #ifndef CBLAS_H
         extern "C"
         {
@@ -25,6 +26,7 @@ namespace dlib
                              double *B, const int ldb);
         }
 #endif // if not CBLAS_H
+#endif // if DLIB_USE_BLAS
 
     // ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
fix unneeded reference for cblas_strsm and cblas_dtrsm when DLIB_USE_BLAS is not defined