### PR TITLE
Add test for serializing DNNs

### DIFF
--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -1523,51 +1523,6 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    class proxy_serialize_ostream
-    {
-    public:
-        explicit proxy_serialize_ostream (
-            std::ostream& out
-        ) : out(out)
-        {}
-
-        template <typename T>
-        inline proxy_serialize_ostream& operator<<(const T& item)
-        {
-            serialize(item, out);
-            return *this;
-        }
-
-    private:
-        std::ostream& out;
-    };
-
-    class proxy_deserialize_istream
-    {
-    public:
-        explicit proxy_deserialize_istream (
-            std::istream& in
-        ) : in(in)
-        {}
-
-        template <typename T>
-        inline proxy_deserialize_istream& operator>>(T& item)
-        {
-            deserialize(item, in);
-            return *this;
-        }
-
-    private:
-        std::istream& in;
-    };
-
-    inline proxy_serialize_ostream serialize(std::ostream& out)
-    { return proxy_serialize_ostream(out); }
-    inline proxy_deserialize_istream deserialize(std::istream& in)
-    { return proxy_deserialize_istream(in); }
-
-// ----------------------------------------------------------------------------------------
-
 }
 
 // forward declare the MessageLite object so we can reference it below.

--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -1523,6 +1523,51 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    class proxy_serialize_ostream
+    {
+    public:
+        explicit proxy_serialize_ostream (
+            std::ostream& out
+        ) : out(out)
+        {}
+
+        template <typename T>
+        inline proxy_serialize_ostream& operator<<(const T& item)
+        {
+            serialize(item, out);
+            return *this;
+        }
+
+    private:
+        std::ostream& out;
+    };
+
+    class proxy_deserialize_istream
+    {
+    public:
+        explicit proxy_deserialize_istream (
+            std::istream& in
+        ) : in(in)
+        {}
+
+        template <typename T>
+        inline proxy_deserialize_istream& operator>>(T& item)
+        {
+            deserialize(item, in);
+            return *this;
+        }
+
+    private:
+        std::istream& in;
+    };
+
+    inline proxy_serialize_ostream serialize(std::ostream& out)
+    { return proxy_serialize_ostream(out); }
+    inline proxy_deserialize_istream deserialize(std::istream& in)
+    { return proxy_deserialize_istream(in); }
+
+// ----------------------------------------------------------------------------------------
+
 }
 
 // forward declare the MessageLite object so we can reference it below.

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2486,6 +2486,32 @@ namespace
         }
     }
 
+    void test_serialization()
+    {
+        print_spinner();
+
+        using net_type = loss_mean_squared<fc<1, input<matrix<double>>>>;
+        net_type net, net2;
+
+#if 0
+        // At least on MSVC, this fails with compiler error:
+        // "C2665: 'dlib::serialize': none of the 46 overloads could convert all the argument types"
+        {
+            std::ostringstream out;
+            dlib::serialize(net, out);
+            const std::string serialized = out.str();
+            std::istringstream in(serialized);
+            dlib::deserialize(net2, in);
+        }
+#endif
+
+        // This at least compiles (with #692):
+        std::ostringstream out;
+        dlib::serialize(out) << net;
+        const std::string serialized = out.str();
+        std::istringstream in(serialized);
+        dlib::deserialize(in) >> net2;
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -2565,6 +2591,7 @@ namespace
             test_loss_multiclass_per_pixel_outputs_on_trivial_task();
             test_loss_multiclass_per_pixel_with_noise_and_pixels_to_ignore();
             test_loss_multiclass_per_pixel_weighted();
+            test_serialization();
         }
 
         void perform_test()

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2493,7 +2493,7 @@ namespace
         using net_type = loss_mean_squared<fc<1, input<matrix<double>>>>;
         net_type net, net2;
 
-#if 0
+#if 1
         // At least on MSVC, this fails with compiler error:
         // "C2665: 'dlib::serialize': none of the 46 overloads could convert all the argument types"
         {

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2493,24 +2493,11 @@ namespace
         using net_type = loss_mean_squared<fc<1, input<matrix<double>>>>;
         net_type net, net2;
 
-#if 1
-        // At least on MSVC, this fails with compiler error:
-        // "C2665: 'dlib::serialize': none of the 46 overloads could convert all the argument types"
-        {
-            std::ostringstream out;
-            dlib::serialize(net, out);
-            const std::string serialized = out.str();
-            std::istringstream in(serialized);
-            dlib::deserialize(net2, in);
-        }
-#endif
-
-        // This at least compiles (with #692):
         std::ostringstream out;
-        dlib::serialize(out) << net;
+        dlib::serialize(net, out);
         const std::string serialized = out.str();
         std::istringstream in(serialized);
-        dlib::deserialize(in) >> net2;
+        dlib::deserialize(net2, in);
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
I wanted to do as follows:

    net_type net, net2;
    // ...
    std::ostringstream out;
    serialize(out) << net;
    const std::string serialized = out.str();
    // ...
    std::istringstream in(serialized);
    deserialize(in) >> net2;

(In other words, I wanted to serialize DNNs, but in memory and not via files.)

I couldn't figure out a way to do this without adding this code somewhere: otherwise, i.e. with `serialize(net, out);` and `deserialize(net2, in);`, MSVC++ would just complain that it can't match `net` and `net2` (didn't try other compilers). First added the new code on the call site, but as it apparently has to be in the `dlib` namespace, thought it'd be better to have it here.

Perhaps I was doing it all wrong to begin with, but at least this addition did let me do what I wanted to do, so thought I'd share it.