### PR TITLE
Let custom loss values affect MMOD gradient

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -763,7 +763,7 @@ namespace dlib
                         const size_t idx = (k*output_tensor.nr() + p.y())*output_tensor.nc() + p.x();
                         loss -= out_data[idx];
                         // compute gradient
-                        g[idx] = -scale;
+                        g[idx] = -scale * options.loss_per_missed_target;
                         truth_idxs.push_back(idx);
                     }
                     else

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -887,7 +887,7 @@ namespace dlib
                 for (auto&& x : final_dets)
                 {
                     loss += out_data[x.tensor_offset];
-                    g[x.tensor_offset] += scale;
+                    g[x.tensor_offset] += scale * options.loss_per_false_alarm;
                 }
 
                 ++truth;

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2884,9 +2884,11 @@ namespace
         std::vector<matrix<rgb_pixel>> input(1);
         std::vector<std::vector<mmod_rect>> truth(1);
 
+        // Create an input image from which nothing can be learned
         input[0].set_size(50, 50);
         input[0] = dlib::rgb_pixel(127, 127, 127);
 
+        // Nevertheless, set a target
         truth[0].push_back(mmod_rect(rectangle(10, 10, 20, 20)));
 
         const mmod_options options1(truth, 8, 8);
@@ -2907,8 +2909,46 @@ namespace
         const auto detections1 = train_and_detect(options1);
         const auto detections2 = train_and_detect(options2);
 
-        DLIB_TEST_MSG(train_and_detect(options1).empty(), "Detections should be empty for default loss_per_missed_target = " << options1.loss_per_missed_target);
-        DLIB_TEST_MSG(!train_and_detect(options2).empty(), "Detections should _not_ be empty for loss_per_missed_target = " << options2.loss_per_missed_target);
+        DLIB_TEST_MSG(detections1.empty(), "Detections should be empty for default loss_per_missed_target = " << options1.loss_per_missed_target);
+        DLIB_TEST_MSG(!detections2.empty(), "Detections should not be empty for loss_per_missed_target = " << options2.loss_per_missed_target);
+    }
+
+    void test_mmod_set_custom_loss_per_false_alarm()
+    {
+        print_spinner();
+
+        using net_type = loss_mmod<con<1,6,6,1,1,input_rgb_image>>;
+
+        std::vector<matrix<rgb_pixel>> input(1);
+        std::vector<std::vector<mmod_rect>> truth(1);
+
+        // Create an input image from which nothing can be learned
+        input[0].set_size(50, 50);
+        input[0] = dlib::rgb_pixel(127, 127, 127);
+
+        // Nevertheless, set a target
+        truth[0].push_back(mmod_rect(rectangle(10, 10, 40, 40)));
+
+        const mmod_options options1(truth, 25, 25);
+
+        mmod_options options2 = options1;
+        options2.loss_per_false_alarm *= 100;
+
+        const auto train_and_detect = [&](const mmod_options& options) {
+            print_spinner();
+            net_type net(options);
+            dnn_trainer<net_type> trainer(net);
+            trainer.set_max_num_epochs(100);
+            trainer.train(input, truth);
+            trainer.get_net();
+            return net(input[0]);
+        };
+
+        const auto detections1 = train_and_detect(options1);
+        const auto detections2 = train_and_detect(options2);
+
+        DLIB_TEST_MSG(!detections1.empty(), "Detections should not be empty for default loss_per_false_alarm = " << options1.loss_per_false_alarm);
+        DLIB_TEST_MSG(detections2.empty(), "Detections should be empty for loss_per_false_alarm = " << options2.loss_per_false_alarm);
     }
 
 // ----------------------------------------------------------------------------------------
@@ -2996,6 +3036,7 @@ namespace
             test_loss_multiclass_per_pixel_weighted();
             test_serialization();
             test_mmod_set_custom_loss_per_missed_target();
+            test_mmod_set_custom_loss_per_false_alarm();
         }
 
         void perform_test()


### PR DESCRIPTION
**Problem**: It looked like `loss_per_missed_target` and `loss_per_false_alarm` only affected the calculated loss, and not the gradient. Therefore, it also looked like these values did not affect the training result.

**Solution**: Make it so that these values enter the calculation of the gradient. Add test cases as well.

---

Also, while at it, fix even loss from ignored rects when using `loss_per_missed_target != 1`.
EDIT: this fix moved from here to #813.