### PR TITLE
Pull in external libpng dependencies properly

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -343,12 +343,12 @@ if (NOT TARGET dlib)
          # Make sure there isn't something wrong with the version of LIBPNG
          # installed on this system.  
          if (PNG_FOUND)
-            set(CMAKE_REQUIRED_LIBRARIES ${PNG_LIBRARY})
+            set(CMAKE_REQUIRED_LIBRARIES ${PNG_LIBRARIES})
             CHECK_FUNCTION_EXISTS(png_create_read_struct LIBPNG_IS_GOOD)
          endif()
          if (PNG_FOUND AND LIBPNG_IS_GOOD)
             include_directories(${PNG_INCLUDE_DIR})
-            set (dlib_needed_libraries ${dlib_needed_libraries} ${PNG_LIBRARY})
+            set (dlib_needed_libraries ${dlib_needed_libraries} ${PNG_LIBRARIES})
             set(REQUIRES_LIBS " libpng")
          else()
             # If we can't find libpng then statically compile it in.


### PR DESCRIPTION
PNG_LIBRARY set by libpng's FindPNG.cmake does not contain zlib dependancy.  This causes the CHECK_FUNCTION_EXISTS(png_create_read_struct LIBPNG_IS_GOOD) to fail with liner errors, and for dlib to use it's internal copy of PNG.

Updated to use libpng's PNG_LIBRARIES variable.  This also sets both PNG and ZLib libraries in dlib_needed_libraries.