### PR TITLE
>2x performance increase if DLIB_DO_NOT_USE_SIMD is defined

### DIFF
--- a/dlib/simd/simd8f.h
+++ b/dlib/simd/simd8f.h
@@ -125,8 +125,8 @@ namespace dlib
                 return _high[idx-4];
         }
 
-        inline simd4f low() const { return _low; }
-        inline simd4f high() const { return _high; }
+        inline const simd4f& low() const { return _low; }
+        inline const simd4f& high() const { return _high; }
 
     private:
         simd4f _low, _high;
@@ -141,8 +141,8 @@ namespace dlib
         inline simd8f_bool(const simd4f_bool& low_, const simd4f_bool& high_): _low(low_),_high(high_){}
 
 
-        inline simd4f_bool low() const { return _low; }
-        inline simd4f_bool high() const { return _high; }
+        inline const simd4f_bool& low() const { return _low; }
+        inline const simd4f_bool& high() const { return _high; }
     private:
         simd4f_bool _low,_high;
     };

--- a/dlib/simd/simd8i.h
+++ b/dlib/simd/simd8i.h
@@ -91,8 +91,8 @@ namespace dlib
                 return _high[idx-4];
         }
 
-        inline simd4i low() const { return _low; }
-        inline simd4i high() const { return _high; }
+        inline const simd4i& low() const { return _low; }
+        inline const simd4i& high() const { return _high; }
 
     private:
         simd4i _low, _high;


### PR DESCRIPTION
avoid excessive copying of simd4f structs by making low() & high() methods of simd8f struct return "const simd4f&"