### PR TITLE
Shape Predictor Members Protected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.3)
 add_subdirectory(dlib)

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.3)
 project(dlib)
 
 # Adhere to GNU filesystem layout conventions

--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -401,7 +401,7 @@ namespace dlib
 
         friend void deserialize (shape_predictor& item, std::istream& in);
 
-    private:
+    protected:
         matrix<float,0,1> initial_shape;
         std::vector<std::vector<impl::regression_tree> > forests;
         std::vector<std::vector<unsigned long> > anchor_idx; 
@@ -521,4 +521,3 @@ namespace dlib
 }
 
 #endif // DLIB_SHAPE_PREDICToR_H_
-


### PR DESCRIPTION
In order to derive shape predictor (we want to make a compressed dat file with custom serialization) we would need these to be protected. I believe it makes sense also generally to keep it that way.