### PR TITLE
CUDA_PROPAGATE_HOST_FLAGS=OFF in FindCUDA.cmake for try_compile tests

### DIFF
--- a/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
+++ b/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
@@ -5,6 +5,8 @@ project(cuda_test)
 include_directories(../../dnn)
 add_definitions(-DDLIB_USE_CUDA)
 
+# Override the FindCUDA.cmake setting to avoid duplication of host flags if using a toolchain:
+option(CUDA_PROPAGATE_HOST_FLAGS "Propage C/CXX_FLAGS and friends to the host compiler via -Xcompile" OFF)
 find_package(CUDA 7.5 REQUIRED)
 set(CUDA_HOST_COMPILATION_CPP ON)
 list(APPEND CUDA_NVCC_FLAGS "-arch=sm_30;-std=c++11;-D__STRICT_ANSI__;-D_MWAITXINTRIN_H_INCLUDED;-D_FORCE_INLINES")

--- a/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
+++ b/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(cudnn_test)
 include(../use_cpp_11.cmake)
 
+# Override the FindCUDA.cmake setting to avoid duplication of host flags if using a toolchain:
+option(CUDA_PROPAGATE_HOST_FLAGS "Propage C/CXX_FLAGS and friends to the host compiler via -Xcompile" OFF)
 find_package(CUDA 7.5 REQUIRED)
 set(CUDA_HOST_COMPILATION_CPP ON)
 list(APPEND CUDA_NVCC_FLAGS "-arch=sm_30;-std=c++11;-D__STRICT_ANSI__")


### PR DESCRIPTION
Set `CUDA_PROPAGATE_HOST_FLAGS=OFF` in FindCUDA.cmake to avoid duplicate flag errors in nvcc that can occur when host flag forwarding is enabled and `-std=c++11` is set in `CMAKE_CXX_FLAGS` in the active toolchain.

```
# Override the FindCUDA.cmake setting to avoid duplication of host flags if using a toolchain:
option(CUDA_PROPAGATE_HOST_FLAGS "Propage C/CXX_FLAGS and friends to the host compiler via -Xcompile" OFF)
```

This is a follow up to #674 and seems to be the simplest way of avoiding the problem.  It is related to this issue https://gitlab.kitware.com/cmake/cmake/merge_requests/1628, which includes a minimal test case.  I realized this is unlikely to occur if one isn't using a toolchain w/ `-std=c++11` for the build.  The only caveat I can see with this solution, is if one needs to cross compile for CUDA somehow in the future, or toolchain flags are needed for the CUDA tests.  On a related note, in the kitware discussion, it seems `cuda_add_library()` will be deprecated (by suggestion) in favor of native CUDA support (where this issue wouldn't show up), but this isn't yet supported for all platforms.
