### PR TITLE
Ambiguous simd4i constructor for ARM

### DIFF
--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -105,7 +105,6 @@ namespace dlib
             x = vld1q_s32(data);
         }
         inline simd4i(const int32x4_t& val):x(val) {}
-        inline simd4i(const uint32x4_t& val):x((int32x4_t)val) {}
 
         inline simd4i& operator=(const int32x4_t& val)
         {


### PR DESCRIPTION
solves error message

`ambiguous conversion for func
tional-style cast from 'const dlib::simd4f' to 'dlib::simd4i’`

which appears on ARM compilers, for iOS and Android