### PR TITLE
Only define one dlib target in CMake and shared vs. static is determined by BUILD_SHARED_LIBS variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,35 @@ cmake_minimum_required(VERSION 2.8.12)
 
 
 
+
+#############################################################################
+#                                                                           #
+#  READ examples/CMakeLists.txt TO SEE HOW TO USE DLIB FROM C++ WITH CMAKE  #
+#                                                                           #
+#############################################################################
+
+
+
+
+
 get_directory_property(has_parent PARENT_DIRECTORY)
 if(NOT has_parent)
-   # Set this so that the dlib subfolder will build both a static and shared
-   # library, since the only reason to build this CMakeLists.txt by itself is
-   # if you want to install dlib.  It should be noted however that installing
-   # dlib is not necessary.  A simpler approach is to use it the way shown in
-   # examples/CMakeLists.txt 
+   # When you call add_subdirectory(dlib) from a parent CMake project dlib's
+   # CMake scripts will assume you want to statically compile dlib into
+   # whatever you are building rather than create a standalone copy of dlib.
+   # This means CMake will build dlib as a static library, disable dlib's
+   # install targets so they don't clutter your project, and adjust a few other
+   # minor things that are convenient when statically building dlib as part of
+   # your own projects.
+   #
+   # On the other hand, if there is no parent CMake project or if
+   # DLIB_IN_PROJECT_BUILD is set to false, CMake will compile dlib as a normal
+   # standalone library (either shared or static, based on the state of CMake's
+   # BUILD_SHARED_LIBS flag), and include the usual install targets so you can
+   # install dlib on your computer via `make install`.  Since the only reason
+   # to build this CMakeLists.txt (the one you are reading right now) by itself
+   # is if you want to install dlib, we indicate as such by setting
+   # DLIB_IN_PROJECT_BUILD to false.
    set(DLIB_IN_PROJECT_BUILD false)
 endif()
-
 add_subdirectory(dlib)

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -195,11 +195,7 @@ if (NOT TARGET dlib)
    set(dlib_needed_includes)
 
    if (DLIB_ISO_CPP_ONLY)
-       add_library(dlib STATIC ${source_files} )
-       if (UNIX AND NOT DLIB_IN_PROJECT_BUILD)
-           add_library(dlib_shared SHARED ${source_files} )
-           add_dependencies(dlib_shared dlib)
-       endif()
+       add_library(dlib ${source_files} )
    else()
 
       set(source_files ${source_files}
@@ -697,18 +693,9 @@ if (NOT TARGET dlib)
          # The old cuda_add_library() command doesn't support CMake's newer dependency
          # stuff, so we have to set the include path manually still, which we do here.
          include_directories(${dlib_needed_includes})
-         cuda_add_library(dlib STATIC ${source_files} )
+         cuda_add_library(dlib ${source_files} )
       else()
-         add_library(dlib STATIC ${source_files} )
-      endif()
-      if (UNIX AND NOT DLIB_IN_PROJECT_BUILD)
-         if (DLIB_USE_CUDA)
-            cuda_add_library(dlib_shared SHARED ${source_files} )
-            add_dependencies(dlib_shared dlib)
-         else()
-            add_library(dlib_shared SHARED ${source_files} )
-            add_dependencies(dlib_shared dlib)
-         endif()
+         add_library(dlib ${source_files} )
       endif()
 
    endif ()  ##### end of if NOT DLIB_ISO_CPP_ONLY ##########################################################
@@ -719,20 +706,11 @@ if (NOT TARGET dlib)
                               INTERFACE $<INSTALL_INTERFACE:include>
                               PUBLIC ${dlib_needed_includes}
                               )
-   target_link_libraries(dlib PRIVATE ${dlib_needed_libraries})
+   target_link_libraries(dlib PUBLIC ${dlib_needed_libraries})
    if (DLIB_IN_PROJECT_BUILD)
       target_compile_options(dlib PUBLIC ${active_preprocessor_switches})
    else()
       target_compile_options(dlib PRIVATE ${active_preprocessor_switches})
-   endif()
-   if (UNIX AND NOT DLIB_IN_PROJECT_BUILD)
-      target_include_directories(dlib_shared
-                                 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-                                 INTERFACE $<INSTALL_INTERFACE:include>
-                                 PUBLIC ${dlib_needed_includes}
-                                 )
-      target_link_libraries(dlib_shared PUBLIC ${dlib_needed_libraries})
-      target_compile_options(dlib_shared PRIVATE ${active_preprocessor_switches})
    endif()
 
 
@@ -748,29 +726,16 @@ if (NOT TARGET dlib)
       enable_cpp11_for_target(dlib)
       target_compile_options(dlib PUBLIC ${active_compile_opts})
    endif()
-   if (TARGET dlib_shared)
-      enable_cpp11_for_target(dlib_shared)
-      target_compile_options(dlib_shared PUBLIC ${active_compile_opts})
-   endif()
 
    # Install the library
    if (NOT DLIB_IN_PROJECT_BUILD)
