### PR TITLE
Fixed type passing to opencv to use basic instead of aggregate.

### DIFF
--- a/dlib/opencv/to_open_cv.h
+++ b/dlib/opencv/to_open_cv.h
@@ -24,9 +24,10 @@ namespace dlib
             return cv::Mat();
 
         typedef typename image_traits<image_type>::pixel_type type;
-        if (pixel_traits<type>::num == 1)
+        typedef typename pixel_traits<type>::basic_pixel_type basic_pixel_type;
+	if (pixel_traits<type>::num == 1)
         {
-            return cv::Mat(num_rows(img), num_columns(img), cv::DataType<type>::type, image_data(img), width_step(img));
+            return cv::Mat(num_rows(img), num_columns(img), cv::DataType<basic_pixel_type>::type, image_data(img), width_step(img));
         }
         else
         {

--- a/dlib/opencv/to_open_cv.h
+++ b/dlib/opencv/to_open_cv.h
@@ -25,7 +25,7 @@ namespace dlib
 
         typedef typename image_traits<image_type>::pixel_type type;
         typedef typename pixel_traits<type>::basic_pixel_type basic_pixel_type;
-	if (pixel_traits<type>::num == 1)
+        if (pixel_traits<type>::num == 1)
         {
             return cv::Mat(num_rows(img), num_columns(img), cv::DataType<basic_pixel_type>::type, image_data(img), width_step(img));
         }


### PR DESCRIPTION
Prevent trying to send aggregate to cv::DataType when converting an image to opencv.

```
In file included from /home/pi/git/dlib/dlib/../dlib/opencv.h:11:0,
                 from /home/pi/git/FaceLibraries/FaceService/src/FaceService.cpp:21:
/home/pi/git/dlib/dlib/../dlib/opencv/to_open_cv.h: In instantiation of ‘cv::Mat dlib::toMat(image_type&) [with image_type = dlib::matrix<dlib::rgb_pixel>]’:
/home/pi/git/FaceLibraries/FaceService/src/FaceService.cpp:299:42:   required from here
/home/pi/git/dlib/dlib/../dlib/opencv/to_open_cv.h:29:24: error: ‘type’ is not a member of ‘cv::DataType<dlib::rgb_pixel>’
             return cv::Mat(num_rows(img), num_columns(img), cv::DataType<type>::type, image_data(img), width_step(img));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
