### PR TITLE
Report confidence of loss_multiclass_log_per_pixel_weighted

### DIFF
--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -912,7 +912,9 @@ namespace dlib
             /*!
                 WHAT THIS OBJECT REPRESENTS
                     This object represents the predicted class label of a single pixel,
-                    together with an associated confidence score.
+                    together with an associated confidence score. Note that you may want
+                    to employ a softmax layer, to make the reported scores represent
+                    probabilities.
             !*/
 
             scored_label();

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -907,8 +907,29 @@ namespace dlib
             float weight = 1.f;
         };
 
+        struct scored_label
+        {
+            /*!
+                WHAT THIS OBJECT REPRESENTS
+                    This object represents the predicted class label of a single pixel,
+                    together with an associated confidence score.
+            !*/
+
+            scored_label();
+            scored_label(uint16_t label, float score = std::numeric_limits<float>::quiet_nan());
+
+            // Returns the predicted label. Provided mainly for backward compatibility.
+            operator uint16_t () const;
+
+            // The predicted label.
+            uint16_t label = std::numeric_limits<uint16_t>::max();
+
+            // The higher the score, the more confident the network is about the label.
+            float score = std::numeric_limits<float>::quiet_nan();
+        };
+
         typedef matrix<weighted_label> training_label_type;
-        typedef matrix<uint16_t> output_label_type;
+        typedef matrix<scored_label> output_label_type;
 
         template <
             typename SUB_TYPE,

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2475,13 +2475,13 @@ namespace
             trainer.set_max_num_epochs(10);
             trainer.train(x, y_weighted);
 
-            const ::std::vector<matrix<uint16_t>> predictions = net(x);
+            const auto predictions = net(x);
 
             int num_weighted_class = 0;
             int num_not_weighted_class = 0;
 
             for ( int ii = 0; ii < num_samples; ++ii ) {
-                const matrix<uint16_t>& prediction = predictions[ii];
+                const auto& prediction = predictions[ii];
                 DLIB_TEST(prediction.nr() == output_height);
                 DLIB_TEST(prediction.nc() == output_width);
                 for ( int jj = 0; jj < output_height; ++jj )


### PR DESCRIPTION
Make `loss_multiclass_log_per_pixel_weighted_::to_label` return not only the predicted class label, but also an associated confidence score.