### PR TITLE
Add some operator() to cv_image for compatibility with mmod loss.

### DIFF
--- a/dlib/opencv/cv_image.h
+++ b/dlib/opencv/cv_image.h
@@ -80,6 +80,32 @@ namespace dlib
             return reinterpret_cast<const pixel_type*>( _data + _widthStep*row);
         }
 
+        inline const pixel_type& operator()(const long row, const long column) const
+        {
+          DLIB_ASSERT(0<= column && column < nc(),
+              "\tcont pixel_type& cv_image::operator()(const long rown const long column)"
+              << "\n\t you have asked for an out of bounds column "
+              << "\n\t column: " << column
+              << "\n\t nc(): " << nc()
+              << "\n\t this:  " << this
+              );
+
+          return (*this)[row][column];
+        }
+
+        inline pixel_type& operator()(const long row, const long column)
+        {
+          DLIB_ASSERT(0<= column && column < nc(),
+              "\tcont pixel_type& cv_image::operator()(const long rown const long column)"
+              << "\n\t you have asked for an out of bounds column "
+              << "\n\t column: " << column
+              << "\n\t nc(): " << nc()
+              << "\n\t this:  " << this
+              );
+
+          return (*this)[row][column];
+        }
+
         long nr() const { return _nr; }
         long nc() const { return _nc; }
         long width_step() const { return _widthStep; }

--- a/dlib/opencv/cv_image_abstract.h
+++ b/dlib/opencv/cv_image_abstract.h
@@ -157,6 +157,30 @@ namespace dlib
                   of this image
         !*/
 
+        inline const pixel_type& operator()(
+            const long row, const long column
+        ) const
+        /*!
+            requires
+                - 0 <= row < nr()
+                - 0 <= column < nc()
+            ensures
+                - returns a const reference to the pixel at coordinates (row, column)
+                  of this image
+        !*/
+
+        inline pixel_type& operator()(
+            const long row, const long column
+        )
+        /*!
+            requires
+                - 0 <= row < nr()
+                - 0 <= column < nc()
+            ensures
+                - returns a reference to the pixel at coordinates (row, column)
+                  of this image
+        !*/
+
         cv_image& operator= ( 
             const cv_image& item
         );


### PR DESCRIPTION
Hi,

I designed a dnn using the mmod_loss and need to rely on a cv::Mat as input image. I may be wrong but when I tried to use the cv_image wrapper without extra copy, I got some errors about missing operators.

I fixed it, and it may be of interests for someone else.

Regards,
Gilles Rochefort

PS:
Here is a copy of the errors I got:
> In file included from 3rdparty/dlib/dlib-src/dlib/../dlib/dnn.h:13:
> 3rdparty/dlib/dlib-src/dlib/../dlib/dnn/input.h:622:33: error: type 'dlib::cv_image<dlib::bgr_pixel>' does not provide a call operator
>                         p[c] = (img(r,c).green-avg_green)/256.0;
>                                 ^~~
> 3rdparty/dlib/dlib-src/dlib/../dlib/dnn/input.h:632:33: error: type 'dlib::cv_image<dlib::bgr_pixel>' does not provide a call operator
>                         p[c] = (img(r,c).blue-avg_blue)/256.0;
>                                 ^~~
> 3 errors generated.