### PR TITLE
ARM NEON SIMD support

### DIFF
--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -529,6 +529,8 @@ namespace dlib
 #ifdef DLIB_HAVE_SSE2
         return _mm_rsqrt_ps(item);
 #elif defined(DLIB_HAVE_VSX)
+        return vec_rsqrt(item());
+#elif defined(DLIB_HAVE_NEON)
         float32x4_t estimate = vrsqrteq_f32(v);
         simd4f estimate2 = vmulq_f32(estimate, v);
         estimate = vmulq_f32(estimate, vrsqrtsq_f32(estimate2, estimate));

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -192,32 +192,8 @@ namespace dlib
         float32x4_t x;
     };
 
-    class simd4f_bool
-    {
-    public:
-        typedef float type;
 
-        inline simd4f_bool() {}
-        inline simd4f_bool(const uint32x4_t& val):x(val) {}
-        inline simd4f_bool(uint32_t r0,  uint32_t r1, uint32_t r2, uint32_t r3)
-        {
-            uint32_t __attribute__ ((aligned (16))) data[4] = { r0, r1, r2, r3 };
-            x = vld1q_u32(data);
-        }
-
-        inline simd4f_bool& operator=(const uint32x4_t& val)
-        {
-            x = val;
-            return *this;
-        }
-
-        inline operator uint32x4_t() const { return x; }
-
-
-    private:
-        uint32x4_t x;
-    };
-
+    typedef simd4i simd4f_bool;
 #else
     class simd4f
     {
@@ -295,6 +271,7 @@ namespace dlib
         float x[4];
     };
 
+
     class simd4f_bool
     {
     public:
@@ -307,6 +284,7 @@ namespace dlib
     private:
         bool x[4];
     };
+
 #endif
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -198,24 +198,24 @@ namespace dlib
         typedef float type;
 
         inline simd4f_bool() {}
-        inline simd4f_bool(const float32x4_t& val):x(val) {}
-        inline simd4f_bool(float r0, float r1, float r2, float r3)
+        inline simd4f_bool(const uint32x4_t& val):x(val) {}
+        inline simd4f_bool(uint32_t r0,  uint32_t r1, uint32_t r2, uint32_t r3)
         {
-            float __attribute__ ((aligned (16))) data[4] = { r0, r1, r2, r3 };
-            x = vld1q_f32(data);
+            uint32_t __attribute__ ((aligned (16))) data[4] = { r0, r1, r2, r3 };
+            x = vld1q_u32(data);
         }
 
-        inline simd4f_bool& operator=(const float32x4_t& val)
+        inline simd4f_bool& operator=(const uint32x4_t& val)
         {
             x = val;
             return *this;
         }
 
-        inline operator float32x4_t() const { return x; }
+        inline operator uint32x4_t() const { return x; }
 
 
     private:
-        float32x4_t x;
+        uint32x4_t x;
     };
 
 #else
@@ -400,19 +400,19 @@ namespace dlib
                       lhs[3]/rhs[3]);
 #endif
     }
