### PR TITLE
Missing interfaces in add_prev for compatibility with mmod loss.

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2078,6 +2078,9 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
+        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
+
         friend void serialize(const add_prev_& , std::ostream& out)
         {
             serialize("add_prev_", out);


### PR DESCRIPTION
Hi,

I should be wrong, but I got some errors when trying to use an add_prev layer with a mmod loss.
I fixed it and hope it could be usefull for someone else.

Regards,
Gilles Rochefort.

PS:
Following is a small snippet of the errors I got
> In file included from 3rdparty/dlib/dlib-src/dlib/../dlib/dnn/layers.h:15:
> 3rdparty/dlib/dlib-src/dlib/../dlib/dnn/utilities.h:218:41: error: no member named 'map_output_to_input'
>  in 'dlib::add_prev_<tag1>'
>                 p = net.layer_details().map_output_to_input(p);
>                     ~~~~~~~~~~~~~~~~~~~ ^
