### PR TITLE
Win lapack

### DIFF
--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -333,6 +333,35 @@ elseif(WIN32 AND NOT MINGW)
         endif()
     endif()
 
+    if (NOT blas_found)
+      find_package(blas)
+      if (${BLAS_FOUND})
+         set(blas_libraries ${BLAS_LIBRARIES})      
+         set(blas_found 1)
+         set(CMAKE_REQUIRED_LIBRARIES ${blas_libraries})
+         # If you compiled OpenBLAS with LAPACK in it then it should have the
+         # sgetrf_single function in it.  So if we find that function in
+         # OpenBLAS then just use OpenBLAS's LAPACK. 
+         CHECK_FUNCTION_EXISTS(sgetrf_single OPENBLAS_HAS_LAPACK)
+         if (OPENBLAS_HAS_LAPACK)
+            message(STATUS "Using OpenBLAS's built in LAPACK")
+            # set(lapack_libraries gfortran) 
+            set(lapack_found 1)
+         endif()
+      endif()
+   endif()
+
+
+   if (NOT lapack_found)
+      find_package(lapack)
+      message("~~~~~~~~~~~~~~> LAPACK: ${LAPACK_FOUND}")
+      if (${LAPACK_FOUND})
+         set(lapack_libraries ${LAPACK_LIBRARIES})
+         set(lapack_found 1)
+         message(STATUS "Found LAPACK library")
+      endif()
+   endif()
+
 
 endif()
 

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -354,7 +354,6 @@ elseif(WIN32 AND NOT MINGW)
 
    if (NOT lapack_found)
       find_package(lapack)
-      message("~~~~~~~~~~~~~~> LAPACK: ${LAPACK_FOUND}")
       if (${LAPACK_FOUND})
          set(lapack_libraries ${LAPACK_LIBRARIES})
          set(lapack_found 1)


### PR DESCRIPTION
On windows, it seems like the CMake build only looks for the Intel MKL versions of LAPACK and BLAS. This PR uses find_package to try and find LAPACK and BLAS. This is useful if you have installed these libraries via vcpkg, for example. 
