### PR TITLE
Add get_net parameter that allows to call the function without forcing flush to disk

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -55,6 +55,10 @@ namespace dlib
         }
     }
 
+    enum class force_flush_to_disk {
+        no = 0,
+        yes = 1
+    };
 
     template <
         typename net_type, 
@@ -135,10 +139,11 @@ namespace dlib
         }
 
         net_type& get_net (
+            force_flush_to_disk force_flush_to_disk = force_flush_to_disk::yes
         )  
         { 
             wait_for_thread_to_pause();
-            sync_to_disk(true);
+            sync_to_disk(force_flush_to_disk == force_flush_to_disk::yes);
             propagate_exception();
             return net; 
         }

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -139,11 +139,11 @@ namespace dlib
         }
 
         net_type& get_net (
-            force_flush_to_disk force_flush_to_disk = force_flush_to_disk::yes
+            force_flush_to_disk force_flush = force_flush_to_disk::yes
         )  
         { 
             wait_for_thread_to_pause();
-            sync_to_disk(force_flush_to_disk == force_flush_to_disk::yes);
+            sync_to_disk(force_flush == force_flush_to_disk::yes);
             propagate_exception();
             return net; 
         }

--- a/dlib/dnn/trainer_abstract.h
+++ b/dlib/dnn/trainer_abstract.h
@@ -99,7 +99,7 @@ namespace dlib
         !*/
 
         net_type& get_net (
-            force_flush_to_disk force_flush_to_disk = force_flush_to_disk::yes
+            force_flush_to_disk force_flush = force_flush_to_disk::yes
         ); 
         /*!
             ensures
@@ -110,9 +110,9 @@ namespace dlib
                   dnn_trainer's constructor.
                 - This function blocks until all threads inside the dnn_trainer have
                   stopped touching the net. 
-                - If force_flush_to_disk is yes, then this function will sync the trainer
-                  state to disk if the current state hasn't already been synced to disk
-                  since the last network modification.
+                - If force_flush is yes, then this function will sync the trainer state to
+                  disk if the current state hasn't already been synced to disk since the
+                  last network modification.
         !*/
 
         const std::vector<solver_type>& get_solvers (

--- a/dlib/dnn/trainer_abstract.h
+++ b/dlib/dnn/trainer_abstract.h
@@ -14,6 +14,13 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    enum class force_flush_to_disk {
+        no = 0,
+        yes = 1
+    };
+
+// ----------------------------------------------------------------------------------------
+
     template <
         typename net_type, 
         typename solver_type = sgd
@@ -92,6 +99,7 @@ namespace dlib
         !*/
 
         net_type& get_net (
+            force_flush_to_disk force_flush_to_disk = force_flush_to_disk::yes
         ); 
         /*!
             ensures
@@ -102,8 +110,9 @@ namespace dlib
                   dnn_trainer's constructor.
                 - This function blocks until all threads inside the dnn_trainer have
                   stopped touching the net. 
-                - This function will sync the trainer state to disk if the current state 
-                  hasn't already been synced to disk since the last network modification.
+                - If force_flush_to_disk is yes, then this function will sync the trainer
+                  state to disk if the current state hasn't already been synced to disk
+                  since the last network modification.
         !*/
 
         const std::vector<solver_type>& get_solvers (


### PR DESCRIPTION
(see the discussion in #869)