### PR TITLE
Disable IntelliSense for all DNN unit tests

### DIFF
--- a/dlib/dnn.h
+++ b/dlib/dnn.h
@@ -11,7 +11,18 @@
 
 #include "dnn/tensor.h"
 #include "dnn/input.h"
+
+// Problem:    Visual Studio's vcpkgsrv.exe constantly uses a single CPU core,
+//             apparently never finishing whatever it's trying to do. Moreover,
+//             this issue prevents some operations like switching from Debug to
+//             Release (and vice versa) in the IDE. (Your mileage may vary.)
+// Workaround: Keep manually killing the vcpkgsrv.exe process.
+// Solution:   Disable IntelliSense for some files. Which files? Unfortunately
+//             this seems to be a trial-and-error process.
+#ifndef __INTELLISENSE__
 #include "dnn/layers.h"
+#endif // __INTELLISENSE__
+
 #include "dnn/loss.h"
 #include "dnn/core.h"
 #include "dnn/solvers.h"

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -13,6 +13,8 @@
 
 #include "tester.h"
 
+#ifndef __INTELLISENSE__
+
 namespace
 {
 
@@ -1603,8 +1605,6 @@ namespace
 
 // ----------------------------------------------------------------------------------------
 
-#ifndef __INTELLISENSE__
-
     template <unsigned long n, typename SUBNET> using rcon = max_pool<2,2,2,2,relu<bn_con<con<n,5,5,1,1,SUBNET>>>>;
     template <unsigned long n, typename SUBNET> using rfc = relu<bn_fc<fc<n,SUBNET>>>;
 
@@ -1691,8 +1691,6 @@ namespace
             DLIB_TEST(x);
         DLIB_TEST(count == pnet.num_computational_layers);
     }
-
-#endif // __INTELLISENSE__
 
     float tensor_read_cpu(const tensor& t, long i, long k, long r, long c)
     {
@@ -1804,8 +1802,6 @@ namespace
     }
 #endif//DLIB_USE_CUDA
 
-#ifndef __INTELLISENSE__
-
     template <typename SUBNET> using concat_block1 = con<5,1,1,1,1,SUBNET>;
     template <typename SUBNET> using concat_block2 = con<8,3,3,1,1,SUBNET>;
     template <typename SUBNET> using concat_block3 = max_pool<3,3,1,1,SUBNET>;
@@ -1867,8 +1863,6 @@ namespace
         error = memcmp(g3.host(), b3g.host(), b3g.size());
         DLIB_TEST(error == 0);
     }
-
-#endif // __INTELLISENSE__
 
 // ----------------------------------------------------------------------------------------
 
@@ -2400,4 +2394,5 @@ namespace
     } a;
 }
 
+#endif // __INTELLISENSE__
 

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -1626,6 +1626,8 @@ namespace
 
 // ----------------------------------------------------------------------------------------
 
+#ifndef __INTELLISENSE__
+
     template <
         int N, 
         template <typename> class BN, 
@@ -1689,6 +1691,8 @@ namespace
             DLIB_TEST(x);
         DLIB_TEST(count == pnet.num_computational_layers);
     }
+
+#endif // __INTELLISENSE__
 
     float tensor_read_cpu(const tensor& t, long i, long k, long r, long c)
     {

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -1603,6 +1603,8 @@ namespace
 
 // ----------------------------------------------------------------------------------------
 
+#ifndef __INTELLISENSE__
+
     template <unsigned long n, typename SUBNET> using rcon = max_pool<2,2,2,2,relu<bn_con<con<n,5,5,1,1,SUBNET>>>>;
     template <unsigned long n, typename SUBNET> using rfc = relu<bn_fc<fc<n,SUBNET>>>;
 
@@ -1625,8 +1627,6 @@ namespace
     }
 
 // ----------------------------------------------------------------------------------------
-
-#ifndef __INTELLISENSE__
 
     template <
         int N, 
@@ -1804,6 +1804,8 @@ namespace
     }
 #endif//DLIB_USE_CUDA
 
+#ifndef __INTELLISENSE__
+
     template <typename SUBNET> using concat_block1 = con<5,1,1,1,1,SUBNET>;
     template <typename SUBNET> using concat_block2 = con<8,3,3,1,1,SUBNET>;
     template <typename SUBNET> using concat_block3 = max_pool<3,3,1,1,SUBNET>;
@@ -1865,6 +1867,8 @@ namespace
         error = memcmp(g3.host(), b3g.host(), b3g.size());
         DLIB_TEST(error == 0);
     }
+
+#endif // __INTELLISENSE__
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Disable IntelliSense even for the local ResNet declarations in the DNN tests.

(See #666.)