### PR TITLE
Added CMakeInstallPrefix as an option in order to improve find() in C…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ Additional options:
     --compiler-flags: pass flags onto the compiler, e.g. --compiler-flag "-Os -Wall" passes -Os -Wall onto GCC.
     --debug: makes a debug build
     --cmake: path to specific cmake executable
+    --cmake-install-prefix: set the cmake install prefix in order to find libraries in custom locations 
     --G or -G: name of a build system generator (equivalent of passing -G "name" to cmake)
 """
 
@@ -84,6 +85,8 @@ def _get_options():
             _cmake_path = arg
         elif opt_key == 'compiler-flags':
             _cmake_extra.append('-DCMAKE_CXX_FLAGS={arg}'.format(arg=arg.strip()))
+        elif opt_key == 'cmake-install-prefix':
+            _cmake_extra.append('-DCMAKE_INSTALL_PREFIX={arg}'.format(arg=arg.strip()))
         elif opt_key == 'yes':
             _cmake_extra.append('-D{arg}=yes'.format(arg=arg.strip()))
         elif opt_key == 'no':
@@ -112,7 +115,7 @@ def _get_options():
             opt_key = opt
             sys.argv.remove(arg)
             continue
-        elif opt in ['yes', 'no', 'compiler-flags']:
+        elif opt in ['yes', 'no', 'compiler-flags', 'cmake-install-prefix']:
             opt_key = opt
             sys.argv.remove(arg)
             continue


### PR DESCRIPTION
I added an option to the setup.py so people can add the option --cmake-install-prefix. 

I did this because people (like me) might install cuda, caffee or whatever in a custom location in order to not mess-up the host system (aka "/") when testing different versions of libraries and frameworks --- multiple versions of libraries in the same prefix usual make things very complicated. 

As an example: I have the CUDA toolkit installed in '/test_env' alongside other tools and libs. So, If I want to install (link) dlib-python against _that_ CUDA version it'll report 'No CUDA found,' if there is no cuda in "/" or, it'll be linked against the 'wrong' version. Thus, if you specify '--cmake-install-prefix /test_env' cmake will try to find cuda in /test_env first and link  it correctly.

Let me know what you think.

Cheers,
  Flo