### PR TITLE
[fix] this change fixes compilation problems under mac

### DIFF
--- a/tools/python/src/other.cpp
+++ b/tools/python/src/other.cpp
@@ -53,7 +53,7 @@ void _save_libsvm_formatted_data (
 
 // ----------------------------------------------------------------------------------------
 
-list _max_cost_assignment (
+boost::python::list _max_cost_assignment (
     const matrix<double>& cost
 )
 {
@@ -69,7 +69,7 @@ list _max_cost_assignment (
 
 double _assignment_cost (
     const matrix<double>& cost,
-    const list& assignment
+    const boost::python::list& assignment
 )
 {
     return assignment_cost(cost, python_list_to_vector<long>(assignment));


### PR DESCRIPTION
I have noticed the following problem with compilation on Mac:

`dlib/tools/python/src/other.cpp:56:1: error: reference to 'list' is ambiguous
list _max_cost_assignment (
^
/Library/Developer/CommandLineTools/usr/include/c++/v1/list:805:28: note: candidate found by name lookup is 'std::__1::list'
class _LIBCPP_TEMPLATE_VIS list
                           ^
/usr/local/include/boost/python/list.hpp:57:7: note: candidate found by name lookup is 'boost::python::list'
class list : public detail::list_base
      ^
/Users/jaroslaw/code/dlib/tools/python/src/other.cpp:72:11: error: reference to 'list' is ambiguous
    const list& assignment
          ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/list:805:28: note: candidate found by name lookup is 'std::__1::list'
class _LIBCPP_TEMPLATE_VIS list
                           ^
/usr/local/include/boost/python/list.hpp:57:7: note: candidate found by name lookup is 'boost::python::list'
class list : public detail::list_base
      ^
2 errors generated.
make[2]: *** [CMakeFiles/dlib_.dir/src/other.cpp.o] Error 1
error: cmake build failed!`

this change fixes it. 

PLEASE DOUBLE CHECK ME - I have not read this code or code in c++ recently... :)