### PR TITLE
Update webcam_face_pose_ex.cpp

### DIFF
--- a/examples/webcam_face_pose_ex.cpp
+++ b/examples/webcam_face_pose_ex.cpp
@@ -60,7 +60,10 @@ int main()
         {
             // Grab a frame
             cv::Mat temp;
-            cap >> temp;
+            if (!cap.read(temp))
+            {
+                break;
+            }
             // Turn OpenCV's Mat into something dlib can deal with.  Note that this just
             // wraps the Mat object, it doesn't copy anything.  So cimg is only valid as
             // long as temp is valid.  Also don't do anything to temp that would cause it


### PR DESCRIPTION
Test on a given video like this 
`cv::VideoCapture cap("Sample.avi")`
may be broken when the video frames are not enough before the main window is closed by the user.