### PR TITLE
Suggesting to fix possible parenthesis issue in elastic net test

### DIFF
--- a/dlib/test/elastic_net.cpp
+++ b/dlib/test/elastic_net.cpp
@@ -109,7 +109,7 @@ namespace
                 results = basic_elastic_net(X, Y, ridge_lambda, lasso_budget*s, eps);
                 results2 = solver(ridge_lambda, lasso_budget*s);
                 dlog << LINFO << "error: "<< max(abs(results - results2));
-                DLIB_TEST(max(abs(results - results2) < 1e-3));
+                DLIB_TEST(max(abs(results - results2)) < 1e-3);
             }
         }
     } a;


### PR DESCRIPTION
Noticed compiler warning `C4800: 'double': forcing value to bool 'true' or 'false' (performance warning)`.

Suggesting to change the test to what perhaps was the original intention.