-       if(UNIX)
-           set_target_properties(dlib_shared PROPERTIES
-                                        OUTPUT_NAME dlib 
-                                        VERSION ${VERSION})
-           install(TARGETS dlib dlib_shared
-                   EXPORT dlib 
-                   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # Windows (including cygwin) considers .dll to be runtime artifacts
-                   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-       else()
-           install(TARGETS dlib
-                   EXPORT dlib 
-                   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # Windows considers .dll to be runtime artifacts
-                   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-       endif()
+       set_target_properties(dlib PROPERTIES
+                                 VERSION ${VERSION})
+       install(TARGETS dlib
+               EXPORT dlib 
+               RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # Windows considers .dll to be runtime artifacts
+               LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+               ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dlib
                FILES_MATCHING PATTERN "*.h" PATTERN "*.cmake"

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -32,6 +32,31 @@ if(has_parent)
    endif()
 endif()
 
+
+if (DLIB_IN_PROJECT_BUILD)
+   # DLIB_IN_PROJECT_BUILD==true means you are using dlib by invoking
+   # add_subdirectory(dlib) in the parent project. In this case, we always want
+   # to build dlib as a static library so the parent project doesn't need to
+   # deal with some random dlib shared library file.  It is much better to
+   # statically compile dlib into the parent project.  So the following bit of
+   # CMake ensures that happens.  However, we have to take care to compile dlib
+   # with position independent code if appropriate (i.e. if the parent project
+   # is a shared library).
+   if (BUILD_SHARED_LIBS)
+      if (CMAKE_COMPILER_IS_GNUCXX)
+         # Just setting CMAKE_POSITION_INDEPENDENT_CODE should be enough to set
+         # -fPIC for GCC but sometimes it still doesn't get set, so make sure it
+         # does.
+         add_definitions("-fPIC")
+      endif()
+      set(CMAKE_POSITION_INDEPENDENT_CODE true)
+   endif()
+
+   # Tell cmake to build dlib as a static library
+   set(BUILD_SHARED_LIBS false)
+endif()
+
+
 if (CMAKE_VERSION VERSION_LESS "3.9.0")
    # Set only because there are old target_link_libraries() statements in the
    # FindCUDA.cmake file that comes with CMake that error out if the new behavior
@@ -710,6 +735,9 @@ if (NOT TARGET dlib)
    if (DLIB_IN_PROJECT_BUILD)
       target_compile_options(dlib PUBLIC ${active_preprocessor_switches})
    else()
+      # These are private in this case because they will be controlled by the
+      # contents of dlib/config.h once it's installed. But for in project
+      # builds, there is no real config.h so they are public in the above case.
       target_compile_options(dlib PRIVATE ${active_preprocessor_switches})
    endif()
 


### PR DESCRIPTION
This PR removes the dlib-shared CMake target and also causes the dlib CMake target to be either a shared or static library depending on the state of CMake's BUILD_SHARED_LIBS variable. Currently, the dlib target is always a static library.

There has been some discussion about this already: https://github.com/davisking/dlib/issues/923, @SoapGentoo, @xsacha, https://github.com/davisking/dlib/issues/1137, @kimwalisch.

This PR addresses some of the issues.  However, it isn't perfect. Here is one problematic case: Someone builds their own library via cmake and uses `add_subdirectory(dlib)` to add dlib as a dependency. They then set `BUILD_SHARED_LIBS=1` so that their library (and now dlib as well) are built as shared libraries. They then do `make install`, but since dlib's cmake files don't have an install target when invoked from a parent project via `add_subdirectory(dlib)` this user's install will be broken since it will be missing the dlib shared library files.

The obvious fix is to make dlib's CMake files always define install targets.  However, I am certain that would confuse and/or irritate many users who use `add_subdirectory(dlib)`. For example, people who don't set `BUILD_SHARED_LIBS=1` have no need to have any dlib files installed anywhere then they run `make install` on their own projects. To use a specific example, the dlib/tools/imglab program depends on dlib via `add_subdirectory(dlib)` and it would be inappropriate for `make install` of imglab to try to install dlib as well. It should install only imglab. In addition to this being just weird and irritating for experienced C++ users, I'm very confident I would get lots of questions from inexperienced users who are simply confused and assume they are supposed to do something with the static dlib library files and headers that cmake would be trying to install in this situation. 

Another option is to cause any project that depends on dlib via `add_subdirectory(dlib)` to build dlib as static library regardless of the state of BUILD_SHARED_LIBS. I think this is the best option.  However, it has the downside that a top level cmake file that merely aggregates many cmake projects together so that they can all be `make installed` with one command will not work as expected. There doesn't seem to be a way in cmake to distinguish between the two cases (1) someone using `add_subdirectory(dlib)` to get the `dlib::dlib` target to link to vs (2) someone using `add_subdirectory(dlib)` for meere cmake project aggregation. 

I'm not sure we care about project aggregation. Is there a reason to care about this case?

