### PR TITLE
hotfix static runtime in cuda with clang and windows

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -523,7 +523,7 @@ if (NOT TARGET dlib)
             # -std=c++11 option if you let it propagate it to nvcc in some
             # cases.  So instead we disable this and manually include
             # things from CMAKE_CXX_FLAGS in the CUDA_NVCC_FLAGS list below.
-            if (APPLE OR MSVC)
+            if (APPLE)
                set(CUDA_PROPAGATE_HOST_FLAGS OFF)
                # Grab all the -D flags from CMAKE_CXX_FLAGS so we can pass them
                # to nvcc.

--- a/dlib/cmake_utils/use_cpp_11.cmake
+++ b/dlib/cmake_utils/use_cpp_11.cmake
@@ -61,7 +61,7 @@ if (CMAKE_VERSION VERSION_LESS "3.1.2")
 elseif( MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.3) 
    # Clang can compile all Dlib's code at Windows platform. Tested with Clang 5
    message(STATUS "C++11 activated.")
-   add_global_compiler_switch("-Xclang -fcxx-exceptions -Xclang -Wno-microsoft-pure-definition -Xclang -Wno-unused-local-typedef")
+   add_global_compiler_switch("-Xclang -fcxx-exceptions")
    set(COMPILER_CAN_DO_CPP_11 1)
 elseif(MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0.24215.1 ) 
    message(STATUS "NOTE: Visual Studio didn't have good enough C++11 support until Visual Studio 2015 update 3 (v19.0.24215.1)")


### PR DESCRIPTION
This PR fixes the compilation of examples with Clang + CUDA + Windows. There will be a lot of warnings, but compilation of dnn_mmod_exx is successul