### PR TITLE
add chrono::duration_cast<>() cast for clang error

### DIFF
--- a/dlib/dir_nav/dir_nav_kernel_2.cpp
+++ b/dlib/dir_nav/dir_nav_kernel_2.cpp
@@ -66,7 +66,7 @@ namespace dlib
 
             state.last_modified = std::chrono::system_clock::from_time_t(buffer.st_mtime);
 #ifdef _BSD_SOURCE 
-            state.last_modified += std::chrono::nanoseconds(buffer.st_atim.tv_nsec);
+            state.last_modified += std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::nanoseconds(buffer.st_atim.tv_nsec));
 #endif
         }
 

--- a/dlib/dir_nav/dir_nav_kernel_2.h
+++ b/dlib/dir_nav/dir_nav_kernel_2.h
@@ -394,7 +394,7 @@ namespace dlib
                 }
                 auto last_modified = std::chrono::system_clock::from_time_t(buffer.st_mtime);
 #ifdef _BSD_SOURCE 
-                last_modified += std::chrono::duration_cast<std::chrono:system_clock::duration>(std::chrono::nanoseconds(buffer.st_atim.tv_nsec));
+                last_modified += std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::nanoseconds(buffer.st_atim.tv_nsec));
 #endif
 
                 if (S_ISDIR(buffer.st_mode) == 0)

--- a/dlib/dir_nav/dir_nav_kernel_2.h
+++ b/dlib/dir_nav/dir_nav_kernel_2.h
@@ -394,7 +394,7 @@ namespace dlib
                 }
                 auto last_modified = std::chrono::system_clock::from_time_t(buffer.st_mtime);
 #ifdef _BSD_SOURCE 
-                last_modified += std::chrono::nanoseconds(buffer.st_atim.tv_nsec);
+                last_modified += std::chrono::duration_cast<std::chrono:system_clock::duration>(std::chrono::nanoseconds(buffer.st_atim.tv_nsec));
 #endif
 
                 if (S_ISDIR(buffer.st_mode) == 0)


### PR DESCRIPTION
see: https://stackoverflow.com/a/18284105
tested: clang-3.9, clang-5.0
Error:
```
/Source/dlib/dir_nav/dir_nav_kernel_2.h:397:31: error: no viable overloaded '+='
                last_modified += std::chrono::nanoseconds(buffer.st_atim.tv_nsec);
                ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/chrono:782:43: note: candidate function not viable: no known conversion from 'duration<[...], ratio<[...], 1000000000>>' to 'const duration<[...], ratio<[...], 1000000>>' for 1st argument
    _LIBCPP_INLINE_VISIBILITY time_point& operator+=(const duration& __d) {__d_ += __d; return *this;}
                                          ^
Source/dlib/dir_nav/dir_nav_kernel_2.cpp:69:33: error: no viable overloaded '+='
            state.last_modified += std::chrono::nanoseconds(buffer.st_atim.tv_nsec);
            ~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/chrono:782:43: note: candidate function not viable: no known conversion from 'duration<[...], ratio<[...], 1000000000>>' to 'const duration<[...], ratio<[...], 1000000>>' for 1st argument
    _LIBCPP_INLINE_VISIBILITY time_point& operator+=(const duration& __d) {__d_ += __d; return *this;}
```