### PR TITLE
Clang support for Windows

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -523,7 +523,7 @@ if (NOT TARGET dlib)
             # -std=c++11 option if you let it propagate it to nvcc in some
             # cases.  So instead we disable this and manually include
             # things from CMAKE_CXX_FLAGS in the CUDA_NVCC_FLAGS list below.
-            if (APPLE)
+            if (APPLE OR MSVC)
                set(CUDA_PROPAGATE_HOST_FLAGS OFF)
                # Grab all the -D flags from CMAKE_CXX_FLAGS so we can pass them
                # to nvcc.

--- a/dlib/cmake_utils/use_cpp_11.cmake
+++ b/dlib/cmake_utils/use_cpp_11.cmake
@@ -58,6 +58,11 @@ if (CMAKE_VERSION VERSION_LESS "3.1.2")
       # Since we don't know what compiler this is just try to build a c++11 project and see if it compiles.
       test_compiler_for_cpp11()
    endif()
+elseif( MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.3) 
+   # Clang can compile all Dlib's code at Windows platform. Tested with Clang 5
+   message(STATUS "C++11 activated.")
+   add_global_compiler_switch("-Xclang -fcxx-exceptions -Xclang -Wno-microsoft-pure-definition -Xclang -Wno-unused-local-typedef")
+   set(COMPILER_CAN_DO_CPP_11 1)
 elseif(MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0.24215.1 ) 
    message(STATUS "NOTE: Visual Studio didn't have good enough C++11 support until Visual Studio 2015 update 3 (v19.0.24215.1)")
    message(STATUS "So we aren't enabling things that require full C++11 support (e.g. the deep learning tools).")


### PR DESCRIPTION
This PR makes pussible compilation with Clang on Windows platform. I have tried Clang 5.0, it has full support of C++11, it is compatible with all MSVC libraries (MKL) and it supports CUDA and compiled code is faster than original MSVC-generated code

So I think, users of Dlib who need CUDA on Windows platform for DNN can easily do it with Clang

To use Clang after installation, you need to pass this arguments to CMAKE:
```
cmake ..  -G"Visual Studio 14 2015 Win64" -T"LLVM-vs2014"
```

There is one annoying warning during compilation
```
 warning : argument unused during compilation: '/Gm-' [-Wunused-command-line-argument]
```

But I can't find way to disable it. -Wno-unused-command-line-argument does not help, -Qunused-argument does not help too