### PR TITLE
Replace shared_ptr_thread_safe with std::shared_ptr

### DIFF
--- a/dlib/gui_core/gui_core_kernel_1.cpp
+++ b/dlib/gui_core/gui_core_kernel_1.cpp
@@ -17,16 +17,17 @@
 #pragma comment (lib, "imm32.lib")
 #endif
 
-
+#include <cmath>
+#include <memory>
 #include <sstream>
+#include <vector>
+
 #include "../threads.h"
 #include "../assert.h"
 #include "../queue.h"
 #include "../sync_extension.h"
 #include "../queue.h"
 #include "../logger.h"
-#include <cmath>
-#include <vector>
 
 namespace dlib
 {
@@ -63,9 +64,9 @@ namespace dlib
 
     // ----------------------------------------------------------------------------------------
 
-        const shared_ptr_thread_safe<dlib::mutex>& global_mutex()
+        const std::shared_ptr<dlib::mutex>& global_mutex()
         {
-            static shared_ptr_thread_safe<dlib::mutex> m(new dlib::mutex);
+            static std::shared_ptr<dlib::mutex> m(new dlib::mutex);
             return m;
         }
 
@@ -118,7 +119,7 @@ namespace dlib
             // processing.
             thread_id_type event_thread_id;
 
-            shared_ptr_thread_safe<dlib::mutex> reference_to_global_mutex;
+            std::shared_ptr<dlib::mutex> reference_to_global_mutex;
 
             event_handler_thread(
             ) :
@@ -288,10 +289,10 @@ namespace dlib
         struct call_global_mutex { call_global_mutex() { global_mutex(); } };
         static call_global_mutex call_global_mutex_instance;
 
-        const shared_ptr_thread_safe<event_handler_thread>& global_data()
+        const std::shared_ptr<event_handler_thread>& global_data()
         {
             auto_mutex M(*global_mutex());
-            static shared_ptr_thread_safe<event_handler_thread> p;
+            static std::shared_ptr<event_handler_thread> p;
             if (p.get() == 0)
             {
                 p.reset(new event_handler_thread());
@@ -671,7 +672,7 @@ namespace dlib
             SetThreadPriority(hand,THREAD_PRIORITY_ABOVE_NORMAL);
             CloseHandle(hand);
 
-            shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+            std::shared_ptr<event_handler_thread> globals(global_data());
 
             window_table_type& window_table = globals->window_table;
             HWND& helper_window = globals->helper_window;
@@ -1465,7 +1466,7 @@ namespace dlib
         !*/
         {   
             using namespace gui_core_kernel_1_globals;
-            shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+            std::shared_ptr<event_handler_thread> globals(global_data());
             // if we are running in the event handling thread then just call
             // CreateWindow directly
             if (get_thread_id() == globals->event_thread_id)
@@ -2071,7 +2072,7 @@ namespace dlib
         using namespace gui_core_kernel_1_globals;
         using namespace std;
 
-        shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+        std::shared_ptr<event_handler_thread> globals(global_data());
 
         if (OpenClipboard(globals->helper_window))
         {
@@ -2138,7 +2139,7 @@ namespace dlib
     {
         using namespace gui_core_kernel_1_globals;
         using namespace std;
-        shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+        std::shared_ptr<event_handler_thread> globals(global_data());
 
         auto_mutex M(globals->window_table.get_mutex());
         if (OpenClipboard(globals->helper_window))

--- a/dlib/gui_core/gui_core_kernel_1.h
+++ b/dlib/gui_core/gui_core_kernel_1.h
@@ -11,7 +11,9 @@
 #error "DLIB_NO_GUI_SUPPORT is defined so you can't use the GUI code.  Turn DLIB_NO_GUI_SUPPORT off if you want to use it."
 #endif
 
+#include <memory>
 #include <string>
+
 #include "../windows_magic.h"
 
 
@@ -39,8 +41,6 @@
 #include "../queue.h"
 #include "../pixel.h"
 #include "../unicode.h"
-#include "../smart_pointers_thread_safe.h"
-
 
 namespace dlib
 {
@@ -169,7 +169,7 @@ namespace dlib
     class base_window
     {
         friend LRESULT CALLBACK gui_core_kernel_1_globals::WndProc (HWND, UINT, WPARAM, LPARAM);
-        shared_ptr_thread_safe<gui_core_kernel_1_globals::event_handler_thread> globals;
+        std::shared_ptr<gui_core_kernel_1_globals::event_handler_thread> globals;
 
         HWND hwnd;
         DWORD style;

--- a/dlib/gui_core/gui_core_kernel_2.cpp
+++ b/dlib/gui_core/gui_core_kernel_2.cpp
@@ -8,24 +8,25 @@
 
 #include "gui_core_kernel_2.h"
 
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <vector>
+#include <set>
 
+#include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <X11/Xlocale.h>
 #include <X11/XKBlib.h>
+
 #include <poll.h>
-#include <iostream>
+
 #include "../assert.h"
 #include "../queue.h"
-#include <cstring>
-#include <cmath>
-#include <X11/Xatom.h>
 #include "../sync_extension.h"
 #include "../logger.h"
-#include <vector>
-#include <set>
-#include "../smart_pointers_thread_safe.h"
 
 namespace dlib
 {
@@ -49,9 +50,9 @@ namespace dlib
 
     // ----------------------------------------------------------------------------------------
 
-        const shared_ptr_thread_safe<dlib::mutex>& global_mutex()
+        const std::shared_ptr<dlib::mutex>& global_mutex()
         {
-            static shared_ptr_thread_safe<dlib::mutex> m(new dlib::mutex);
+            static std::shared_ptr<dlib::mutex> m(new dlib::mutex);
             return m;
         }
 
@@ -95,7 +96,7 @@ namespace dlib
             queue_of_user_events user_events;
             queue_of_user_events user_events_temp;
 
-            shared_ptr_thread_safe<dlib::mutex> reference_to_global_mutex;
+            std::shared_ptr<dlib::mutex> reference_to_global_mutex;
 
             event_handler_thread(
             ) :
@@ -315,7 +316,7 @@ namespace dlib
             Time last_click_time;
             XIC xic;
             XFontSet fs;
-            shared_ptr_thread_safe<event_handler_thread> globals;
+            std::shared_ptr<event_handler_thread> globals;
         };
 
         // Do all this just to make sure global_mutex() is initialized at program start
@@ -324,10 +325,10 @@ namespace dlib
         struct call_global_mutex { call_global_mutex() { global_mutex(); } };
         static call_global_mutex call_global_mutex_instance;
 
-        const shared_ptr_thread_safe<event_handler_thread>& global_data()
+        const std::shared_ptr<event_handler_thread>& global_data()
         {
             auto_mutex M(*global_mutex());
-            static shared_ptr_thread_safe<event_handler_thread> p;
+            static std::shared_ptr<event_handler_thread> p;
             if (p.get() == 0)
                 p.reset(new event_handler_thread());
             return p;
@@ -1356,7 +1357,7 @@ namespace dlib
     {
         using namespace gui_core_kernel_2_globals;
 
-        shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+        std::shared_ptr<event_handler_thread> globals(global_data());
 
         auto_mutex M(globals->window_table.get_mutex());
         globals->clipboard = str.c_str();
@@ -1405,7 +1406,7 @@ namespace dlib
     )
     {
         using namespace gui_core_kernel_2_globals;
-        shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+        std::shared_ptr<event_handler_thread> globals(global_data());
 
         auto_mutex M(globals->window_table.get_mutex());
         str.clear();
@@ -1495,7 +1496,7 @@ namespace dlib
             void*
         )
         {
-            shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+            std::shared_ptr<event_handler_thread> globals(global_data());
             auto_mutex M(globals->window_table.get_mutex());
 
             globals->user_events.lock();
@@ -1536,7 +1537,7 @@ namespace dlib
         e.p = p;
         e.i = i;
         {
-            shared_ptr_thread_safe<event_handler_thread> globals(global_data());
+            std::shared_ptr<event_handler_thread> globals(global_data());
             auto_mutex M(globals->user_events.get_mutex());
             globals->user_events.enqueue(e);
 

--- a/dlib/gui_widgets/base_widgets.cpp
+++ b/dlib/gui_widgets/base_widgets.cpp
@@ -3,10 +3,11 @@
 #ifndef DLIB_BASE_WIDGETs_CPP_
 #define DLIB_BASE_WIDGETs_CPP_
 
+#include <iostream>
+#include <memory>
+
 #include "base_widgets.h"
 #include "../assert.h"
-#include <iostream>
-
 
 namespace dlib
 {
@@ -133,7 +134,7 @@ namespace dlib
 
     void button::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);

--- a/dlib/gui_widgets/base_widgets.h
+++ b/dlib/gui_widgets/base_widgets.h
@@ -4,6 +4,8 @@
 #ifndef DLIB_BASE_WIDGETs_
 #define DLIB_BASE_WIDGETs_
 
+#include <memory>
+
 #include "base_widgets_abstract.h"
 #include "drawable.h"
 #include "../gui_core.h"
@@ -586,7 +588,7 @@ namespace dlib
         class tooltip_window : public base_window 
         {
         public:
-            tooltip_window (const shared_ptr_thread_safe<font>& f) : base_window(false,true), pad(3), mfont(f)
+            tooltip_window (const std::shared_ptr<font>& f) : base_window(false,true), pad(3), mfont(f)
             {
             }
 
@@ -594,7 +596,7 @@ namespace dlib
             rectangle rect_all;
             rectangle rect_text;
             const unsigned long pad;
-            const shared_ptr_thread_safe<font> mfont;
+            const std::shared_ptr<font> mfont;
             
             void set_text (
                 const std::string& str
@@ -777,7 +779,7 @@ namespace dlib
         ) const;
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         void show (
@@ -1623,7 +1625,7 @@ namespace dlib
 
     private:
         dlib::ustring text;
-        const shared_ptr_thread_safe<font> f;
+        const std::shared_ptr<font> f;
         any_function<void()> action;
         unichar hotkey;
         point underline_p1;
@@ -1801,7 +1803,7 @@ namespace dlib
 
     private:
         dlib::ustring text;
-        const shared_ptr_thread_safe<font> f;
+        const std::shared_ptr<font> f;
         any_function<void()> action;
         unichar hotkey;
         point underline_p1;

--- a/dlib/gui_widgets/drawable.h
+++ b/dlib/gui_widgets/drawable.h
@@ -4,6 +4,8 @@
 #ifndef DLIB_DRAWABLe_
 #define DLIB_DRAWABLe_
 
+#include <memory>
+
 #include "drawable_abstract.h"
 #include "../gui_core.h"
 #include "../set.h"
@@ -344,7 +346,7 @@ namespace dlib
         }
 
         virtual void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         )
         {
             auto_mutex M(m);
@@ -352,7 +354,7 @@ namespace dlib
             parent.invalidate_rectangle(rect);
         }
 
-        const shared_ptr_thread_safe<font> main_font (
+        const std::shared_ptr<font> main_font (
         ) const
         {
             auto_mutex M(m);
@@ -420,7 +422,7 @@ namespace dlib
         bool enabled;
         const long& lastx;
         const long& lasty;
-        shared_ptr_thread_safe<font> mfont;
+        std::shared_ptr<font> mfont;
 
         
         void enable_events (

--- a/dlib/gui_widgets/fonts.cpp
+++ b/dlib/gui_widgets/fonts.cpp
@@ -5,11 +5,13 @@
 
 #include "fonts.h"
 
-#include "../serialize.h"
+#include <fstream>
+#include <memory>
 #include <sstream>
+
+#include "../serialize.h"
 #include "../base64.h"
 #include "../compress_stream.h"
-#include <fstream>
 #include "../tokenizer.h"
 #include "nativefont.h"
    
@@ -657,7 +659,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    const shared_ptr_thread_safe<font> get_native_font (
+    const std::shared_ptr<font> get_native_font (
     )
     {
         return nativefont::native_font::get_font();

--- a/dlib/gui_widgets/fonts.h
+++ b/dlib/gui_widgets/fonts.h
@@ -4,16 +4,17 @@
 #ifndef DLIB_FONTs_
 #define DLIB_FONTs_
 
+#include <memory>
+#include <string>
+
 #include "fonts_abstract.h"
 #include "../gui_core.h"
-#include <string>
 #include "../algs.h"
 #include "../serialize.h"
 #include "../unicode.h"
 #include "../array.h"
 #include "../array2d.h"
 #include "../threads.h"
-#include "../smart_pointers_thread_safe.h"
 
 namespace dlib
 {
@@ -483,7 +484,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    const shared_ptr_thread_safe<font> get_native_font ();
+    const std::shared_ptr<font> get_native_font ();
 
 // ----------------------------------------------------------------------------------------
 
@@ -500,11 +501,11 @@ namespace dlib
 
 
     public:
-        static const shared_ptr_thread_safe<font>& get_font (
+        static const std::shared_ptr<font>& get_font (
         )
         {        
             static mutex m;
-            static shared_ptr_thread_safe<font> f;
+            static std::shared_ptr<font> f;
             auto_mutex M(m);
             if (f.get() == 0)
                 f.reset(new default_font);

--- a/dlib/gui_widgets/nativefont.h
+++ b/dlib/gui_widgets/nativefont.h
@@ -7,10 +7,10 @@
 
 #include "../gui_widgets.h"
 #include "../unicode.h"
-#include "../smart_pointers_thread_safe.h"
 #include "../uintn.h"
 
 #include <map>
+#include <memory>
 
 #include <stdio.h>
 #include <string.h>
@@ -546,10 +546,10 @@ namespace nativefont
             return (*this)[ch].width() > 0;
         }
 
-        static const dlib::shared_ptr_thread_safe<font>& get_font (
+        static const std::shared_ptr<font>& get_font (
         )
         {
-            static dlib::shared_ptr_thread_safe<font> f(new native_font);
+            static std::shared_ptr<font> f(new native_font);
             return f;
         }
 

--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -3,8 +3,10 @@
 #ifndef DLIB_WIDGETs_CPP_
 #define DLIB_WIDGETs_CPP_
 
-#include "widgets.h"
 #include <algorithm>
+#include <memory>
+
+#include "widgets.h"
 #include "../string.h"
 
 namespace dlib
@@ -160,7 +162,7 @@ namespace dlib
 
     void toggle_button::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -309,7 +311,7 @@ namespace dlib
 
     void label::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -638,7 +640,7 @@ namespace dlib
 
     void text_field::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -1745,7 +1747,7 @@ namespace dlib
 
     void tabbed_display::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -1887,7 +1889,7 @@ namespace dlib
 
     void named_rectangle::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -2065,7 +2067,7 @@ namespace dlib
 
     void mouse_tracker::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -2270,7 +2272,7 @@ namespace dlib
     template <typename S>
     void list_box<S>::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -3300,7 +3302,7 @@ namespace dlib
 
     void menu_bar::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);
@@ -4916,7 +4918,7 @@ namespace dlib
 
     void text_box::
     set_main_font (
-        const shared_ptr_thread_safe<font>& f
+        const std::shared_ptr<font>& f
     )
     {
         auto_mutex M(m);

--- a/dlib/gui_widgets/widgets.h
+++ b/dlib/gui_widgets/widgets.h
@@ -4,13 +4,18 @@
 #ifndef DLIB_WIDGETs_
 #define DLIB_WIDGETs_
 
+#include <cctype>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "../algs.h"
 #include "widgets_abstract.h"
 #include "drawable.h"
 #include "../gui_core.h"
 #include "fonts.h"
-#include <string>
-#include <sstream>
 #include "../timer.h"
 #include "base_widgets.h"
 #include "../member_function_pointer.h"
@@ -23,10 +28,7 @@
 #include "style.h"
 #include "../string.h"
 #include "../misc_api.h"
-#include <cctype>
-#include <vector>
 #include "../any.h"
-#include <set>
 #include "../image_processing/full_object_detection.h"
 
 #ifdef _MSC_VER
@@ -93,7 +95,7 @@ namespace dlib
         ) const;
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
     private:
@@ -213,7 +215,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         void set_pos (
@@ -478,7 +480,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         int next_free_user_event_number (
@@ -866,7 +868,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         int next_free_user_event_number (
@@ -1262,7 +1264,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         void fit_to_contents (
@@ -1381,7 +1383,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
     protected:
@@ -1440,7 +1442,7 @@ namespace dlib
         );
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
     protected:
@@ -1795,7 +1797,7 @@ namespace dlib
         ) const;
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
     private:
@@ -2041,7 +2043,7 @@ namespace dlib
         void set_pos(long,long){}
 
         void set_main_font (
-            const shared_ptr_thread_safe<font>& f
+            const std::shared_ptr<font>& f
         );
 
         void set_number_of_menus (

--- a/dlib/iosockstream/iosockstream.h
+++ b/dlib/iosockstream/iosockstream.h
@@ -6,8 +6,9 @@
 #include "iosockstream_abstract.h"
 
 #include <iostream>
+#include <memory>
+
 #include "../sockstreambuf.h"
-#include "../smart_pointers_thread_safe.h"
 #include "../timeout.h"
 
 #ifdef _MSC_VER
@@ -147,7 +148,7 @@ namespace dlib
     private:
 
         void terminate_connection(
-            shared_ptr_thread_safe<connection> thecon
+            std::shared_ptr<connection> thecon
         )
         {
             thecon->shutdown();
@@ -155,7 +156,7 @@ namespace dlib
 
         scoped_ptr<timeout> con_timeout;
         rmutex class_mutex; 
-        shared_ptr_thread_safe<connection> con;
+        std::shared_ptr<connection> con;
         scoped_ptr<sockstreambuf> buf;
 
     };

--- a/dlib/smart_pointers_thread_safe.h
+++ b/dlib/smart_pointers_thread_safe.h
@@ -3,6 +3,16 @@
 #ifndef DLIB_SMART_POINTERs_THREAD_SAFE_H_
 #define DLIB_SMART_POINTERs_THREAD_SAFE_H_ 
 
+// This is legacy smart pointer code that will likely to stop working under default
+// compiler flags when C++17 becomes the default standard in the compilers.
+// Please consider migrating your code to contemporary smart pointers from C++
+// standard library. The warning below will help to detect if the deprecated code
+// was included from library's clients.
+#if (defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))) || \
+  (defined(__clang__) && ((__clang_major__ >= 3 && __clang_minor__ >= 4)))
+#pragma GCC warning "smart_pointers_thread_safe.h is included which will fail to compile under C++17"
+#endif
+
 #include "smart_pointers/shared_ptr_thread_safe.h"
 
 #endif // DLIB_SMART_POINTERs_THREAD_SAFE_H_ 

--- a/dlib/sockets/sockets_kernel_1.h
+++ b/dlib/sockets/sockets_kernel_1.h
@@ -12,7 +12,6 @@
 #include "../algs.h"
 #include <string>
 #include "../threads.h"
-#include "../smart_pointers.h"
 #include "../uintn.h"
 
 

--- a/dlib/test/gui/main.cpp
+++ b/dlib/test/gui/main.cpp
@@ -1,18 +1,21 @@
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
 #include "dlib/image_io.h"
 #include "dlib/array2d.h"
 #include "dlib/gui_core.h"
 #include "dlib/assert.h"
 #include "dlib/misc_api.h"
-#include <string>
+
 #include "dlib/image_transforms.h"
 
 #include "dlib/timer.h"
 
 #include "dlib/gui_widgets.h"
 #include "dlib/queue.h"
-#include <sstream>
-#include <iostream>
-#include <fstream>
 
 using namespace dlib;
 using namespace std;
@@ -444,7 +447,7 @@ public:
     {
         bool use_bdf_fonts = false;
 
-        shared_ptr_thread_safe<bdf_font> f(new bdf_font);
+        std::shared_ptr<bdf_font> f(new bdf_font);
         
         if (use_bdf_fonts)
         {

--- a/dlib/threads/thread_pool_extension.h
+++ b/dlib/threads/thread_pool_extension.h
@@ -3,6 +3,10 @@
 #ifndef DLIB_THREAD_POOl_Hh_
 #define DLIB_THREAD_POOl_Hh_ 
 
+#include <exception>
+#include <memory>
+#include <thread>
+
 #include "thread_pool_extension_abstract.h"
 #include "multithreaded_object_extension.h"
 #include "../member_function_pointer.h"
@@ -11,10 +15,6 @@
 #include "auto_mutex_extension.h"
 #include "../uintn.h"
 #include "../array.h"
-#include "../smart_pointers_thread_safe.h"
-#include <exception>
-#include <thread>
-#include <memory>
 
 namespace dlib
 {
@@ -88,7 +88,7 @@ namespace dlib
         inline void wait () const;
 
         mutable uint64 task_id;
-        mutable shared_ptr_thread_safe<thread_pool_implementation> tp;
+        mutable std::shared_ptr<thread_pool_implementation> tp;
 
         T var;
     };
@@ -489,7 +489,7 @@ namespace dlib
     class thread_pool 
     {
         /*!
-            This object is just a shell that holds a shared_ptr_thread_safe 
+            This object is just a shell that holds a std::shared_ptr 
             to the real thread_pool_implementation object.  The reason for doing
             it this way is so that we can allow any mixture of destruction orders
             between thread_pool objects and futures.  Whoever gets destroyed
@@ -1355,7 +1355,7 @@ namespace dlib
 
     private:
 
-        shared_ptr_thread_safe<thread_pool_implementation> impl;
+        std::shared_ptr<thread_pool_implementation> impl;
 
         // restricted functions
         thread_pool(thread_pool&);        // copy constructor

--- a/dlib/timer/timer.cpp
+++ b/dlib/timer/timer.cpp
@@ -208,9 +208,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    shared_ptr_thread_safe<timer_global_clock> get_global_clock()
+    std::shared_ptr<timer_global_clock> get_global_clock()
     {
-        static shared_ptr_thread_safe<timer_global_clock> d(new timer_global_clock);
+        static std::shared_ptr<timer_global_clock> d(new timer_global_clock);
         return d;
     }
 

--- a/dlib/timer/timer.h
+++ b/dlib/timer/timer.h
@@ -3,13 +3,14 @@
 #ifndef DLIB_TIMEr_Hh_
 #define DLIB_TIMEr_Hh_
 
+#include <memory>
+
 #include "../threads.h"
 #include "../algs.h"
 #include "../misc_api.h"
 #include "timer_abstract.h"
 #include "../uintn.h"
 #include "../binary_search_tree.h"
-#include "../smart_pointers_thread_safe.h"
 #include "timer_heavy.h"
 
 namespace dlib
@@ -96,7 +97,7 @@ namespace dlib
 
         mutex m;
 
-        friend shared_ptr_thread_safe<timer_global_clock> get_global_clock();
+        friend std::shared_ptr<timer_global_clock> get_global_clock();
 
     private:
         timer_global_clock();
@@ -113,7 +114,7 @@ namespace dlib
                 - spawns timer tasks as is appropriate
         !*/
     };
-    shared_ptr_thread_safe<timer_global_clock> get_global_clock();
+    std::shared_ptr<timer_global_clock> get_global_clock();
     /*!
         ensures
             - returns the global instance of the timer_global_clock object
@@ -209,7 +210,7 @@ namespace dlib
         // data members
         T& ao;
         const af_type af;
-        shared_ptr_thread_safe<timer_global_clock> gc;
+        std::shared_ptr<timer_global_clock> gc;
 
         // restricted functions
         timer(const timer&);        // copy constructor


### PR DESCRIPTION
In an effort to make DLib compilable under C++17 shared_ptr_thread_safe is replaced with std::shared_ptr. See #586 and #588