### PR TITLE
Add support for non-scale-invariant MMOD

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -360,6 +360,12 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
+    enum class use_image_pyramid : uint8_t
+    {
+        no,
+        yes
+    };
+
     struct mmod_options
     {
     public:
@@ -405,12 +411,6 @@ namespace dlib
         double truth_match_iou_threshold = 0.5;
         test_box_overlap overlaps_nms = test_box_overlap(0.4);
         test_box_overlap overlaps_ignore;
-
-        enum class use_image_pyramid : uint8_t
-        {
-            no,
-            yes
-        };
 
         use_image_pyramid assume_image_pyramid = use_image_pyramid::yes;
 
@@ -685,7 +685,7 @@ namespace dlib
         {
             uint8_t assume_image_pyramid = 0;
             deserialize(assume_image_pyramid, in);
-            item.assume_image_pyramid = static_cast<mmod_options::use_image_pyramid>(assume_image_pyramid);
+            item.assume_image_pyramid = static_cast<use_image_pyramid>(assume_image_pyramid);
         }
     }
 
@@ -1052,10 +1052,10 @@ namespace dlib
         size_t find_best_detection_window (
             rectangle rect,
             const std::string& label,
-            mmod_options::use_image_pyramid assume_image_pyramid
+            use_image_pyramid assume_image_pyramid
         ) const
         {
-            if (assume_image_pyramid == mmod_options::use_image_pyramid::yes)
+            if (assume_image_pyramid == use_image_pyramid::yes)
             {
                 rect = move_rect(set_rect_area(rect, 400*400), point(0,0));
             }
@@ -1075,7 +1075,7 @@ namespace dlib
 
                 rectangle det_window;
                 
-                if (options.assume_image_pyramid == mmod_options::use_image_pyramid::yes)
+                if (options.assume_image_pyramid == use_image_pyramid::yes)
                 {
                     det_window = centered_rect(point(0,0), options.detector_windows[i].width, options.detector_windows[i].height);
                     det_window = move_rect(set_rect_area(det_window, 400*400), point(0,0));
@@ -1103,7 +1103,7 @@ namespace dlib
             const std::string& label,
             const net_type& net,
             size_t& det_idx,
-            mmod_options::use_image_pyramid assume_image_pyramid
+            use_image_pyramid assume_image_pyramid
         ) const 
         {
             using namespace std;
@@ -1118,7 +1118,7 @@ namespace dlib
             det_idx = find_best_detection_window(rect,label,assume_image_pyramid);
 
             double scale = 1.0;
-            if (options.assume_image_pyramid == mmod_options::use_image_pyramid::yes)
+            if (options.assume_image_pyramid == use_image_pyramid::yes)
             {
                 // Compute the scale we need to be at to get from rect to our detection window.
                 // Note that we compute the scale as the max of two numbers.  It doesn't

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -406,7 +406,8 @@ namespace dlib
         test_box_overlap overlaps_nms = test_box_overlap(0.4);
         test_box_overlap overlaps_ignore;
 
-        enum class assumed_input_layer_type_t {
+        enum class assumed_input_layer_type_t : uint8_t
+        {
             NO_IMAGE_PYRAMID,
             IMAGE_PYRAMID
         };
@@ -645,7 +646,7 @@ namespace dlib
 
     inline void serialize(const mmod_options& item, std::ostream& out)
     {
-        int version = 2;
+        int version = 3;
 
         serialize(version, out);
         serialize(item.detector_windows, out);
@@ -654,13 +655,14 @@ namespace dlib
         serialize(item.truth_match_iou_threshold, out);
         serialize(item.overlaps_nms, out);
         serialize(item.overlaps_ignore, out);
+        serialize(static_cast<uint8_t>(item.assumed_input_layer_type), out);
     }
 
     inline void deserialize(mmod_options& item, std::istream& in)
     {
         int version = 0;
         deserialize(version, in);
-        if (version != 2 && version != 1)
+        if (version != 3 && version != 2 && version != 1)
             throw serialization_error("Unexpected version found while deserializing dlib::mmod_options");
         if (version == 1)
         {
@@ -679,6 +681,12 @@ namespace dlib
         deserialize(item.truth_match_iou_threshold, in);
         deserialize(item.overlaps_nms, in);
         deserialize(item.overlaps_ignore, in);
+        if (version >= 3)
+        {
+            uint8_t assumed_input_layer_type = 0;
+            deserialize(assumed_input_layer_type, in);
+            item.assumed_input_layer_type = static_cast<mmod_options::assumed_input_layer_type_t>(assumed_input_layer_type);
+        }
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1077,10 +1077,11 @@ namespace dlib
                 
                 if (options.assumed_input_layer_type == mmod_options::assumed_input_layer_type_t::IMAGE_PYRAMID)
                 {
-                    det_window = centered_rect(point(0, 0), options.detector_windows[i].width, options.detector_windows[i].height);
-                    det_window = move_rect(set_rect_area(det_window, 400 * 400), point(0, 0));
+                    det_window = centered_rect(point(0,0), options.detector_windows[i].width, options.detector_windows[i].height);
+                    det_window = move_rect(set_rect_area(det_window, 400*400), point(0,0));
                 }
-                else {
+                else
+                {
                     det_window = rectangle(options.detector_windows[i].width, options.detector_windows[i].height);
                 }
 

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -365,6 +365,12 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
+    enum class use_image_pyramid : uint8_t
+    {
+        no,
+        yes
+    };
+
     struct mmod_options
     {
         /*!
@@ -422,13 +428,7 @@ namespace dlib
 
         // Usually the detector would be scale-invariant, and used with an image pyramid.
         // However, sometimes scale-invariance may not be desired.
-        enum class use_image_pyramid : uint8_t
-        {
-            no,
-            yes
-        };
-
-        use_image_pyramid use_image_pyramid_ = use_image_pyramid::yes;
+        use_image_pyramid assume_image_pyramid = use_image_pyramid::yes;
 
         mmod_options (
             const std::vector<std::vector<mmod_rect>>& boxes,

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -422,7 +422,12 @@ namespace dlib
 
         // Usually the detector would be scale-invariant, and used with an image pyramid.
         // However, sometimes scale-invariance may not be desired.
-        bool scale_invariant = true;
+        enum class assumed_input_layer_type_t {
+            NO_IMAGE_PYRAMID,
+            IMAGE_PYRAMID
+        };
+
+        assumed_input_layer_type_t assumed_input_layer_type = assumed_input_layer_type_t::IMAGE_PYRAMID;
 
         mmod_options (
             const std::vector<std::vector<mmod_rect>>& boxes,
@@ -435,9 +440,9 @@ namespace dlib
                 - 0 < min_target_size <= target_size
                 - 0.5 < min_detector_window_overlap_iou < 1
             ensures
-                - scale_invariant = true
-                - This function should be used when scale-invariance is desired, and an
-                  image pyramid will be applied.
+                - assumed_input_layer_type == IMAGE_PYRAMID
+                - This function should be used when scale-invariance is desired, and
+                  input_rgb_image_pyramid is therefore used as the input layer.
                 - This function tries to automatically set the MMOD options to reasonable
                   values, assuming you have a training dataset of boxes.size() images, where
                   the ith image contains objects boxes[i] you want to detect.
@@ -470,14 +475,15 @@ namespace dlib
         !*/
 
         mmod_options (
+            assumed_input_layer_type_t assumed_input_layer_type,
             const std::vector<std::vector<mmod_rect>>& boxes,
             const double min_detector_window_overlap_iou = 0.75
         );
         /*!
             requires
+                - assumed_input_layer_type == NO_IMAGE_PYRAMID
                 - 0.5 < min_detector_window_overlap_iou < 1
             ensures
-                - scale_invariant = false
                 - This function should be used when scale-invariance is not desired, and
                   there is no intention to apply an image pyramid.
                 - This function tries to automatically set the MMOD options to reasonable
@@ -486,7 +492,7 @@ namespace dlib
                 - The most important thing this function does is decide what detector
                   windows should be used.  This is done by finding a set of detector
                   windows that are sized such that:
-                    - When slid over an image pyramid, each box in boxes will have an
+                    - When slid over an image, each box in boxes will have an
                       intersection-over-union with one of the detector windows of at least
                       min_detector_window_overlap_iou.  That is, we will make sure that
                       each box in boxes could potentially be detected by one of the

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -422,12 +422,13 @@ namespace dlib
 
         // Usually the detector would be scale-invariant, and used with an image pyramid.
         // However, sometimes scale-invariance may not be desired.
-        enum class assumed_input_layer_type_t {
-            NO_IMAGE_PYRAMID,
-            IMAGE_PYRAMID
+        enum class use_image_pyramid : uint8_t
+        {
+            no,
+            yes
         };
 
-        assumed_input_layer_type_t assumed_input_layer_type = assumed_input_layer_type_t::IMAGE_PYRAMID;
+        use_image_pyramid use_image_pyramid_ = use_image_pyramid::yes;
 
         mmod_options (
             const std::vector<std::vector<mmod_rect>>& boxes,
@@ -440,7 +441,7 @@ namespace dlib
                 - 0 < min_target_size <= target_size
                 - 0.5 < min_detector_window_overlap_iou < 1
             ensures
-                - assumed_input_layer_type == IMAGE_PYRAMID
+                - use_image_pyramid_ == use_image_pyramid::yes
                 - This function should be used when scale-invariance is desired, and
                   input_rgb_image_pyramid is therefore used as the input layer.
                 - This function tries to automatically set the MMOD options to reasonable
@@ -475,13 +476,13 @@ namespace dlib
         !*/
 
         mmod_options (
-            assumed_input_layer_type_t assumed_input_layer_type,
+            use_image_pyramid use_image_pyramid,
             const std::vector<std::vector<mmod_rect>>& boxes,
             const double min_detector_window_overlap_iou = 0.75
         );
         /*!
             requires
-                - assumed_input_layer_type == NO_IMAGE_PYRAMID
+                - use_image_pyramid == use_image_pyramid::no
                 - 0.5 < min_detector_window_overlap_iou < 1
             ensures
                 - This function should be used when scale-invariance is not desired, and

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -420,6 +420,10 @@ namespace dlib
         // don't care if the detector gets them or not.  
         test_box_overlap overlaps_ignore;
 
+        // Usually the detector would be scale-invariant, and used with an image pyramid.
+        // However, sometimes scale-invariance may not be desired.
+        bool scale_invariant = true;
+
         mmod_options (
             const std::vector<std::vector<mmod_rect>>& boxes,
             const unsigned long target_size,      
@@ -431,6 +435,9 @@ namespace dlib
                 - 0 < min_target_size <= target_size
                 - 0.5 < min_detector_window_overlap_iou < 1
             ensures
+                - scale_invariant = true
+                - This function should be used when scale-invariance is desired, and an
+                  image pyramid will be applied.
                 - This function tries to automatically set the MMOD options to reasonable
                   values, assuming you have a training dataset of boxes.size() images, where
                   the ith image contains objects boxes[i] you want to detect.
@@ -458,6 +465,32 @@ namespace dlib
                   emphasized that the detector isn't going to be able to detect objects
                   smaller than any of the detector windows.  So consider that when setting
                   these sizes.
+                - This function will also set the overlaps_nms tester to the most
+                  restrictive tester that doesn't reject anything in boxes.
+        !*/
+
+        mmod_options (
+            const std::vector<std::vector<mmod_rect>>& boxes,
+            const double min_detector_window_overlap_iou = 0.75
+        );
+        /*!
+            requires
+                - 0.5 < min_detector_window_overlap_iou < 1
+            ensures
+                - scale_invariant = false
+                - This function should be used when scale-invariance is not desired, and
+                  there is no intention to apply an image pyramid.
+                - This function tries to automatically set the MMOD options to reasonable
+                  values, assuming you have a training dataset of boxes.size() images, where
+                  the ith image contains objects boxes[i] you want to detect.
+                - The most important thing this function does is decide what detector
+                  windows should be used.  This is done by finding a set of detector
+                  windows that are sized such that:
+                    - When slid over an image pyramid, each box in boxes will have an
+                      intersection-over-union with one of the detector windows of at least
+                      min_detector_window_overlap_iou.  That is, we will make sure that
+                      each box in boxes could potentially be detected by one of the
+                      detector windows.
                 - This function will also set the overlaps_nms tester to the most
                   restrictive tester that doesn't reject anything in boxes.
         !*/

--- a/examples/dnn_mmod_find_cars_ex.cpp
+++ b/examples/dnn_mmod_find_cars_ex.cpp
@@ -51,7 +51,16 @@ int main() try
     // This network was produced by the dnn_mmod_train_find_cars_ex.cpp example program.
     // As you can see, it also includes a shape_predictor.  To see a generic example of how
     // to train those refer to train_shape_predictor_ex.cpp.
-    deserialize("mmod_rear_end_vehicle_detector.dat") >> net >> sp;
+    proxy_deserialize deserializer = deserialize("mmod_rear_end_vehicle_detector.dat");
+    deserializer >> net;
+    try
+    {
+        deserializer >> sp;
+    }
+    catch (const serialization_error&)
+    {
+        cout << "Unable to deserialize the shape predictor - that's ok if you trained only the net" << endl;
+    }
 
     matrix<rgb_pixel> img;
     load_image(img, "../mmod_cars_test_image.jpg");

--- a/examples/dnn_mmod_find_cars_ex.cpp
+++ b/examples/dnn_mmod_find_cars_ex.cpp
@@ -51,16 +51,7 @@ int main() try
     // This network was produced by the dnn_mmod_train_find_cars_ex.cpp example program.
     // As you can see, it also includes a shape_predictor.  To see a generic example of how
     // to train those refer to train_shape_predictor_ex.cpp.
-    proxy_deserialize deserializer = deserialize("mmod_rear_end_vehicle_detector.dat");
-    deserializer >> net;
-    try
-    {
-        deserializer >> sp;
-    }
-    catch (const serialization_error&)
-    {
-        cout << "Unable to deserialize the shape predictor - that's ok if you trained only the net" << endl;
-    }
+    deserialize("mmod_rear_end_vehicle_detector.dat") >> net >> sp;
 
     matrix<rgb_pixel> img;
     load_image(img, "../mmod_cars_test_image.jpg");


### PR DESCRIPTION
**What**

I want to train MMOD based detectors that are _not_ scale-invariant. So I am not even going to use an image pyramid.

How come? Think of detecting vehicles in satellite images, for example. There is essentially no perspective, and all cars and trucks are pretty much the same size. Now it would be silly to report a sedan that is 50 cm or 50 m long, for example – even if there is something in the image that, when scale is ignored, looks a lot like a sedan.

In fact it would be silly to even look for a sedan that is 50 cm or 50 m long. So bypassing the image pyramid should also make the detector run faster, when invariance to scale is not needed.

However, I still want my detector to understand different object sizes. (For example, to have separate detector windows for small trucks and large trucks.)

(In fact I'm not really processing satellite images – just wanted to give an example.)

**How**

This PR adds a new `mmod_options` constructor for this purpose. The new constructor doesn't find covering aspect ratios, but covering rectangles instead. In some cases this means that there will be
many more detector windows, which may at least partially offset the speed gains from bypassing the image pyramid. (But regardless of the speed, I still don't want to report sedans that are 50 cm or 50 m long.)