### PR TITLE
Add methods pipe::has_blocked_dequeues and trainer::is_training.

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -564,6 +564,11 @@ namespace dlib
             return train_one_step_calls;
         }
 
+        bool is_training() const
+        {
+            return !job_pipe.has_blocked_dequeues();
+        }
+
     private:
 
         void record_test_loss(double loss)

--- a/dlib/pipe/pipe_kernel_1.h
+++ b/dlib/pipe/pipe_kernel_1.h
@@ -82,6 +82,9 @@ namespace dlib
             unsigned long num
         )const;
 
+        bool has_blocked_dequeues (
+        ) const;
+
         void enable (
         );
 
@@ -664,6 +667,18 @@ namespace dlib
             unblock_sig.broadcast();
 
         --unblock_sig_waiters;
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    template <
+        typename T
+        >
+    bool pipe<T>::
+    has_blocked_dequeues () const
+    {
+        auto_mutex M(m);
+        return pipe_size == 0 && dequeue_waiters > 0;
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
The latter uses the former. It may be useful e.g. if you are doing online training and need to know when a new trained network is readily available (without having to block in get_net).

Again: I can add documentation, if this is seen generally useful and in line with the overall design of the library.