### PR TITLE
MMOD: fix loss from ignored rects when using loss_per_missed_target != 1

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -757,7 +757,7 @@ namespace dlib
                         if(image_rect_to_feat_coord(p, input_tensor, x, x.label, sub, k))
                         {
                             // Ignore boxes that can't be detected by the CNN.
-                            loss -= 1;
+                            loss -= options.loss_per_missed_target;
                             continue;
                         }
                         const size_t idx = (k*output_tensor.nr() + p.y())*output_tensor.nc() + p.x();
@@ -769,7 +769,7 @@ namespace dlib
                     else
                     {
                         // This box was ignored so shouldn't have been counted in the loss.
-                        loss -= 1;
+                        loss -= options.loss_per_missed_target;
                         truth_idxs.push_back(0);
                     }
                 }


### PR DESCRIPTION
Extract this fix from #812, to be handled separately.