### PR TITLE
Problem: integer overflow when calculating sizes (may happen e.g. with very large images)

### DIFF
--- a/dlib/array/array_kernel.h
+++ b/dlib/array/array_kernel.h
@@ -245,11 +245,12 @@ namespace dlib
     {
         try
         {
-            // This is probably the least likely value for a max_size from an old version.
+            // This is probably the least likely value for a max_size from an old version,
+            // from among numbers that are guaranteed to be representable using unsigned long.
             // TODO: start version numbering from 1, when it can be reasonably expected that
             //       there aren't too many objects around any longer serialized without any
             //       version number (but directly a max_size).
-            const unsigned long version = std::numeric_limits<unsigned long>::max();
+            const unsigned long version = 4294967295;
 
             serialize(version,out);
 
@@ -279,7 +280,7 @@ namespace dlib
             unsigned long version;
             deserialize(version, in);
 
-            if (version != std::numeric_limits<unsigned long>::max()) {
+            if (version != 4294967295) {
                 // old version - the "version" field is actually max_size, serialized as unsigned long
                 //             - also size is serialized as unsigned long
                 // TODO: remove this branch completely, when backward compatibility is no longer needed

--- a/dlib/array/array_kernel.h
+++ b/dlib/array/array_kernel.h
@@ -245,15 +245,6 @@ namespace dlib
     {
         try
         {
-            // This is probably the least likely value for a max_size from an old version,
-            // from among numbers that are guaranteed to be representable using unsigned long.
-            // TODO: start version numbering from 1, when it can be reasonably expected that
-            //       there aren't too many objects around any longer serialized without any
-            //       version number (but directly a max_size).
-            const unsigned long version = 4294967295;
-
-            serialize(version,out);
-
             serialize(item.max_size(),out);
             serialize(item.size(),out);
 
@@ -277,29 +268,13 @@ namespace dlib
     {
         try
         {
-            unsigned long version;
-            deserialize(version, in);
-
-            if (version != 4294967295) {
-                // old version - the "version" field is actually max_size, serialized as unsigned long
-                //             - also size is serialized as unsigned long
-                // TODO: remove this branch completely, when backward compatibility is no longer needed
-                unsigned long max_size = version, size;
-                deserialize(size, in);
-                item.set_max_size(max_size);
-                item.set_size(size);
-                for (unsigned long i = 0; i < size; ++i)
-                    deserialize(item[i], in);
-            }
-            else {
-                size_t max_size, size;
-                deserialize(max_size, in);
-                deserialize(size, in);
-                item.set_max_size(max_size);
-                item.set_size(size);
-                for (size_t i = 0; i < size; ++i)
-                    deserialize(item[i], in);
-            }
+            size_t max_size, size;
+            deserialize(max_size,in);
+            deserialize(size,in);
+            item.set_max_size(max_size);
+            item.set_size(size);
+            for (size_t i = 0; i < size; ++i)
+                deserialize(item[i],in);
         }
         catch (serialization_error e)
         { 

--- a/dlib/array/array_kernel.h
+++ b/dlib/array/array_kernel.h
@@ -106,7 +106,7 @@ namespace dlib
         }
 
         explicit array (
-            unsigned long new_size
+            size_t new_size
         ) :
             array_size(0),
             max_array_size(0),
@@ -125,22 +125,22 @@ namespace dlib
         );
 
         inline const T& operator[] (
-            unsigned long pos
+            size_t pos
         ) const;
 
         inline T& operator[] (
-            unsigned long pos
+            size_t pos
         );
 
         void set_size (
-            unsigned long size
+            size_t size
         );
 
-        inline unsigned long max_size(
+        inline size_t max_size(
         ) const;
 
         void set_max_size(
-            unsigned long max
+            size_t max
         );
 
         void swap (
@@ -148,7 +148,7 @@ namespace dlib
         );
 
         // functions from the enumerable interface
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline bool at_start (
@@ -173,7 +173,7 @@ namespace dlib
         );
 
         void resize (
-            unsigned long new_size
+            size_t new_size
         );
 
         const T& back (
@@ -209,8 +209,8 @@ namespace dlib
         typename mem_manager::template rebind<T>::other pool;
 
         // data members
-        unsigned long array_size;
-        unsigned long max_array_size;
+        size_t array_size;
+        size_t max_array_size;
         T* array_elements;
 
         mutable T* pos;
@@ -245,10 +245,18 @@ namespace dlib
     {
         try
         {
+            // This is probably the least likely value for a max_size from an old version.
+            // TODO: start version numbering from 1, when it can be reasonably expected that
+            //       there aren't too many objects around any longer serialized without any
+            //       version number (but directly a max_size).
+            const unsigned long version = std::numeric_limits<unsigned long>::max();
+
+            serialize(version,out);
+
             serialize(item.max_size(),out);
             serialize(item.size(),out);
 
-            for (unsigned long i = 0; i < item.size(); ++i)
+            for (size_t i = 0; i < item.size(); ++i)
                 serialize(item[i],out);
         }
         catch (serialization_error e)
@@ -268,13 +276,29 @@ namespace dlib
     {
         try
         {
-            unsigned long max_size, size;
-            deserialize(max_size,in);
-            deserialize(size,in);
-            item.set_max_size(max_size);
-            item.set_size(size);
-            for (unsigned long i = 0; i < size; ++i)
-                deserialize(item[i],in);
+            unsigned long version;
+            deserialize(version, in);
+
+            if (version != std::numeric_limits<unsigned long>::max()) {
+                // old version - the "version" field is actually max_size, serialized as unsigned long
+                //             - also size is serialized as unsigned long
+                // TODO: remove this branch completely, when backward compatibility is no longer needed
+                unsigned long max_size = version, size;
+                deserialize(size, in);
+                item.set_max_size(max_size);
+                item.set_size(size);
+                for (unsigned long i = 0; i < size; ++i)
+                    deserialize(item[i], in);
+            }
+            else {
+                size_t max_size, size;
+                deserialize(max_size, in);
+                deserialize(size, in);
+                item.set_max_size(max_size);
+                item.set_size(size);
+                for (size_t i = 0; i < size; ++i)
+                    deserialize(item[i], in);
+            }
         }
         catch (serialization_error e)
         { 
@@ -333,7 +357,7 @@ namespace dlib
         >
     const T& array<T,mem_manager>::
     operator[] (
-        unsigned long pos
+        size_t pos
     ) const
     {
         // make sure requires clause is not broken
@@ -356,7 +380,7 @@ namespace dlib
         >
     T& array<T,mem_manager>::
     operator[] (
-        unsigned long pos
+        size_t pos
     ) 
     {
         // make sure requires clause is not broken
@@ -379,7 +403,7 @@ namespace dlib
         >
     void array<T,mem_manager>::
     set_size (
-        unsigned long size
+        size_t size
     )
     {
         // make sure requires clause is not broken
@@ -405,7 +429,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long array<T,mem_manager>::
+    size_t array<T,mem_manager>::
     size (
     ) const
     {
@@ -420,7 +444,7 @@ namespace dlib
         >
     void array<T,mem_manager>::
     set_max_size(
-        unsigned long max
+        size_t max
     )
     {
         reset();
@@ -458,7 +482,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long array<T,mem_manager>::
+    size_t array<T,mem_manager>::
     max_size (
     ) const
     {
@@ -476,8 +500,8 @@ namespace dlib
         array<T,mem_manager>& item
     )
     {
-        unsigned long    array_size_temp        = item.array_size;
-        unsigned long    max_array_size_temp    = item.max_array_size;
+        auto             array_size_temp        = item.array_size;
+        auto             max_array_size_temp    = item.max_array_size;
         T*               array_elements_temp    = item.array_elements;
 
         item.array_size         = array_size;
@@ -646,7 +670,7 @@ namespace dlib
         >
     void array<T,mem_manager>::
     resize (
-        unsigned long new_size
+        size_t new_size
     )
     {
         if (this->max_size() < new_size)
@@ -654,7 +678,7 @@ namespace dlib
             array temp;
             temp.set_max_size(new_size);
             temp.set_size(new_size);
-            for (unsigned long i = 0; i < this->size(); ++i)
+            for (size_t i = 0; i < this->size(); ++i)
             {
                 exchange((*this)[i],temp[i]);
             }
@@ -769,7 +793,7 @@ namespace dlib
             array temp;
             temp.set_max_size(this->size()*2 + 1);
             temp.set_size(this->size()+1);
-            for (unsigned long i = 0; i < this->size(); ++i)
+            for (size_t i = 0; i < this->size(); ++i)
             {
                 exchange((*this)[i],temp[i]);
             }

--- a/dlib/array/array_kernel_abstract.h
+++ b/dlib/array/array_kernel_abstract.h
@@ -66,7 +66,7 @@ namespace dlib
             !*/
 
             explicit array (
-                unsigned long new_size
+                size_t new_size
             );
             /*!
                 ensures 
@@ -116,7 +116,7 @@ namespace dlib
             !*/
 
             const T& operator[] (
-                unsigned long pos
+                size_t pos
             ) const;
             /*!
                 requires
@@ -126,7 +126,7 @@ namespace dlib
             !*/
             
             T& operator[] (
-                unsigned long pos
+                size_t pos
             );
             /*!
                 requires
@@ -136,7 +136,7 @@ namespace dlib
             !*/
 
             void set_size (
-                unsigned long size
+                size_t size
             );
             /*!
                 requires
@@ -155,7 +155,7 @@ namespace dlib
                         if it does throw then the call to set_size() has no effect    
             !*/
 
-            unsigned long max_size(
+            size_t max_size(
             ) const;
             /*!
                 ensures
@@ -163,7 +163,7 @@ namespace dlib
             !*/
 
             void set_max_size(
-                unsigned long max
+                size_t max
             );
             /*!
                 ensures
@@ -198,7 +198,7 @@ namespace dlib
             !*/
 
             void resize (
-                unsigned long new_size
+                size_t new_size
             );
             /*!
                 ensures

--- a/dlib/array2d/array2d_kernel.h
+++ b/dlib/array2d/array2d_kernel.h
@@ -312,8 +312,8 @@ namespace dlib
             }
         }
 
-        unsigned long size (
-        ) const { return static_cast<unsigned long>(nc_ * nr_); }
+        size_t size (
+        ) const { return static_cast<size_t>(nc_) * static_cast<size_t>(nr_); }
 
         long width_step (
         ) const

--- a/dlib/bayes_utils/bayes_utils.h
+++ b/dlib/bayes_utils/bayes_utils.h
@@ -356,7 +356,7 @@ namespace dlib
             table.clear();
         }
 
-        unsigned long size () const { return table.size(); }
+        size_t size () const { return table.size(); }
         bool move_next() const { return table.move_next(); }
         void reset() const { table.reset(); }
         map_pair<assignment,double>& element() 

--- a/dlib/binary_search_tree/binary_search_tree_kernel_1.h
+++ b/dlib/binary_search_tree/binary_search_tree_kernel_1.h
@@ -168,7 +168,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             bool at_start (
@@ -597,7 +597,7 @@ namespace dlib
         typename mem_manager,
         typename compare
         >   
-    unsigned long binary_search_tree_kernel_1<domain,range,mem_manager,compare>::
+    size_t binary_search_tree_kernel_1<domain,range,mem_manager,compare>::
     size (
     ) const
     {

--- a/dlib/binary_search_tree/binary_search_tree_kernel_2.h
+++ b/dlib/binary_search_tree/binary_search_tree_kernel_2.h
@@ -169,7 +169,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             bool at_start (
@@ -543,7 +543,7 @@ namespace dlib
         typename mem_manager,
         typename compare
         >
-    unsigned long binary_search_tree_kernel_2<domain,range,mem_manager,compare>::
+    size_t binary_search_tree_kernel_2<domain,range,mem_manager,compare>::
     size (
     ) const
     {

--- a/dlib/cmd_line_parser/cmd_line_parser_kernel_1.h
+++ b/dlib/cmd_line_parser/cmd_line_parser_kernel_1.h
@@ -305,7 +305,7 @@ namespace dlib
         bool move_next (
         ) const { return options.move_next(); }
 
-        unsigned long size (
+        size_t size (
         ) const { return options.size(); }
 
     private:

--- a/dlib/disjoint_subsets/disjoint_subsets.h
+++ b/dlib/disjoint_subsets/disjoint_subsets.h
@@ -34,7 +34,7 @@ namespace dlib
             }
         }
 
-        unsigned long size (
+        size_t size (
         ) const noexcept
         {
             return items.size();

--- a/dlib/disjoint_subsets/disjoint_subsets_abstract.h
+++ b/dlib/disjoint_subsets/disjoint_subsets_abstract.h
@@ -44,7 +44,7 @@ namespace dlib
                       (i.e. this object contains new_size subsets, each containing exactly one element)
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const noexcept;
         /*!
             ensures

--- a/dlib/disjoint_subsets/disjoint_subsets_sized.h
+++ b/dlib/disjoint_subsets/disjoint_subsets_sized.h
@@ -34,7 +34,7 @@ namespace dlib
             number_of_sets = new_size;
         }
 
-        unsigned long size (
+        size_t size (
         ) const noexcept
         {
             return disjoint_subsets_.size();

--- a/dlib/disjoint_subsets/disjoint_subsets_sized_abstract.h
+++ b/dlib/disjoint_subsets/disjoint_subsets_sized_abstract.h
@@ -50,7 +50,7 @@ namespace dlib
                     - #get_size_of_set(i) == 1
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const noexcept;
         /*!
             ensures

--- a/dlib/dnn/cpu_dlib.cpp
+++ b/dlib/dnn/cpu_dlib.cpp
@@ -1639,11 +1639,11 @@ namespace dlib
             float* g = grad.host();
             const float x_scale = (grad.nc()-1)/(float)std::max<long>((gradient_input.nc()-1),1);
             const float y_scale = (grad.nr()-1)/(float)std::max<long>((gradient_input.nr()-1),1);
-            for (long samp = 0; samp < gradient_input.num_samples(); ++samp)
+            for (long long samp = 0; samp < gradient_input.num_samples(); ++samp)
             {
-                for (long k = 0; k < gradient_input.k(); ++k)
+                for (long long k = 0; k < gradient_input.k(); ++k)
                 {
-                    for (long r = 0; r < gradient_input.nr(); ++r)
+                    for (long long r = 0; r < gradient_input.nr(); ++r)
                     {
                         const float y = r*y_scale;
                         const long long top    = static_cast<long long>(std::floor(y));

--- a/dlib/dnn/cpu_dlib.cpp
+++ b/dlib/dnn/cpu_dlib.cpp
@@ -1646,14 +1646,14 @@ namespace dlib
                     for (long r = 0; r < gradient_input.nr(); ++r)
                     {
                         const float y = r*y_scale;
-                        const long top    = static_cast<long>(std::floor(y));
-                        const long bottom = std::min(top+1, grad.nr()-1);
+                        const long long top    = static_cast<long>(std::floor(y));
+                        const long long bottom = std::min(top+1, grad.nr()-1);
                         const float tb_frac = y - top;
-                        for (long c = 0; c < gradient_input.nc(); ++c)
+                        for (long long c = 0; c < gradient_input.nc(); ++c)
                         {
                             const float x = c*x_scale;
-                            const long left   = static_cast<long>(std::floor(x));
-                            const long right  = std::min(left+1, grad.nc()-1);
+                            const long long left   = static_cast<long>(std::floor(x));
+                            const long long right  = std::min(left+1, grad.nc()-1);
                             const float lr_frac = x - left;
 
                             const float tmp = gi[r*gradient_input_row_stride+c];

--- a/dlib/dnn/tensor.h
+++ b/dlib/dnn/tensor.h
@@ -205,7 +205,7 @@ namespace dlib
         long m_k;
         long m_nr;
         long m_nc;
-        size_t m_size; // always equal to m_n*m_k*m_nr*m_nc
+        long long m_size; // always equal to m_n*m_k*m_nr*m_nc
     };
 
 // ----------------------------------------------------------------------------------------
@@ -386,7 +386,7 @@ namespace dlib
             m_k = k_;
             m_nr = nr_;
             m_nc = nc_;
-            m_size = static_cast<size_t>(n_) * static_cast<size_t>(k_) * static_cast<size_t>(nr_) * static_cast<size_t>(nc_);
+            m_size = static_cast<long long>(n_) * static_cast<long long>(k_) * static_cast<long long>(nr_) * static_cast<long long>(nc_);
             if ((long)data_instance.size() < m_size)
                 data_instance.set_size(m_size);
 #ifdef DLIB_USE_CUDA

--- a/dlib/dnn/tensor.h
+++ b/dlib/dnn/tensor.h
@@ -45,10 +45,10 @@ namespace dlib
 
         virtual ~tensor() {}
 
-        long num_samples() const { return m_n; }
-        long k() const { return m_k; }
-        long nr() const { return m_nr; }
-        long nc() const { return m_nc; }
+        long long num_samples() const { return m_n; }
+        long long k() const { return m_k; }
+        long long nr() const { return m_nr; }
+        long long nc() const { return m_nc; }
         size_t size() const { return m_size; }
 
         typedef float* iterator;
@@ -150,11 +150,11 @@ namespace dlib
 
         template <typename EXP>
         void set_sample (
-            unsigned long idx,
+            unsigned long long idx,
             const matrix_exp<EXP>& item
         )
         {
-            DLIB_CASSERT(idx < (unsigned long)num_samples());
+            DLIB_CASSERT(idx < (unsigned long long)num_samples());
             DLIB_CASSERT(item.size() == nr()*nc()*k());
             static_assert((is_same_type<float, typename EXP::type>::value == true),
                 "To assign a matrix to a tensor the matrix must contain float values");
@@ -164,11 +164,11 @@ namespace dlib
 
         template <typename EXP>
         void add_to_sample (
-            unsigned long idx,
+            unsigned long long idx,
             const matrix_exp<EXP>& item
         )
         {
-            DLIB_CASSERT(idx < (unsigned long)num_samples());
+            DLIB_CASSERT(idx < (unsigned long long)num_samples());
             DLIB_CASSERT(item.size() == nr()*nc()*k());
             static_assert((is_same_type<float, typename EXP::type>::value == true),
                 "To assign a matrix to a tensor the matrix must contain float values");
@@ -201,10 +201,10 @@ namespace dlib
         virtual const gpu_data& data() const = 0;
         virtual size_t get_alias_offset() const { return 0; } // needed by alias_tensor.
 
-        long m_n;
-        long m_k;
-        long m_nr;
-        long m_nc;
+        long long m_n;
+        long long m_k;
+        long long m_nr;
+        long long m_nc;
         long long m_size; // always equal to m_n*m_k*m_nr*m_nc
     };
 
@@ -224,8 +224,8 @@ namespace dlib
 
     inline const matrix_op<op_pointer_to_mat<float> > mat (
         const tensor& t,
-        long nr,
-        long nc
+        long long nr,
+        long long nc
     )
     {
         DLIB_ASSERT(nr >= 0 && nc >= 0 , 
@@ -234,7 +234,7 @@ namespace dlib
                     << "\n\t nr: " << nr
                     << "\n\t nc: " << nc
         );
-        DLIB_ASSERT(nr*nc == (long)t.size() , 
+        DLIB_ASSERT(nr*nc == (long long)t.size() , 
                     "\tconst matrix_exp mat(tensor, nr, nc)"
                     << "\n\t The sizes don't match up."
                     << "\n\t nr*nc:    " << nr*nc
@@ -256,8 +256,8 @@ namespace dlib
 
     inline const matrix_op<op_pointer_to_mat<float> > image_plane (
         const tensor& t,
-        long sample = 0,
-        long k = 0
+        long long sample = 0,
+        long long k = 0
     )
     {
         DLIB_ASSERT(0 <= sample && sample < t.num_samples() &&
@@ -311,7 +311,7 @@ namespace dlib
         }
 
         explicit resizable_tensor(
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         ) 
         {
             DLIB_ASSERT( n_ >= 0 && k_ >= 0 && nr_ >= 0 && nc_ >= 0);
@@ -377,7 +377,7 @@ namespace dlib
         }
 
         void set_size(
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         )
         {
             DLIB_ASSERT( n_ >= 0 && k_ >= 0 && nr_ >= 0 && nc_ >= 0);
@@ -386,8 +386,8 @@ namespace dlib
             m_k = k_;
             m_nr = nr_;
             m_nc = nc_;
-            m_size = static_cast<long long>(n_) * static_cast<long long>(k_) * static_cast<long long>(nr_) * static_cast<long long>(nc_);
-            if ((long)data_instance.size() < m_size)
+            m_size = n_*k_*nr_*nc_;
+            if ((long long)data_instance.size() < m_size)
                 data_instance.set_size(m_size);
 #ifdef DLIB_USE_CUDA
             cudnn_descriptor.set_size(m_n,m_k,m_nr,m_nc);
@@ -472,7 +472,7 @@ namespace dlib
         if (version != 2)
             throw serialization_error("Unexpected version found while deserializing dlib::resizable_tensor.");
 
-        long num_samples=0, k=0, nr=0, nc=0;
+        long long num_samples=0, k=0, nr=0, nc=0;
         deserialize(num_samples, in);
         deserialize(k, in);
         deserialize(nr, in);
@@ -588,7 +588,7 @@ namespace dlib
         ) {}
 
         alias_tensor (
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         ) 
         {
             DLIB_ASSERT( n_ >= 0 && k_ >= 0 && nr_ >= 0 && nc_ >= 0);
@@ -600,16 +600,16 @@ namespace dlib
             inst.m_size = n_*k_*nr_*nc_;
         }
 
-        long num_samples(
+        long long num_samples(
         ) const { return inst.m_n; }
 
-        long k(
+        long long k(
         ) const { return inst.m_k; }
 
-        long nr(
+        long long nr(
         ) const { return inst.m_nr; }
 
-        long nc(
+        long long nc(
         ) const { return inst.m_nc; }
 
         size_t size(
@@ -670,7 +670,7 @@ namespace dlib
         deserialize(version, in);
         if (version != 1)
             throw serialization_error("Unexpected version found while deserializing dlib::alias_tensor.");
-        long num_samples, k, nr, nc;
+        long long num_samples, k, nr, nc;
         deserialize(num_samples, in);
         deserialize(k, in);
         deserialize(nr, in);

--- a/dlib/dnn/tensor.h
+++ b/dlib/dnn/tensor.h
@@ -205,7 +205,7 @@ namespace dlib
         long m_k;
         long m_nr;
         long m_nc;
-        long m_size; // always equal to m_n*m_k*m_nr*m_nc
+        size_t m_size; // always equal to m_n*m_k*m_nr*m_nc
     };
 
 // ----------------------------------------------------------------------------------------
@@ -386,7 +386,7 @@ namespace dlib
             m_k = k_;
             m_nr = nr_;
             m_nc = nc_;
-            m_size = n_*k_*nr_*nc_;
+            m_size = static_cast<size_t>(n_) * static_cast<size_t>(k_) * static_cast<size_t>(nr_) * static_cast<size_t>(nc_);
             if ((long)data_instance.size() < m_size)
                 data_instance.set_size(m_size);
 #ifdef DLIB_USE_CUDA

--- a/dlib/dnn/tensor_abstract.h
+++ b/dlib/dnn/tensor_abstract.h
@@ -46,7 +46,7 @@ namespace dlib
 
         virtual ~tensor();
 
-        long num_samples(
+        long long num_samples(
         ) const; 
         /*!
             ensures
@@ -54,7 +54,7 @@ namespace dlib
                   are in this object.  
         !*/
 
-        long k(
+        long long k(
         ) const; 
         /*!
             ensures
@@ -63,14 +63,14 @@ namespace dlib
                   with k() channels.
         !*/
 
-        long nr(
+        long long nr(
         ) const; 
         /*!
             ensures
                 - returns the number of rows in this tensor.
         !*/
 
-        long nc(
+        long long nc(
         ) const; 
         /*!
             ensures
@@ -288,7 +288,7 @@ namespace dlib
 
         template <typename EXP>
         void set_sample (
-            unsigned long idx,
+            unsigned long long idx,
             const matrix_exp<EXP>& item
         );
         /*!
@@ -304,7 +304,7 @@ namespace dlib
 
         template <typename EXP>
         void add_to_sample (
-            unsigned long idx,
+            unsigned long long idx,
             const matrix_exp<EXP>& item
         );
         /*!
@@ -363,8 +363,8 @@ namespace dlib
 
     const matrix_exp mat (
         const tensor& t,
-        long nr,
-        long nc
+        long long nr,
+        long long nc
     );
     /*!
         requires
@@ -394,8 +394,8 @@ namespace dlib
 
     const matrix_exp image_plane (
         const tensor& t,
-        long sample = 0,
-        long k = 0
+        long long sample = 0,
+        long long k = 0
     );
     /*!
         requires
@@ -467,7 +467,7 @@ namespace dlib
         !*/
 
         explicit resizable_tensor(
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         );
         /*!
             requires
@@ -524,7 +524,7 @@ namespace dlib
         !*/
 
         void set_size(
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         );
         /*!
             requires
@@ -656,7 +656,7 @@ namespace dlib
         !*/
 
         alias_tensor (
-            long n_, long k_ = 1, long nr_ = 1, long nc_ = 1
+            long long n_, long long k_ = 1, long long nr_ = 1, long long nc_ = 1
         );
         /*!
             requires
@@ -672,10 +672,10 @@ namespace dlib
                 - #nc() == nc_
         !*/
 
-        long num_samples() const; 
-        long k() const; 
-        long nr() const; 
-        long nc() const; 
+        long long num_samples() const;
+        long long k() const;
+        long long nr() const;
+        long long nc() const;
         size_t size() const;
 
         alias_tensor_instance operator() (

--- a/dlib/geometry/border_enumerator.h
+++ b/dlib/geometry/border_enumerator.h
@@ -125,7 +125,7 @@ namespace dlib
             return false;
         }
 
-        unsigned long size (
+        size_t size (
         ) const
         {
             return rect.area() - inner_rect.area();

--- a/dlib/geometry/border_enumerator_abstract.h
+++ b/dlib/geometry/border_enumerator_abstract.h
@@ -99,7 +99,7 @@ namespace dlib
                 - returns false if there are no more elements in the container
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/gui_widgets/base_widgets.cpp
+++ b/dlib/gui_widgets/base_widgets.cpp
@@ -1399,7 +1399,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    unsigned long widget_group::
+    size_t widget_group::
     size (
     ) const 
     {  
@@ -1578,7 +1578,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    unsigned long popup_menu::
+    size_t popup_menu::
     size (
     ) const
     { 

--- a/dlib/gui_widgets/base_widgets.h
+++ b/dlib/gui_widgets/base_widgets.h
@@ -329,7 +329,7 @@ namespace dlib
             const drawable& widget
         );
 
-        unsigned long size (
+        size_t size (
         ) const; 
 
         void set_pos (
@@ -2039,7 +2039,7 @@ namespace dlib
             unsigned long idx
         );
 
-        unsigned long size (
+        size_t size (
         ) const;
 
         void clear (

--- a/dlib/gui_widgets/base_widgets_abstract.h
+++ b/dlib/gui_widgets/base_widgets_abstract.h
@@ -967,7 +967,7 @@ namespace dlib
                       widgets in this group and the upper left corner of get_rect(). 
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures
@@ -1561,7 +1561,7 @@ namespace dlib
                 - the menu_item in this with the index idx has been disabled
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -2470,7 +2470,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename S>
-    unsigned long list_box<S>::
+    size_t list_box<S>::
     size (
     ) const
     {

--- a/dlib/gui_widgets/widgets.h
+++ b/dlib/gui_widgets/widgets.h
@@ -1792,7 +1792,7 @@ namespace dlib
         bool move_next (
         ) const;
 
-        unsigned long size (
+        size_t size (
         ) const;
 
         unsigned long get_selected (

--- a/dlib/hash_map/hash_map_kernel_1.h
+++ b/dlib/hash_map/hash_map_kernel_1.h
@@ -100,7 +100,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (

--- a/dlib/hash_map/hash_map_kernel_1.h
+++ b/dlib/hash_map/hash_map_kernel_1.h
@@ -328,7 +328,7 @@ namespace dlib
         typename hash_table,
         typename mem_manager
         >
-    unsigned long hash_map_kernel_1<domain,range,expnum,hash_table,mem_manager>::
+    size_t hash_map_kernel_1<domain,range,expnum,hash_table,mem_manager>::
     size (
     ) const
     {

--- a/dlib/hash_set/hash_set_kernel_1.h
+++ b/dlib/hash_set/hash_set_kernel_1.h
@@ -266,7 +266,7 @@ namespace dlib
         typename hash_table,
         typename mem_manager
         >
-    unsigned long hash_set_kernel_1<T,expnum,hash_table,mem_manager>::
+    size_t hash_set_kernel_1<T,expnum,hash_table,mem_manager>::
     size (
     ) const
     {

--- a/dlib/hash_set/hash_set_kernel_1.h
+++ b/dlib/hash_set/hash_set_kernel_1.h
@@ -85,7 +85,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (

--- a/dlib/hash_table/hash_table_kernel_1.h
+++ b/dlib/hash_table/hash_table_kernel_1.h
@@ -145,7 +145,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             bool at_start (

--- a/dlib/hash_table/hash_table_kernel_1.h
+++ b/dlib/hash_table/hash_table_kernel_1.h
@@ -336,7 +336,7 @@ namespace dlib
         typename mem_manager,
         typename compare
         >
-    unsigned long hash_table_kernel_1<domain,range,mem_manager,compare>::
+    size_t hash_table_kernel_1<domain,range,mem_manager,compare>::
     size(
     ) const
     {

--- a/dlib/hash_table/hash_table_kernel_2.h
+++ b/dlib/hash_table/hash_table_kernel_2.h
@@ -266,7 +266,7 @@ namespace dlib
         typename mem_manager,
         typename compare
         >
-    unsigned long hash_table_kernel_2<domain,range,bst_base,mem_manager,compare>::
+    size_t hash_table_kernel_2<domain,range,bst_base,mem_manager,compare>::
     size(
     ) const
     {

--- a/dlib/hash_table/hash_table_kernel_2.h
+++ b/dlib/hash_table/hash_table_kernel_2.h
@@ -116,7 +116,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (

--- a/dlib/image_keypoint/binned_vector_feature_image.h
+++ b/dlib/image_keypoint/binned_vector_feature_image.h
@@ -55,7 +55,7 @@ namespace dlib
             const image_type& img
         );
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline long nr (
@@ -280,7 +280,7 @@ namespace dlib
         typename feature_extractor,
         typename hash_function_type
         >
-    unsigned long binned_vector_feature_image<feature_extractor,hash_function_type>::
+    size_t binned_vector_feature_image<feature_extractor,hash_function_type>::
     size (
     ) const
     {

--- a/dlib/image_keypoint/binned_vector_feature_image_abstract.h
+++ b/dlib/image_keypoint/binned_vector_feature_image_abstract.h
@@ -132,7 +132,7 @@ namespace dlib
                   operator() as defined below.
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/image_keypoint/fine_hog_image.h
+++ b/dlib/image_keypoint/fine_hog_image.h
@@ -73,8 +73,8 @@ namespace dlib
         inline void unload(
         ) { clear(); }
 
-        inline unsigned long size (
-        ) const { return static_cast<unsigned long>(nr()*nc()); }
+        inline size_t size (
+        ) const { return static_cast<size_t>(nr()*nc()); }
 
         inline long nr (
         ) const { return num_block_rows; }

--- a/dlib/image_keypoint/fine_hog_image_abstract.h
+++ b/dlib/image_keypoint/fine_hog_image_abstract.h
@@ -132,7 +132,7 @@ namespace dlib
                   Both sequence 1 and sequence 2 should have the same effect on H.  
         !*/
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/image_keypoint/hashed_feature_image.h
+++ b/dlib/image_keypoint/hashed_feature_image.h
@@ -56,7 +56,7 @@ namespace dlib
             const image_type& img
         );
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline long nr (
@@ -325,7 +325,7 @@ namespace dlib
         typename feature_extractor,
         typename hash_function_type
         >
-    unsigned long hashed_feature_image<feature_extractor,hash_function_type>::
+    size_t hashed_feature_image<feature_extractor,hash_function_type>::
     size (
     ) const
     {

--- a/dlib/image_keypoint/hashed_feature_image_abstract.h
+++ b/dlib/image_keypoint/hashed_feature_image_abstract.h
@@ -125,7 +125,7 @@ namespace dlib
                   operator() as defined below.
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/image_keypoint/hog.h
+++ b/dlib/image_keypoint/hog.h
@@ -89,8 +89,8 @@ namespace dlib
         inline void unload(
         ) { clear(); }
 
-        inline unsigned long size (
-        ) const { return static_cast<unsigned long>(nr()*nc()); }
+        inline size_t size (
+        ) const { return static_cast<size_t>(nr()*nc()); }
 
         inline long nr (
         ) const { return num_block_rows; }

--- a/dlib/image_keypoint/hog_abstract.h
+++ b/dlib/image_keypoint/hog_abstract.h
@@ -188,7 +188,7 @@ namespace dlib
                   Both sequence 1 and sequence 2 should have the same effect on H.  
         !*/
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/image_keypoint/nearest_neighbor_feature_image.h
+++ b/dlib/image_keypoint/nearest_neighbor_feature_image.h
@@ -53,7 +53,7 @@ namespace dlib
             const image_type& img
         );
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline long nr (
@@ -250,7 +250,7 @@ namespace dlib
     template <
         typename feature_extractor
         >
-    unsigned long nearest_neighbor_feature_image<feature_extractor>::
+    size_t nearest_neighbor_feature_image<feature_extractor>::
     size (
     ) const
     {

--- a/dlib/image_keypoint/nearest_neighbor_feature_image_abstract.h
+++ b/dlib/image_keypoint/nearest_neighbor_feature_image_abstract.h
@@ -102,7 +102,7 @@ namespace dlib
                   operator() as defined below.
         !*/
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/image_keypoint/poly_image.h
+++ b/dlib/image_keypoint/poly_image.h
@@ -193,7 +193,7 @@ namespace dlib
             num_cols = 0;
         }
 
-        inline unsigned long size (
+        inline size_t size (
         ) const { return static_cast<unsigned long>(nr()*nc()); }
 
         inline long nr (

--- a/dlib/image_keypoint/poly_image_abstract.h
+++ b/dlib/image_keypoint/poly_image_abstract.h
@@ -197,7 +197,7 @@ namespace dlib
                   Both sequence 1 and sequence 2 should have the same effect on H.  
         !*/
 
-        inline unsigned long size (
+        inline size_t size (
         ) const; 
         /*!
             ensures

--- a/dlib/interfaces/enumerable.h
+++ b/dlib/interfaces/enumerable.h
@@ -104,7 +104,7 @@ namespace dlib
                 - returns false if there are no more elements in the container
         !*/
 
-        virtual unsigned long size (
+        virtual size_t size (
         ) const = 0;
         /*!
             ensures

--- a/dlib/interfaces/remover.h
+++ b/dlib/interfaces/remover.h
@@ -54,7 +54,7 @@ namespace dlib
                         - #at_start() == true
             !*/
 
-            virtual unsigned long size (
+            virtual size_t size (
             ) const = 0;
             /*!
                 ensures
@@ -152,7 +152,7 @@ namespace dlib
                         - #at_start() == true
             !*/
 
-            virtual unsigned long size (
+            virtual size_t size (
             ) const = 0;
             /*!
                 ensures

--- a/dlib/lzp_buffer/lzp_buffer_kernel_1.h
+++ b/dlib/lzp_buffer/lzp_buffer_kernel_1.h
@@ -63,7 +63,7 @@ namespace dlib
             unsigned long& index
         );
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline unsigned char operator[] (
@@ -208,7 +208,7 @@ namespace dlib
     template <
         typename sbuf
         >
-    unsigned long lzp_buffer_kernel_1<sbuf>::
+    size_t lzp_buffer_kernel_1<sbuf>::
     size (
     ) const 
     { 

--- a/dlib/lzp_buffer/lzp_buffer_kernel_2.h
+++ b/dlib/lzp_buffer/lzp_buffer_kernel_2.h
@@ -63,7 +63,7 @@ namespace dlib
             unsigned long& index
         );
 
-        inline unsigned long size (
+        inline size_t size (
         ) const;
 
         inline unsigned char operator[] (
@@ -291,7 +291,7 @@ namespace dlib
     template <
         typename sbuf
         >
-    unsigned long lzp_buffer_kernel_2<sbuf>::
+    size_t lzp_buffer_kernel_2<sbuf>::
     size (
     ) const 
     { 

--- a/dlib/lzp_buffer/lzp_buffer_kernel_abstract.h
+++ b/dlib/lzp_buffer/lzp_buffer_kernel_abstract.h
@@ -100,7 +100,7 @@ namespace dlib
                     until clear() is called and succeeds            
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/manifold_regularization/linear_manifold_regularizer.h
+++ b/dlib/manifold_regularization/linear_manifold_regularizer.h
@@ -40,7 +40,7 @@ namespace dlib
 
             typedef std::vector<neighbor>::const_iterator const_iterator;
 
-            unsigned long size (
+            size_t size (
             ) const
             /*!
                 ensures

--- a/dlib/map/map_kernel_1.h
+++ b/dlib/map/map_kernel_1.h
@@ -91,7 +91,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (
@@ -311,7 +311,7 @@ namespace dlib
         typename bst_base,
         typename mem_manager
         >
-    unsigned long map_kernel_1<domain,range,bst_base,mem_manager>::
+    size_t map_kernel_1<domain,range,bst_base,mem_manager>::
     size (
     ) const
     {

--- a/dlib/opencv/cv_image.h
+++ b/dlib/opencv/cv_image.h
@@ -50,7 +50,7 @@ namespace dlib
 
         cv_image() : _data(0), _widthStep(0), _nr(0), _nc(0) {}
 
-        unsigned long size () const { return static_cast<unsigned long>(_nr*_nc); }
+        size_t size () const { return static_cast<size_t>(_nr*_nc); }
 
         inline pixel_type* operator[](const long row ) 
         { 

--- a/dlib/opencv/cv_image_abstract.h
+++ b/dlib/opencv/cv_image_abstract.h
@@ -127,7 +127,7 @@ namespace dlib
                 - returns the number of columns in this image
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const; 
         /*!
             ensures

--- a/dlib/pipe/pipe_kernel_1.h
+++ b/dlib/pipe/pipe_kernel_1.h
@@ -66,7 +66,7 @@ namespace dlib
         typedef T type;
 
         explicit pipe (  
-            unsigned long maximum_size
+            size_t maximum_size
         );
 
         virtual ~pipe (
@@ -109,10 +109,10 @@ namespace dlib
         bool is_enabled (
         ) const;
 
-        unsigned long max_size (
+        size_t max_size (
         ) const;
 
-        unsigned long size (
+        size_t size (
         ) const;
 
         bool enqueue (
@@ -144,14 +144,14 @@ namespace dlib
 
     private:
 
-        unsigned long pipe_size;
-        const unsigned long pipe_max_size;
+        size_t pipe_size;
+        const size_t pipe_max_size;
         bool enabled;
 
         T* const data;
 
-        unsigned long first;
-        unsigned long last;
+        size_t first;
+        size_t last;
 
         mutex m;
         signaler dequeue_sig;
@@ -181,7 +181,7 @@ namespace dlib
         >
     pipe<T>::
     pipe (  
-        unsigned long maximum_size
+        size_t maximum_size
     ) : 
         pipe_size(0),
         pipe_max_size(maximum_size),
@@ -313,7 +313,7 @@ namespace dlib
     template <
         typename T
         >
-    unsigned long pipe<T>::
+    size_t pipe<T>::
     max_size (
     ) const
     {
@@ -326,7 +326,7 @@ namespace dlib
     template <
         typename T
         >
-    unsigned long pipe<T>::
+    size_t pipe<T>::
     size (
     ) const
     {

--- a/dlib/pipe/pipe_kernel_abstract.h
+++ b/dlib/pipe/pipe_kernel_abstract.h
@@ -38,7 +38,7 @@ namespace dlib
         typedef T type;
 
         explicit pipe (  
-            unsigned long maximum_size
+            size_t maximum_size
         );
         /*!
             ensures                
@@ -175,7 +175,7 @@ namespace dlib
                 - #is_dequeue_enabled() == true
         !*/
 
-        unsigned long max_size (
+        size_t max_size (
         ) const;
         /*!
             ensures
@@ -183,7 +183,7 @@ namespace dlib
                   pipe can contain.
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/queue/queue_kernel_1.h
+++ b/dlib/queue/queue_kernel_1.h
@@ -103,7 +103,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (
@@ -402,7 +402,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long queue_kernel_1<T,mem_manager>::
+    size_t queue_kernel_1<T,mem_manager>::
     size (
     ) const
     {

--- a/dlib/queue/queue_kernel_2.h
+++ b/dlib/queue/queue_kernel_2.h
@@ -112,7 +112,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (
@@ -155,13 +155,13 @@ namespace dlib
 
             node* in;
             node* out;
-            unsigned long queue_size;
-            unsigned long in_pos;
-            unsigned long out_pos;
+            size_t queue_size;
+            size_t in_pos;
+            size_t out_pos;
 
 
             mutable node* current_element;
-            mutable unsigned long current_element_pos;
+            mutable size_t current_element_pos;
             mutable bool at_start_;
 
             // restricted functions
@@ -419,7 +419,7 @@ namespace dlib
         unsigned long block_size,
         typename mem_manager
         >
-    unsigned long queue_kernel_2<T,block_size,mem_manager>::
+    size_t queue_kernel_2<T,block_size,mem_manager>::
     size (
     ) const
     {

--- a/dlib/sequence/sequence_kernel_1.h
+++ b/dlib/sequence/sequence_kernel_1.h
@@ -144,7 +144,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             bool at_start (
@@ -446,7 +446,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long sequence_kernel_1<T,mem_manager>::
+    size_t sequence_kernel_1<T,mem_manager>::
     size (
     ) const
     {

--- a/dlib/sequence/sequence_kernel_2.h
+++ b/dlib/sequence/sequence_kernel_2.h
@@ -103,7 +103,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             bool at_start (
@@ -430,7 +430,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long sequence_kernel_2<T,mem_manager>::
+    size_t sequence_kernel_2<T,mem_manager>::
     size (
     ) const
     {

--- a/dlib/set/set_kernel_1.h
+++ b/dlib/set/set_kernel_1.h
@@ -80,7 +80,7 @@ namespace dlib
             );
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (
@@ -254,7 +254,7 @@ namespace dlib
         typename bst_base,
         typename mem_manager
         >
-    unsigned long set_kernel_1<T,bst_base,mem_manager>::
+    size_t set_kernel_1<T,bst_base,mem_manager>::
     size (
     ) const
     {

--- a/dlib/sliding_buffer/sliding_buffer_kernel_1.h
+++ b/dlib/sliding_buffer/sliding_buffer_kernel_1.h
@@ -82,7 +82,7 @@ namespace dlib
             catch (...) { buffer = 0; buffer_size = 0; throw; }
         }
 
-        unsigned long size (
+        size_t size (
         ) const { return buffer_size; }
 
         void rotate_left (

--- a/dlib/stack/stack_kernel_1.h
+++ b/dlib/stack/stack_kernel_1.h
@@ -97,7 +97,7 @@ namespace dlib
             ); 
 
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (
@@ -365,7 +365,7 @@ namespace dlib
         typename T,
         typename mem_manager
         >
-    unsigned long stack_kernel_1<T,mem_manager>::
+    size_t stack_kernel_1<T,mem_manager>::
     size (
     ) const
     {

--- a/dlib/static_map/static_map_kernel_1.h
+++ b/dlib/static_map/static_map_kernel_1.h
@@ -433,7 +433,7 @@ namespace dlib
         typename range,
         typename compare
         >
-    unsigned long static_map_kernel_1<domain,range,compare>::
+    size_t static_map_kernel_1<domain,range,compare>::
     size (
     ) const
     {

--- a/dlib/static_map/static_map_kernel_1.h
+++ b/dlib/static_map/static_map_kernel_1.h
@@ -157,7 +157,7 @@ namespace dlib
             );
     
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (

--- a/dlib/static_set/static_set_kernel_1.h
+++ b/dlib/static_set/static_set_kernel_1.h
@@ -116,7 +116,7 @@ namespace dlib
             );
     
             // functions from the enumerable interface
-            inline unsigned long size (
+            inline size_t size (
             ) const;
 
             inline bool at_start (

--- a/dlib/static_set/static_set_kernel_1.h
+++ b/dlib/static_set/static_set_kernel_1.h
@@ -52,11 +52,11 @@ namespace dlib
             try
             {
                 item.clear();
-                unsigned long size;
+                size_t size;
                 deserialize(size,in);
                 item.set_size = size;
                 item.d = new T[size];
-                for (unsigned long i = 0; i < size; ++i)
+                for (size_t i = 0; i < size; ++i)
                 {
                     deserialize(item.d[i],in);
                 }
@@ -142,7 +142,7 @@ namespace dlib
 
    
             // data members
-            unsigned long set_size;
+            size_t set_size;
             T* d;
             mutable T* cur;
             mutable bool at_start_;
@@ -231,7 +231,7 @@ namespace dlib
 
             set_size = source.size();
 
-            for (unsigned long i = 0; source.size() > 0; ++i)
+            for (size_t i = 0; source.size() > 0; ++i)
                 source.remove_any(d[i]);
             
             compare comp;
@@ -261,7 +261,7 @@ namespace dlib
 
             set_size = source.size();
 
-            for (unsigned long i = 0; source.size() > 0; ++i)
+            for (size_t i = 0; source.size() > 0; ++i)
                 source.remove_any(d[i]);
         }
         else
@@ -282,10 +282,10 @@ namespace dlib
         const T& item
     ) const
     {
-        unsigned long high = set_size;
-        unsigned long low = 0;
-        unsigned long p = set_size;
-        unsigned long idx;
+        size_t high = set_size;
+        size_t low = 0;
+        size_t p = set_size;
+        size_t idx;
         while (p > 0)
         {
             p = (high-low)>>1;
@@ -306,7 +306,7 @@ namespace dlib
         typename T,
         typename compare
         >
-    unsigned long static_set_kernel_1<T,compare>::
+    size_t static_set_kernel_1<T,compare>::
     size (
     ) const
     {
@@ -421,7 +421,7 @@ namespace dlib
         else if (cur != 0)
         {
             ++cur;
-            if (static_cast<unsigned long>(cur - d) < set_size)
+            if (static_cast<size_t>(cur - d) < set_size)
             {
                 return true;
             }

--- a/dlib/statistics/random_subset_selector.h
+++ b/dlib/statistics/random_subset_selector.h
@@ -67,7 +67,7 @@ namespace dlib
         const std::vector<T>& to_std_vector(
         ) const { return items; }
 
-        unsigned long size (
+        size_t size (
         ) const 
         {
             return items.size();

--- a/dlib/statistics/random_subset_selector_abstract.h
+++ b/dlib/statistics/random_subset_selector_abstract.h
@@ -101,7 +101,7 @@ namespace dlib
                 - #size() == 0
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/svm/kernel_matrix.h
+++ b/dlib/svm/kernel_matrix.h
@@ -65,7 +65,7 @@ namespace dlib
         }
 
         template <typename kernel_type>
-        inline unsigned long size ( 
+        inline size_t size (
             const typename kernel_type::sample_type&  
         )
         {

--- a/dlib/svm/linearly_independent_subset_finder.h
+++ b/dlib/svm/linearly_independent_subset_finder.h
@@ -296,7 +296,7 @@ namespace dlib
             temp.swap(item.temp);
         }
 
-        unsigned long size (
+        size_t size (
         ) const { return dictionary.size(); }
 
         const matrix<sample_type,0,1,mem_manager_type> get_dictionary (

--- a/dlib/svm/linearly_independent_subset_finder_abstract.h
+++ b/dlib/svm/linearly_independent_subset_finder_abstract.h
@@ -173,7 +173,7 @@ namespace dlib
                 - swaps *this with item
         !*/
 
-        unsigned long size (
+        size_t size (
         ) const;
         /*!
             ensures

--- a/dlib/test/object_detector.cpp
+++ b/dlib/test/object_detector.cpp
@@ -151,7 +151,7 @@ namespace
             }
         }
 
-        inline unsigned long size () const { return feat_image.size(); }
+        inline size_t size () const { return feat_image.size(); }
         inline long nr () const { return feat_image.nr(); }
         inline long nc () const { return feat_image.nc(); }
 

--- a/dlib/xml_parser/xml_parser_kernel_1.h
+++ b/dlib/xml_parser/xml_parser_kernel_1.h
@@ -127,7 +127,7 @@ namespace dlib
                 bool move_next (
                 ) const { return list.move_next(); }
 
-                unsigned long size (
+                size_t size (
                 ) const { return list.size(); }
             };
 

--- a/examples/object_detector_advanced_ex.cpp
+++ b/examples/object_detector_advanced_ex.cpp
@@ -134,7 +134,7 @@ public:
         }
     }
 
-    inline unsigned long size () const { return feat_image.size(); }
+    inline size_t size () const { return feat_image.size(); }
     inline long nr () const { return feat_image.nr(); }
     inline long nc () const { return feat_image.nc(); }
 


### PR DESCRIPTION
Consider an innocent-looking 2D-array whose size is, say, 70,000 * 70,000. When using `unsigned long` all the way, there is an overflow in calculating the size. Similar for tensors, although there it may happen even more easier, if `n > 1` and/or `k > 1`.

Solution: change some types from `unsigned long` to `size_t`.

Note: certainly didn't think everything through yet – or even test almost anything (only my own case where overflow actually did happen). Really just opening the PR to start a discussion as to whether this kind of a direction makes sense. (Personally I think it's more future-proof, but I guess there may also be arguments against this approach.)