### PR TITLE
Keep recent losses and current step counts when restoring previous state from disk

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1012,28 +1012,9 @@ namespace dlib
                 // previously saved state in the hopes that the problem won't reoccur.
                 if (loss_increased_since_last_disk_sync()) 
                 {
-                    // keep the loss values, because otherwise we might end up never shrinking the learning rate
-                    const auto previous_loss_values_to_keep = std::move(previous_loss_values);
-                    const auto test_previous_loss_values_to_keep = std::move(test_previous_loss_values);
-
-                    // keep also the step counts, in order to avoid confusion
-                    const auto train_one_step_calls_to_keep = train_one_step_calls;
-                    const auto test_one_step_calls_to_keep = test_one_step_calls;
-                    const unsigned long steps_without_progress_to_keep = steps_without_progress;
-                    const unsigned long test_steps_without_progress_to_keep = test_steps_without_progress;
-
                     std::ifstream fin(newest_syncfile(), std::ios::binary);
                     deserialize(*this, fin);
                     sync_file_reloaded = true;
-
-                    // restore the loss and the step count values
-                    previous_loss_values = std::move(previous_loss_values_to_keep);
-                    test_previous_loss_values = std::move(test_previous_loss_values_to_keep);
-                    train_one_step_calls = train_one_step_calls_to_keep;
-                    test_one_step_calls = test_one_step_calls_to_keep;
-                    steps_without_progress = steps_without_progress_to_keep;
-                    test_steps_without_progress = test_steps_without_progress_to_keep;
-
                     if (verbose)
                         std::cout << "Loss has been increasing, reloading saved state from " << newest_syncfile() << std::endl;
                 }

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1012,9 +1012,28 @@ namespace dlib
                 // previously saved state in the hopes that the problem won't reoccur.
                 if (loss_increased_since_last_disk_sync()) 
                 {
+                    // keep the loss values, because otherwise we might end up never shrinking the learning rate
+                    const auto previous_loss_values_to_keep = std::move(previous_loss_values);
+                    const auto test_previous_loss_values_to_keep = std::move(test_previous_loss_values);
+
+                    // keep also the step counts, in order to avoid confusion
+                    const auto train_one_step_calls_to_keep = train_one_step_calls;
+                    const auto test_one_step_calls_to_keep = test_one_step_calls;
+                    const unsigned long steps_without_progress_to_keep = steps_without_progress;
+                    const unsigned long test_steps_without_progress_to_keep = test_steps_without_progress;
+
                     std::ifstream fin(newest_syncfile(), std::ios::binary);
                     deserialize(*this, fin);
                     sync_file_reloaded = true;
+
+                    // restore the loss and the step count values
+                    previous_loss_values = std::move(previous_loss_values_to_keep);
+                    test_previous_loss_values = std::move(test_previous_loss_values_to_keep);
+                    train_one_step_calls = train_one_step_calls_to_keep;
+                    test_one_step_calls = test_one_step_calls_to_keep;
+                    steps_without_progress = steps_without_progress_to_keep;
+                    test_steps_without_progress = test_steps_without_progress_to_keep;
+
                     if (verbose)
                         std::cout << "Loss has been increasing, reloading saved state from " << newest_syncfile() << std::endl;
                 }

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1007,9 +1007,11 @@ namespace dlib
                 this->net.clean(); 
 
                 // if the loss has actually been going up since the last time we saved our
-                // state to disk then something has probably gone wrong in the
-                // optimization.  So in this case we do the opposite and recall the
-                // previously saved state in the hopes that the problem won't reoccur.
+                // state to disk then something has probably gone wrong in the optimization
+                // (for example, the trainer may have dropped the learning rate too early
+                // because of a sudden spike in loss). So in this case we do the opposite
+                // and recall the previously saved state in the hopes that the problem won't
+                // reoccur.
                 if (loss_increased_since_last_disk_sync()) 
                 {
                     std::ifstream fin(newest_syncfile(), std::ios::binary);


### PR DESCRIPTION
Problem: It happened to me that the training state was saved to disk when the previous loss values were quite low. After this, the loss generally started to go up. At the same time, I had `iterations_without_progress_threshold` set to a relatively high value, at least when compared to `time_between_syncs`, so the threshold was not reached before another sync-to-disk-call was due. Therefore, the learning rate wasn't shrunk, but instead the old state was restored from disk. Consequently, the learning rate never went down, and the process just kept restoring the old state from disk. (I guess it would have gone down at some point, with a probability of 1, but hey – life is short...)

Solution: When loading a previously saved training state from disk, do not load the previous loss values, but rather keep the values currently in memory. This way, we should eventually reach `iterations_without_progress_threshold`, shrink the learning rate, and get back on track.

To avoid confusion, also keep the step counts (not sure if this part is necessary / useful).