### PR TITLE
Make sure intel architecture is properly detected

### DIFF
--- a/dlib/cmake_utils/set_compiler_specific_options.cmake
+++ b/dlib/cmake_utils/set_compiler_specific_options.cmake
@@ -41,7 +41,7 @@ endif()
 
 
 set(gcc_like_compilers GNU Clang  Intel)
-set(intel_archs x86_64 i386 i686 AMD64 x86)
+set(intel_archs x86_64 i386 i686 AMD64 amd64 x86)
 
 
 # Setup some options to allow a user to enable SSE and AVX instruction use.  


### PR DESCRIPTION
On systems such as FreeBSD, `uname -p` returns amd64 (in lowercase) and `-DUSE_AVX_INSTRUCTIONS=1` does not work (the option is ignored).