### PR TITLE
Adding missing implementation of tabbed_display::selected_tab

### DIFF
--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -1466,6 +1466,14 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     unsigned long tabbed_display::
+    selected_tab (
+    ) const
+    {
+        auto_mutex M(m);
+        return selected_tab_;
+    }
+
+    unsigned long tabbed_display::
     number_of_tabs (
     ) const
     {

--- a/dlib/gui_widgets/widgets.h
+++ b/dlib/gui_widgets/widgets.h
@@ -1190,6 +1190,9 @@ namespace dlib
             unsigned long num
         );
 
+        unsigned long selected_tab (
+        ) const;
+
         unsigned long number_of_tabs (
         ) const;
 


### PR DESCRIPTION
This pull request adds a few lines to provide a getter for the selected tab in a tabbed_display.

In [`dlib/gui_widgets/widgets_abstract.h:1115`](https://github.com/davisking/dlib/blob/acda88a5e3ec51e0880a15683fb75e07d8145261/dlib/gui_widgets/widgets_abstract.h#L1115) there is a getter for the currently selected tab in a tabbed_display. However, `widgets.h` and `widget.cpp` missed this, which I figured out when my code wouldn't link properly. 

Out of curiosity, what is the reason to have basically two almost identical header definitions of the tabbed_display, one in `widgets.h` and one in `widgets_abstract.h`? The latter seems not to be picked up by the compiler (without my changes in `widgets.h` the new function wouldn't compile) and seems to be there mostly for the documentation purpose?