### PR TITLE
Appveyor for Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ build_script:
   - mkdir %APPVEYOR_BUILD_FOLDER%\build_test
   - cd %APPVEYOR_BUILD_FOLDER%\build_test
   - cmake -G "Visual Studio 14 2015 Win64" ../dlib/test
-  - cmake --build . --config %CONFIGURATION% --target dtest -- /m
+  - cmake --build . --config %CONFIGURATION% --target dtest -- /m /verbosity:minimal
   # build examples
   - mkdir %APPVEYOR_BUILD_FOLDER%\build_examples
   - cd %APPVEYOR_BUILD_FOLDER%\build_examples
   - cmake -G "Visual Studio 14 2015 Win64" ../examples
-  - cmake --build . --config %CONFIGURATION% -- /m
+  - cmake --build . --config %CONFIGURATION% -- /m /verbosity:minimal
 
 test_script:
   # run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: "{build}"
+
+configuration: Release
+
+build_script:
+  # build test
+  - mkdir %APPVEYOR_BUILD_FOLDER%\build_test
+  - cd %APPVEYOR_BUILD_FOLDER%\build_test
+  - cmake -G "Visual Studio 14 2015 Win64" ../dlib/test
+  - cmake --build . --config %CONFIGURATION% --target dtest -- /m
+  # build examples
+  - mkdir %APPVEYOR_BUILD_FOLDER%\build_examples
+  - cd %APPVEYOR_BUILD_FOLDER%\build_examples
+  - cmake -G "Visual Studio 14 2015 Win64" ../examples
+  - cmake --build . --config %CONFIGURATION% -- /m
+
+test_script:
+  # run test
+  - cd %APPVEYOR_BUILD_FOLDER%\build_test\%CONFIGURATION%
+  - dtest --runall


### PR DESCRIPTION
I've created a simple AppVeyor config for building the test and examples on Windows. The test is actually run, although I find them a little bit unstable - they sometimes fail.. e.g: https://ci.appveyor.com/project/andyli/dlib/build/5

Anyway, that can be improved separately later by e.g. having a fixed random seed.

Before merging this, please head to https://ci.appveyor.com, add this repo as a project.
You probably want to enable "Skip branches without appveyor.yml" in project setting.