### PR TITLE
imglab: add parts markers rapid fire

### DIFF
--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -18,9 +18,6 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
-    // trz
-    int auto_part_num = 0;
-
     void toggle_button::
     set_size (
         unsigned long width,
@@ -6036,6 +6033,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+
     void image_display::
     on_part_add (
         const std::string& part_name
@@ -6062,14 +6060,16 @@ namespace dlib
         overlay_rects[selected_rect].parts[part_name] = c1;
         parent.invalidate_rectangle(rect); 
 
-        // trz
         // I do this here so that it advances when parts
         // are added from the context menu too
         // This also allows to restart the sequence from
         // a random point using the context menu
         int part_idx = std::distance(part_names.begin(), part_names.find(part_name));
-        //printf("part_idx: %d\n", part_idx);
-        auto_part_num = part_idx+1;
+        printf("part_idx: %d\n", part_idx);
+        if (part_idx < part_names.size())
+            auto_part_num = part_idx+1;
+        else
+            auto_part_num = 0;
 
         if (event_handler.is_set())
             event_handler();
@@ -6209,10 +6209,8 @@ namespace dlib
     {
         auto_mutex M(m);
 
-        // trz
         // reset it when we move to another image
         auto_part_num = 0;
-        //printf("reset_auto_part_num\n");
 
         overlay_rects.clear();
         overlay_lines.clear();
@@ -6510,14 +6508,12 @@ namespace dlib
     {
         scrollable_region::on_mouse_down(btn, state, x, y, is_double_click);
 
-        //trz
         /*
           Shift + click adds parts in sequence.
           I'm not sure if here is the best place to add this, but it looks like
           everything else is still working.
         */
         if (btn == base_window::LEFT && (state&base_window::SHIFT) && rect_is_selected) {
-            //printf("ADD PART\n");
 
             if (auto_part_num == part_names.size()) {
                 // I think it's safer to do nothing rather that to loop over
@@ -6527,7 +6523,6 @@ namespace dlib
             std::set<std::string>::iterator it = part_names.begin();
             std::advance(it, auto_part_num);
             std::string partName = *it;
-            //printf("Part name: %s - AutoPartNum: %d\n", partName.c_str(), auto_part_num);
 
             last_right_click_pos = point(x,y);  //sorry, on_part_add wants this...
             on_part_add(partName);
@@ -6762,8 +6757,10 @@ namespace dlib
             if (best_dist < 13)
             {
                 rect_is_selected = true;
-                if (part_names.size() != 0)
+                if (part_names.size() != 0) {
                     parts_menu.enable();
+                    auto_part_num = 0;
+                }
                 selected_rect = best_idx;
                 selected_part_name = best_part;
                 if (orect_selected_event_handler.is_set())

--- a/dlib/gui_widgets/widgets.h
+++ b/dlib/gui_widgets/widgets.h
@@ -3574,6 +3574,8 @@ namespace dlib
         std::vector<overlay_line> overlay_lines;
         std::vector<overlay_circle> overlay_circles;
 
+        unsigned long auto_part_num = 0;
+
         long zoom_in_scale;
         long zoom_out_scale;
         bool drawing_rect;


### PR DESCRIPTION
Hi, it works like this. 

- Start imglab in "parts" mode. 
- Select a rectangle
- Now holding shift left click to add part markers, as many as you want. The counter will auto advance following the parts sequence
- use the context menu' as before to add parts and to reset the auto_add starting point right after that part

I think it's a huge improvement over the context menu. I'm not a c++ programmer so my code may need a good review.

What do you think?
