### PR TITLE
Clear flags

### DIFF
--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -576,7 +576,7 @@ namespace dlib
     )
     {
         std::ios::fmtflags oldflags = in.flags();  
-        in.flags(); 
+        in.flags(0); 
         std::streamsize ss = in.precision(35); 
         if (in.peek() == 'i')
         {


### PR DESCRIPTION
Set istream flags to 0 in old_deserialize_floating_point.  This fixes [[nodiscard]] warning.