-    inline simd4f& operator/= (simd4f& lhs, const simd4f& rhs) 
+    inline simd4f& operator/= (simd4f& lhs, const simd4f& rhs)
     { lhs = lhs / rhs; return lhs; }
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f_bool operator== (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f_bool operator== (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_cmpeq_ps(lhs, rhs); 
+        return _mm_cmpeq_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmpeq(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return (float32x4_t)vceqq_f32(lhs, rhs);
+        return vceqq_f32(lhs, rhs);
 #else
         return simd4f_bool(lhs[0]==rhs[0],
                            lhs[1]==rhs[1],
@@ -423,14 +423,14 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f_bool operator!= (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f_bool operator!= (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_cmpneq_ps(lhs, rhs); 
+        return _mm_cmpneq_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return ~(lhs==rhs);     // simd4f_bool is simd4i typedef, can use ~
-#elif defined(DLIB_HAVE_NEON)
-        return (float32x4_t)vmvnq_s32((int32x4_t)vceqq_f32(lhs, rhs));
+#elif defined(DLIB_HAVE_NEON1)
+        return vsubq_u32(vdupq_n_u32(0x1), vceqq_f32(lhs, rhs));
 #else
         return simd4f_bool(lhs[0]!=rhs[0],
                            lhs[1]!=rhs[1],
@@ -441,14 +441,14 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f_bool operator< (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f_bool operator< (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_cmplt_ps(lhs, rhs); 
+        return _mm_cmplt_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmplt(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return (float32x4_t)vcltq_f32(lhs, rhs);
+        return vcltq_f32(lhs, rhs);
 #else
         return simd4f_bool(lhs[0]<rhs[0],
                            lhs[1]<rhs[1],
@@ -466,14 +466,14 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f_bool operator<= (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f_bool operator<= (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_cmple_ps(lhs, rhs); 
+        return _mm_cmple_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmple(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return (float32x4_t)vcleq_f32(lhs, rhs);
+        return vcleq_f32(lhs, rhs);
 #else
         return simd4f_bool(lhs[0]<=rhs[0],
                            lhs[1]<=rhs[1],
@@ -484,17 +484,17 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f_bool operator>= (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f_bool operator>= (const simd4f& lhs, const simd4f& rhs)
+    {
         return rhs <= lhs;
     }
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f min (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f min (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_min_ps(lhs, rhs); 
+        return _mm_min_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return vec_min(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
@@ -509,10 +509,10 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f max (const simd4f& lhs, const simd4f& rhs) 
-    { 
+    inline simd4f max (const simd4f& lhs, const simd4f& rhs)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_max_ps(lhs, rhs); 
+        return _mm_max_ps(lhs, rhs);
 #elif defined(DLIB_HAVE_VSX)
         return vec_max(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
@@ -527,13 +527,13 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f reciprocal (const simd4f& item) 
-    { 
+    inline simd4f reciprocal (const simd4f& item)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_rcp_ps(item); 
+        return _mm_rcp_ps(item);
 #elif defined(DLIB_HAVE_VSX)
         return vec_re(item());
-#elif defined(DLIB_HAVE_NEON)
+#elif defined(DLIB_HAVE_NEON1)
         float32x4_t estimate  = vrecpeq_f32(item);
         estimate  = vmulq_f32(vrecpsq_f32(estimate , item), estimate );
         estimate  = vmulq_f32(vrecpsq_f32(estimate , item), estimate );
@@ -548,10 +548,10 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    inline simd4f reciprocal_sqrt (const simd4f& item) 
-    { 
+    inline simd4f reciprocal_sqrt (const simd4f& item)
+    {
 #ifdef DLIB_HAVE_SSE2
-        return _mm_rsqrt_ps(item); 
+        return _mm_rsqrt_ps(item);
 #elif defined(DLIB_HAVE_VSX)
         float32x4_t estimate = vrsqrteq_f32(v);
         simd4f estimate2 = vmulq_f32(estimate, v);
@@ -593,16 +593,11 @@ namespace dlib
     {
 #ifdef DLIB_HAVE_SSE41
         return _mm_cvtss_f32(_mm_dp_ps(lhs, rhs, 0xff));
-#elif defined(DLIB_HAVE_NEON)
-        vec4 prod = vmulq_f32(alhs rhs);
-        vec4 sum1 = vaddq_f32(prod, vrev64q_f32(prod));
-        vec4 sum2 = vaddq_f32(sum1, vcombine_f32(vget_high_f32(sum1), vget_low_f32(sum1)));
-        return sum2;
 #else
         return sum(lhs*rhs);
 #endif
     }
-   
+
 // ----------------------------------------------------------------------------------------
 
     inline simd4f sqrt(const simd4f& item)
@@ -612,8 +607,49 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_sqrt(item());
 #elif defined(DLIB_HAVE_NEON)
-        float32x4_t reciprocal = vrsqrteq_f32(item);
-        return vmulq_f32(item, reciprocal);
+//    float32x4_t sqrt_reciprocal = vrsqrteq_f32(item);
+//    float32x4_t result2 = item * vrsqrtsq_f32(item * sqrt_reciprocal, sqrt_reciprocal) * sqrt_reciprocal;
+
+//        float32x4_t reciprocal1 = vrsqrteq_f32(item);
+//        float32x4_t result = vrecpeq_f32(reciprocal1);
+
+//    simd4f res_slow(std::sqrt(item[0]),
+//                      std::sqrt(item[1]),
+//                      std::sqrt(item[2]),
+//                      std::sqrt(item[3]));
+
+        float32x4_t q_step_0 = vrsqrteq_f32(item);
+        float32x4_t q_step_parm0 = vmulq_f32(item, q_step_0);
+        float32x4_t q_step_result0 = vrsqrtsq_f32(q_step_parm0, q_step_0);
+        float32x4_t q_step_1 = vmulq_f32(q_step_0, q_step_result0);
+        float32x4_t q_step_parm1 = vmulq_f32(item, q_step_1);
+        float32x4_t q_step_result1 = vrsqrtsq_f32(q_step_parm1, q_step_1);
+        float32x4_t q_step_2 = vmulq_f32(q_step_1, q_step_result1);
+        float32x4_t res3 = vmulq_f32(item, q_step_2);
+
+        float32x4_t zero = vdupq_n_f32(0);
+        uint32x4_t zcomp = vceqq_f32(zero, item);
+        float32x4_t rcorr = vbslq_f32(zcomp, zero, res3);
+//    float d = sum(res_slow - result);
+//    if (d)
+//        std::cout << "SQRT(" << item << ") = " << result << " correct: " << res_slow 
+//                  << "res2: " << rcorr
+//                  << "res3: " << q_step_parm0
+
+//        << std::endl;
+return rcorr;
+/*
+        float32x4_t q_step_0 = vrsqrteq_f32(item);
+        float32x4_t q_step_parm0 = vmulq_f32(item, q_step_0);
+        float32x4_t q_step_result0 = vrsqrtsq_f32(q_step_parm0, q_step_0);
+        float32x4_t q_step_1 = vmulq_f32(q_step_0, q_step_result0);
+        float32x4_t q_step_parm1 = vmulq_f32(item, q_step_1);
+        float32x4_t q_step_result1 = vrsqrtsq_f32(q_step_parm1, q_step_1);
+        float32x4_t q_step_2 = vmulq_f32(q_step_1, q_step_result1);
+        return vmulq_f32(item, q_step_2);
+*/
+//return sq;
+//        return vmulq_f32(item, reciprocal);
 #else
         return simd4f(std::sqrt(item[0]),
                       std::sqrt(item[1]),
@@ -684,11 +720,12 @@ namespace dlib
 #elif defined(DLIB_HAVE_SSE2)
         return _mm_or_ps(_mm_and_ps(cmp,a) , _mm_andnot_ps(cmp,b));
 #elif defined(DLIB_HAVE_NEON)
-        return (float32x4_t)vorrq_s32(
-        vandq_s32((int32x4_t)((float32x4_t)cmp),(int32x4_t)((float32x4_t)a)) ,
-        vbicq_s32((int32x4_t)((float32x4_t)b), (int32x4_t)((float32x4_t)cmp)));
+
+//        uint32x4_t cmp_a = vsubq_u32(vdupq_n_u32(0x0), cmp);
+        return vbslq_f32(cmp, a, b);
+
 #else
-        return simd4f(cmp[0]?a[0]:b[0],
+	        return simd4f(cmp[0]?a[0]:b[0],
                       cmp[1]?a[1]:b[1],
                       cmp[2]?a[2]:b[2],
                       cmp[3]?a[3]:b[3]);

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -618,7 +618,7 @@ namespace dlib
 
         // normalize sqrt(0)=0
         uint32x4_t zcomp = vceqq_f32(vdupq_n_f32(0), item);
-        float32x4_t rcorr = vbslq_f32(zcomp, zero, res3);
+        float32x4_t rcorr = vbslq_f32(zcomp, item, res3);
         return rcorr;
 #else
         return simd4f(std::sqrt(item[0]),

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -427,10 +427,8 @@ namespace dlib
     {
 #ifdef DLIB_HAVE_SSE2
         return _mm_cmpneq_ps(lhs, rhs);
-#elif defined(DLIB_HAVE_VSX)
+#elif defined(DLIB_HAVE_VSX) || defined(DLIB_HAVE_NEON)
         return ~(lhs==rhs);     // simd4f_bool is simd4i typedef, can use ~
-#elif defined(DLIB_HAVE_NEON1)
-        return vsubq_u32(vdupq_n_u32(0x1), vceqq_f32(lhs, rhs));
 #else
         return simd4f_bool(lhs[0]!=rhs[0],
                            lhs[1]!=rhs[1],
@@ -533,7 +531,7 @@ namespace dlib
         return _mm_rcp_ps(item);
 #elif defined(DLIB_HAVE_VSX)
         return vec_re(item());
-#elif defined(DLIB_HAVE_NEON1)
+#elif defined(DLIB_HAVE_NEON)
         float32x4_t estimate  = vrecpeq_f32(item);
         estimate  = vmulq_f32(vrecpsq_f32(estimate , item), estimate );
         estimate  = vmulq_f32(vrecpsq_f32(estimate , item), estimate );
@@ -690,11 +688,9 @@ namespace dlib
 #elif defined(DLIB_HAVE_SSE2)
         return _mm_or_ps(_mm_and_ps(cmp,a) , _mm_andnot_ps(cmp,b));
 #elif defined(DLIB_HAVE_NEON)
-        // required cmp to have true_value == -1
         return vbslq_f32(cmp, a, b);
-
 #else
-	        return simd4f(cmp[0]?a[0]:b[0],
+        return simd4f(cmp[0]?a[0]:b[0],
                       cmp[1]?a[1]:b[1],
                       cmp[2]?a[2]:b[2],
                       cmp[3]?a[3]:b[3]);

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -531,8 +531,8 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_rsqrt(item());
 #elif defined(DLIB_HAVE_NEON)
-        float32x4_t estimate = vrsqrteq_f32(v);
-        simd4f estimate2 = vmulq_f32(estimate, v);
+        float32x4_t estimate = vrsqrteq_f32(item);
+        simd4f estimate2 = vmulq_f32(estimate, item);
         estimate = vmulq_f32(estimate, vrsqrtsq_f32(estimate2, estimate));
         return estimate;
 #else

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -452,7 +452,7 @@ namespace dlib
 
     inline simd4i operator<= (const simd4i& lhs, const simd4i& rhs) 
     { 
-#if defined DLIB_HAVE_SSE2
+#ifdef DLIB_HAVE_SSE2
         return ~(lhs > rhs); 
 #elif defined(DLIB_HAVE_NEON)
         return (int32x4_t)vcleq_s32(lhs, rhs);
@@ -530,6 +530,10 @@ namespace dlib
         temp = _mm_hadd_epi32(temp,temp);
         return _mm_cvtsi128_si32(temp);
 #elif defined(DLIB_HAVE_SSE2)
+        int32 temp[4];
+        item.store(temp);
+        return temp[0]+temp[1]+temp[2]+temp[3];
+#elif defined(DLIB_HAVE_NEON)
         int32x2_t r = vadd_s32(vget_high_s32(item), vget_low_s32(item));
         return vget_lane_s32(vpadd_s32(r, r), 0);
 #else

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -453,8 +453,8 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     inline simd4i operator<= (const simd4i& lhs, const simd4i& rhs) 
-    { //todo: VSX ?
-#ifdef DLIB_HAVE_SSE2 || defined(DLIB_HAVE_NEON)
+    { 
+#if defined DLIB_HAVE_SSE2 || defined(DLIB_HAVE_NEON)
         return ~(lhs > rhs); 
 #else
         return simd4i(lhs[0]<=rhs[0] ? 0xFFFFFFFF : 0,

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -54,9 +54,9 @@ namespace dlib
             vector bool int b;
             signed int x[4];
         } v4i;
-        
+
         v4i x;
-        
+
     public:
         inline simd4i() : x{0,0,0,0} { }
         inline simd4i(const simd4i& v) : x(v.x) { }
@@ -81,13 +81,54 @@ namespace dlib
         inline void load(const int32* ptr) { x.v = vec_vsx_ld(0, ptr); }
         inline void store(int32* ptr) const { vec_vsx_st(x.v, 0, ptr); }
         
-        
+
         struct rawarray
         {
             v4i v;
         };
         inline simd4i(const rawarray& a) : x{a.v} { }
- 
+
+    };
+
+#elif defined(DLIB_HAVE_NEON)
+
+    class simd4i
+    {
+    public:
+        typedef int32 type;
+
+        inline simd4i() {}
+        inline simd4i(int32 f) { x = vdupq_n_s32(f); }
+        inline simd4i(int32 r0, int32 r1, int32 r2, int32 r3)
+        {
+            int32 __attribute__((aligned(16))) data[4] = { r0, r1, r2, r3 };
+            x = vld1q_s32(data);
+        }
+        inline simd4i(const int32x4_t& val):x(val) {}
+
+        inline simd4i& operator=(const int32x4_t& val)
+        {
+            x = val;
+            return *this;
+        }
+
+        inline operator int32x4_t() const { return x; }
+
+        inline void load_aligned(const type* ptr)  { x = vld1q_s32(ptr); }
+        inline void store_aligned(type* ptr) const { vst1q_s32(ptr, x); }
+        inline void load(const type* ptr)          { x = vld1q_s32(ptr); }
+        inline void store(type* ptr)         const { vst1q_s32(ptr, x); }
+
+        inline unsigned int size() const { return 4; }
+        inline int32 operator[](unsigned int idx) const
+        {
+            int32 temp[4];
+            store(temp);
+            return temp[idx];
+        }
+
+    private:
+        int32x4_t x;
     };
 
 #else
@@ -165,6 +206,8 @@ namespace dlib
         return _mm_add_epi32(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_add(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vaddq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]+rhs[0],
                       lhs[1]+rhs[1],
@@ -183,6 +226,8 @@ namespace dlib
         return _mm_sub_epi32(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_sub(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vsubq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]-rhs[0],
                       lhs[1]-rhs[1],
@@ -210,6 +255,8 @@ namespace dlib
         vector int a = lhs(), b = rhs();
         asm("vmuluwm %0, %0, %1\n\t" : "+&v" (a) : "v" (b) );
         return simd4i(a);
+#elif defined(DLIB_HAVE_NEON)
+        return vmulq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]*rhs[0],
                       lhs[1]*rhs[1],
@@ -228,6 +275,8 @@ namespace dlib
         return _mm_and_si128(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_and(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vandq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]&rhs[0],
                       lhs[1]&rhs[1],
@@ -246,6 +295,8 @@ namespace dlib
         return _mm_or_si128(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_or(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vorrq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]|rhs[0],
                       lhs[1]|rhs[1],
@@ -264,6 +315,8 @@ namespace dlib
         return _mm_xor_si128(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_xor(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return veorq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]^rhs[0],
                       lhs[1]^rhs[1],
@@ -282,6 +335,8 @@ namespace dlib
         return _mm_xor_si128(lhs, _mm_set1_epi32(0xFFFFFFFF)); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_xor(lhs(), vec_splats(~0));
+#elif defined(DLIB_HAVE_NEON)
+        return veorq_s32(lhs, vdupq_n_s32(0xFFFFFFFF));
 #else
         return simd4i(~lhs[0],
                       ~lhs[1],
@@ -298,6 +353,12 @@ namespace dlib
         return _mm_sll_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
         return vec_sl(lhs(), vec_splats((uint32_t)rhs));         
+#elif defined(DLIB_HAVE_NEON)//todo: NEON
+        int32 _lhs[4]; lhs.store(_lhs);
+        return simd4i(_lhs[0]<<rhs,
+                      _lhs[1]<<rhs,
+                      _lhs[2]<<rhs,
+                      _lhs[3]<<rhs);
 #else
         return simd4i(lhs[0]<<rhs,
                       lhs[1]<<rhs,
@@ -316,6 +377,12 @@ namespace dlib
         return _mm_sra_epi32(lhs,_mm_cvtsi32_si128(rhs));
 #elif defined(DLIB_HAVE_VSX)
         return vec_sr(lhs(), vec_splats((uint32_t)rhs)); 
+#elif defined(DLIB_HAVE_NEON)//todo: NEON
+        int32 _lhs[4]; lhs.store(_lhs);
+        return simd4i(_lhs[0]>>rhs,
+                      _lhs[1]>>rhs,
+                      _lhs[2]>>rhs,
+                      _lhs[3]>>rhs);
 #else
         return simd4i(lhs[0]>>rhs,
                       lhs[1]>>rhs,
@@ -334,6 +401,8 @@ namespace dlib
         return _mm_cmpeq_epi32(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmpeq(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return (int32x4_t)vceqq_s32(lhs,rhs);
 #else
         return simd4i(lhs[0]==rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]==rhs[1] ? 0xFFFFFFFF : 0,
@@ -346,7 +415,7 @@ namespace dlib
 
     inline simd4i operator!= (const simd4i& lhs, const simd4i& rhs) 
     { 
-#if defined(DLIB_HAVE_SSE2) || defined(DLIB_HAVE_VSX)
+#if defined(DLIB_HAVE_SSE2) || defined(DLIB_HAVE_VSX) || defined(DLIB_HAVE_NEON)
         return ~(lhs==rhs);
 #else
         return simd4i(lhs[0]!=rhs[0] ? 0xFFFFFFFF : 0,
@@ -364,6 +433,8 @@ namespace dlib
         return _mm_cmplt_epi32(lhs, rhs); 
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmplt(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return (int32x4_t)vcltq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]<rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]<rhs[1] ? 0xFFFFFFFF : 0,
@@ -382,8 +453,8 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     inline simd4i operator<= (const simd4i& lhs, const simd4i& rhs) 
-    { 
-#ifdef DLIB_HAVE_SSE2
+    { //todo: VSX ?
+#ifdef DLIB_HAVE_SSE2 || defined(DLIB_HAVE_NEON)
         return ~(lhs > rhs); 
 #else
         return simd4i(lhs[0]<=rhs[0] ? 0xFFFFFFFF : 0,
@@ -415,6 +486,8 @@ namespace dlib
                       std::min(_lhs[3],_rhs[3]));
 #elif defined(DLIB_HAVE_VSX)
         return vec_min(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vminq_s32(lhs, rhs);
 #else
         return simd4i(std::min(lhs[0],rhs[0]),
                       std::min(lhs[1],rhs[1]),
@@ -438,6 +511,8 @@ namespace dlib
                       std::max(_lhs[3],_rhs[3]));
 #elif defined(DLIB_HAVE_VSX)
         return vec_max(lhs(), rhs());
+#elif defined(DLIB_HAVE_NEON)
+        return vmaxq_s32(lhs, rhs);
 #else
         return simd4i(std::max(lhs[0],rhs[0]),
                       std::max(lhs[1],rhs[1]),
@@ -458,6 +533,7 @@ namespace dlib
         int32 temp[4];
         item.store(temp);
         return temp[0]+temp[1]+temp[2]+temp[3];
+        //todo: NEON
 #else
         return item[0]+item[1]+item[2]+item[3];
 #endif
@@ -474,7 +550,7 @@ namespace dlib
         return ((cmp&a) | _mm_andnot_si128(cmp,b));
 #elif defined(DLIB_HAVE_VSX)
         return vec_sel(b(), a(), cmp.to_bool());
-#else
+#else//todo: NEON
         return ((cmp&a) | (~cmp&b));
 #endif
     }

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -105,6 +105,7 @@ namespace dlib
             x = vld1q_s32(data);
         }
         inline simd4i(const int32x4_t& val):x(val) {}
+        inline simd4i(const uint32x4_t& val):x((int32x4_t)val) {}
 
         inline simd4i& operator=(const int32x4_t& val)
         {
@@ -113,6 +114,7 @@ namespace dlib
         }
 
         inline operator int32x4_t() const { return x; }
+        inline operator uint32x4_t() const { return (uint32x4_t)x; }
 
         inline void load_aligned(const type* ptr)  { x = vld1q_s32(ptr); }
         inline void store_aligned(type* ptr) const { vst1q_s32(ptr, x); }
@@ -374,7 +376,11 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_sr(lhs(), vec_splats((uint32_t)rhs)); 
 #elif defined(DLIB_HAVE_NEON)
-        return vshrq_s32(lhs, simd4i(rhs));
+        int32 _lhs[4]; lhs.store(_lhs);
+        return simd4i(_lhs[0]>>rhs,
+                      _lhs[1]>>rhs,
+                      _lhs[2]>>rhs,
+                      _lhs[3]>>rhs);
 #else
         return simd4i(lhs[0]>>rhs,
                       lhs[1]>>rhs,
@@ -394,7 +400,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmpeq(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return vceqq_s32(lhs,rhs);
+        return (int32x4_t)vceqq_s32(lhs,rhs);
 #else
         return simd4i(lhs[0]==rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]==rhs[1] ? 0xFFFFFFFF : 0,
@@ -426,7 +432,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_cmplt(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return vcltq_s32(lhs, rhs);
+        return (int32x4_t)vcltq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]<rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]<rhs[1] ? 0xFFFFFFFF : 0,
@@ -449,7 +455,7 @@ namespace dlib
 #if defined DLIB_HAVE_SSE2
         return ~(lhs > rhs); 
 #elif defined(DLIB_HAVE_NEON)
-        return vcleq_s32(lhs, rhs);
+        return (int32x4_t)vcleq_s32(lhs, rhs);
 #else
         return simd4i(lhs[0]<=rhs[0] ? 0xFFFFFFFF : 0,
                       lhs[1]<=rhs[1] ? 0xFFFFFFFF : 0,
@@ -481,7 +487,7 @@ namespace dlib
 #elif defined(DLIB_HAVE_VSX)
         return vec_min(lhs(), rhs());
 #elif defined(DLIB_HAVE_NEON)
-        return vminq_s32(lhs, rhs);
+        return (int32x4_t)vminq_s32(lhs, rhs);
 #else
         return simd4i(std::min(lhs[0],rhs[0]),
                       std::min(lhs[1],rhs[1]),

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -66,7 +66,11 @@
                 #define DLIB_HAVE_POWER_VEC
             #endif
         #endif
-
+        #ifdef __ARM_NEON
+            #ifndef DLIB_HAVE_NEON
+                #define DLIB_HAVE_NEON
+            #endif
+        #endif
     #endif
 #endif
 
@@ -97,7 +101,9 @@
     #include <immintrin.h> // AVX
 //    #include <avx2intrin.h>
 #endif
-
+#ifdef DLIB_HAVE_NEON
+    #include <arm_neon.h> // ARM NEON
+#endif
 
 
 #endif // DLIB_SIMd_CHECK_Hh_


### PR DESCRIPTION
This PR adds SIMD instructions support for ARM/NEON processors
Tested with Nvidia Tegra TK1. All face detection, some SVM and correlation tracker functions now will run faster on ARMs. My performance measurements are in #557. 

All code tested with dtest --runall on TK1 and rechecked on Windows machine with MinGW 6.2 in AVX and SSE2 modes.

NEON is not enabled by default in G++ compiler on ARM platfortm. To enable it, pass "-mfpu=neon" flag to compiler

`cmake .. -DCMAKE_CXX_FLAGS="-mfpu=neon"`
