### PR TITLE
Fix asserts for debug builds in IN_PROJECT_BUILD.

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -29,19 +29,6 @@ cmake_policy(SET CMP0023 OLD)
 
 include(cmake_utils/add_global_compiler_switch.cmake)
 
-
-if (DLIB_IN_PROJECT_BUILD)
-   # Make sure ENABLE_ASSERTS is defined for debug builds, but only for uses
-   # who are building an application.  If they are just building dlib as a
-   # stand alone library then don't set this because it will conflict with the
-   # settings in config.h if we did.
-   if (NOT CMAKE_CXX_FLAGS_DEBUG MATCHES "-DENABLE_ASSERTS")
-      set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DENABLE_ASSERTS" 
-         CACHE STRING "Flags used by the compiler during C++ debug builds." 
-         FORCE)
-   endif()
-endif()
-
 macro (toggle_preprocessor_switch option_name)
    if (${option_name})
       add_global_define(${option_name})

--- a/dlib/cmake
+++ b/dlib/cmake
@@ -97,6 +97,15 @@ endif()
 # created by cmake is always release by default.
 include(${dlib_path}/cmake_utils/release_build_by_default)
 
+# Make sure ENABLE_ASSERTS is defined for debug builds, but only for uses
+# who are building an application.  If they are just building dlib as a
+# stand alone library then don't set this because it will conflict with the
+# settings in config.h if we did.
+if (NOT CMAKE_CXX_FLAGS_DEBUG MATCHES "-DENABLE_ASSERTS")
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DENABLE_ASSERTS"
+            CACHE STRING "Flags used by the compiler during C++ debug builds."
+            FORCE)
+endif()
 
 # Don't add dlib if it's already been added to the cmake project
 if (NOT TARGET dlib)


### PR DESCRIPTION
My project is in trouble because of the way the dlib cmake uses the `ENABLE_ASSERTS` for debug builds for in_project_builds.

My proposal is to move this logic to the. Why is the current approach bad: it doesn't work the first time. The reason is rather complex, but I'll try to explain anyways:

```
if (DLIB_IN_PROJECT_BUILD)
   # Make sure ENABLE_ASSERTS is defined for debug builds, but only for uses
   # who are building an application.  If they are just building dlib as a
   # stand alone library then don't set this because it will conflict with the
   # settings in config.h if we did.
   if (NOT CMAKE_CXX_FLAGS_DEBUG MATCHES "-DENABLE_ASSERTS")
      set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DENABLE_ASSERTS" 
         CACHE STRING "Flags used by the compiler during C++ debug builds." 
         FORCE)
   endif()
endif()
````

is currently in the dlib CMakeLists.txt file. The compiler flags are adjusted properly for the current directory, as this is the way cmake works. So the flag is only added for dlib. Therefor, the parent project (my project, which uses dlib) doesn't have this flag, and therefore, the ENABLE_ASSERTS is only added to dlib files, and not to mine, which causes the inconsistency checked at compile time in the code for the asserts using the magic int.

Now, if you rerun, CMake, it updates the cache, which is somehow shared between the project and dlib. And now my project gets the compiler flag ENABLE_ASSERTS. Weird, I'd say, but this is what happens.

So, to fix this, this block should come in the `dlib/cmake` file, which has to be `INCLUDE()`'d instead of `ADD_SUBDIRECTORY()`'d. Therefore, the flags will apply to the parent project as well.