### PR TITLE
Remove explicit specification of library path in dlibConfig.cmake

### DIFF
--- a/dlib/cmake_utils/dlibConfig.cmake.in
+++ b/dlib/cmake_utils/dlibConfig.cmake.in
@@ -29,6 +29,7 @@ if(NOT TARGET dlib-shared AND NOT dlib_BINARY_DIR)
 endif()
 
 set(dlib_LIBRARIES dlib::dlib)
+set(dlib_LIBS      dlib::dlib)
 set(dlib_INCLUDE_DIRS "@CMAKE_INSTALL_FULL_INCLUDEDIR@" "@dlib_needed_includes@")
 
 mark_as_advanced(dlib_LIBRARIES)

--- a/dlib/cmake_utils/dlibConfig.cmake.in
+++ b/dlib/cmake_utils/dlibConfig.cmake.in
@@ -28,9 +28,7 @@ if(NOT TARGET dlib-shared AND NOT dlib_BINARY_DIR)
    include("${dlib_CMAKE_DIR}/dlib.cmake")
 endif()
 
-find_library(dlib_LIBRARIES dlib HINTS "@CMAKE_INSTALL_FULL_LIBDIR@")
-set(dlib_LIBRARIES ${dlib_LIBRARIES} "@dlib_needed_libraries@")
-set(dlib_LIBS      ${dlib_LIBRARIES} "@dlib_needed_libraries@")
+set(dlib_LIBRARIES dlib::dlib)
 set(dlib_INCLUDE_DIRS "@CMAKE_INSTALL_FULL_INCLUDEDIR@" "@dlib_needed_includes@")
 
 mark_as_advanced(dlib_LIBRARIES)


### PR DESCRIPTION
Currently, dlib hardcodes dlib_LIBRARIES in dlibConfig.cmake. This is not required as the library and dependencies will be picked up in a configuration dependent manner by dlib-{configuration}.cmake if dlib_LIBRARIES is set to dlib::dlib. The current approach means that different configurations (Release/Debug/...) cannot easily be installed side-by-side on Windows. 

This PR removes this hardcoded library path. I've tested that CMake successfully detects the library and dependencies on Windows 7 and macOS. 