### PR TITLE
Fix strange dash in Box-Muller

### DIFF
--- a/dlib/general_hash/random_hashing.h
+++ b/dlib/general_hash/random_hashing.h
@@ -862,7 +862,7 @@ namespace dlib
         const static uint64 mask = max-1; 
         return logvals[h.first&mask]*cosvals[h.second&mask];
 
-        // Note that we are just using the Box–Muller transform to compute the result.  In
+        // Note that we are just using the Box-Muller transform to compute the result.  In
         // particular, we are doing this (where u1 and u2 are uniform random variables in
         // the range [0,1]): 
         //    return sqrt(-2*log(u1)) * cos(2*PI*u2);


### PR DESCRIPTION
The non-standard dash character confuses Microsoft compiler and produces warnings like 'The file contains a character that cannot be represented in the current code page (949). Save the file in Unicode format to prevent data loss' when compiled on non-Latin system locale codepages