### PR TITLE
Corrected typo that generated an erroneus Hessian of Brown's function.

### DIFF
--- a/dlib/test/optimization_test_functions.cpp
+++ b/dlib/test/optimization_test_functions.cpp
@@ -378,7 +378,7 @@ namespace dlib
                 h(0,3) = h(0,3) + 8.0E+00 * f1 * f2 * df1dx1 * df2dx4;
 
                 h(1,0) = h(1,0) + 12.0E+00 * pow(f1,2) * df1dx2 * df1dx1 + 4.0E+00 * pow(f2,2) * df1dx2 * df1dx1;
-                h(1,1) = h(1,1) + 12.0E+00 * pow(f1,2) * df1dx2 * df1dx2 + 4.0E+00 * pow(f2,2) * df1dx2 * df1dx1;
+                h(1,1) = h(1,1) + 12.0E+00 * pow(f1,2) * df1dx2 * df1dx2 + 4.0E+00 * pow(f2,2) * df1dx2 * df1dx2;
                 h(1,2) = h(1,2) + 8.0E+00 * f1 * f2 * df1dx2 * df2dx3;
                 h(1,3) = h(1,3) + 8.0E+00 * f1 * f2 * df1dx2 * df2dx4;
 


### PR DESCRIPTION
Hi Davis,

I am currently coding a module for automatic differentation that includes the evaluation of second-order derivatives. While coding and running the module's tests I found out that the module's automatic Hessian of Brown's function wasn't numerically equal to the one you provide in dlib's optimization tests. 

This PR corrects a typo, which generated an erroneus (1,1)-th entry of the Hessian:

```
16 INFO  [0] test.auto_diff_models: brown_hessian(p) = 
[131198 214816 -18521.3 -12455.7] 
[214816 451387 -28454 -18807.9] 
[-18521.3 -28454 49662.9 31984.8] 
[-12455.7 -18807.9 31984.8 27033.6]

16 INFO  [0] test.auto_diff_models: auto_diff_brown_hessian(p) = 
[131198 214816 -18521.3 -12455.7]
[214816 456304 -28454 -18807.9]
[-18521.3 -28454 49662.9 31984.8]
[-12455.7 -18807.9 31984.8 27033.6]]
```

After the correction the Hessian values are numerically equal and `./dtest --test_optimization` complets successfully. I also checked out the results of the correction with generated code of a well known mathematical software. 

Best regards,
Ernesto

