### PR TITLE
cuDNN convolution algorithms shared workspace

### DIFF
--- a/dlib/dnn/cuda_data_ptr.h
+++ b/dlib/dnn/cuda_data_ptr.h
@@ -149,6 +149,32 @@ namespace dlib
 
     // ------------------------------------------------------------------------------------
 
+        class resizable_buffer
+        {
+            /*!
+                WHAT THIS OBJECT REPRESENTS
+                    This is a block of memory on a CUDA device that will be automatically
+                    resized if requestes size is larger than allocated
+            !*/
+        public:
+            cuda_data_void_ptr get(size_t size)
+            /*!
+                ensures
+                    - This object will return the buffer of requested size of larger
+                    - buffer.size() >= size
+            !*/
+            {
+                if (buffer.size() < size)
+                {
+                    buffer.reset();
+                    buffer = cuda_data_void_ptr(size);
+                }
+                return buffer;
+            }
+        private:
+            cuda_data_void_ptr buffer;
+        };
+
     }
 }
 

--- a/dlib/dnn/cuda_data_ptr.h
+++ b/dlib/dnn/cuda_data_ptr.h
@@ -149,7 +149,7 @@ namespace dlib
 
     // ------------------------------------------------------------------------------------
 
-        class resizable_buffer
+        class resizable_cuda_buffer
         {
             /*!
                 WHAT THIS OBJECT REPRESENTS

--- a/dlib/dnn/cudnn_dlibapi.cpp
+++ b/dlib/dnn/cudnn_dlibapi.cpp
@@ -123,8 +123,8 @@ namespace dlib
         {
         public:
             // not copyable
-            cudnn_device_buffer(const cudnn_context&) = delete;
-            cudnn_device_buffer& operator=(const cudnn_context&) = delete;
+            cudnn_device_buffer(const cudnn_device_buffer&) = delete;
+            cudnn_device_buffer& operator=(const cudnn_device_buffer&) = delete;
 
             cudnn_device_buffer()
             {

--- a/dlib/dnn/cudnn_dlibapi.h
+++ b/dlib/dnn/cudnn_dlibapi.h
@@ -268,7 +268,7 @@ namespace dlib
             size_t forward_workspace_size_in_bytes;
             size_t backward_data_workspace_size_in_bytes;
             size_t backward_filters_workspace_size_in_bytes;
-            std::shared_ptr<resizable_buffer> workspace;
+            std::shared_ptr<resizable_cuda_buffer> workspace;
         };
 
     // ------------------------------------------------------------------------------------

--- a/dlib/dnn/cudnn_dlibapi.h
+++ b/dlib/dnn/cudnn_dlibapi.h
@@ -7,6 +7,7 @@
 
 #include "cuda_errors.h"
 #include <memory>
+#include "cuda_data_ptr.h"
 
 namespace dlib
 {
@@ -62,45 +63,6 @@ namespace dlib
             void swap(tensor_descriptor& item) { std::swap(handle, item.handle); }
 
             void* handle;
-        };
-
-        // ------------------------------------------------------------------------------------
-
-        class cudnn_shared_workspace
-        {
-            /*!
-                Some cuDNN algorithms require temporarry memory blocks for processing.
-                This class represents such memory block that can be reused by many
-                cuDNN algorithms from same thread
-            !*/
-
-        public:
-            // not copyable
-            cudnn_shared_workspace(const cudnn_shared_workspace&) = delete;
-            cudnn_shared_workspace& operator=(const cudnn_shared_workspace&) = delete;
-            // but is movable
-            cudnn_shared_workspace(cudnn_shared_workspace&& item) { swap(item); }
-            cudnn_shared_workspace& operator=(cudnn_shared_workspace&& item) { swap(item); return *this; }
-
-            cudnn_shared_workspace();
-            ~cudnn_shared_workspace(){}
-
-            void set_size(size_t size);
-            size_t get_size() const {return size;}
-            void* get();
-
-            void clear() {set_size(0);}
-        private:
-
-            void swap(cudnn_shared_workspace& item) { std::swap(ptr, item.ptr), std::swap(size, item.size); }
-
-            static size_t &reserved_size();
-            static void reserve(size_t size);
-            static std::shared_ptr<void*> allocate();
-            static void release_cuda_ptr(void** ptr);
-
-            std::shared_ptr<void*> ptr;
-            size_t size = 0;
         };
 
         // ------------------------------------------------------------------------------------
@@ -300,13 +262,13 @@ namespace dlib
             int out_nc;
 
             int forward_algo;
-            cudnn_shared_workspace forward_workspace;
-
             int backward_data_algo;
-            cudnn_shared_workspace backward_data_workspace;
-
             int backward_filters_algo;
-            cudnn_shared_workspace backward_filters_workspace;
+
+            size_t forward_workspace_size_in_bytes;
+            size_t backward_data_workspace_size_in_bytes;
+            size_t backward_filters_workspace_size_in_bytes;
+            std::shared_ptr<resizable_buffer> workspace;
         };
 
     // ------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes convolution layers in GPU mode to share workspace memory buffers. This leads to significant memory usage decrease with fast convolution algorithms

Existing dlib implementation of large networks (Resnet34) is using "prefer_smallest" cuDNN convolution algorithms to make it process large batches with same GPU RAM.
With this PR we are now able to use fast convolution algorithm with near the same RAM usage (about 100 Mb additional RAM required)

I have tested it with GTX TitanX (Maxwell/12GB) and GTX 1080 Ti (Pascal/11GB). TitanX is now able to train imagenet with batch size = 160 with fast algorithms (same batch size as smallest algorithms), and 1080 is able to train batch_size = 155

Training time:   
  * TitanX, smallest - 1.6 second per batch of 160 images
  * TitanX, fast  - 0.9 second per batch of 160 images
  * 1080Ti, smallest - 1.4 second per batch of 155 images
  * 1080Ti, fast - 0.7 second per batch of 155 images

All tests with Cudnn 6 and Cuda 8

So overall picture seems like 2x training performance improvement for large networks

Accuracy not changed - tested with MNIST example with multi-gpu mode

I am sure, someone can find more elegant solution, but this should be good as a starting point

Reading CUDNN documentation I have found that RNN networks have "reserve size" that should be kept unchanged between forward and backward passes, but workspace for all agorithms seems to be safely reusable

Also we should know, that backward algorithms require more RAM than forward. So forward-only (production) networks can be optimized even more for RAM usage

This PR changes very internal core things in Dlib, so it should be reviewed carefully before merging
