### PR TITLE
parallelize image rotations

### DIFF
--- a/dlib/array/array_kernel.h
+++ b/dlib/array/array_kernel.h
@@ -90,6 +90,7 @@ namespace dlib
             _at_start(true)
         {}
 
+        array(const array&) = delete;
         array(
             array&& item
         ) : array()


### PR DESCRIPTION
Hello Davis,

This PR is about parallelizing `add_image_rotations` which takes an unreasonable amount of time on my machine, while there are a lot of idling CPUs.

I'm not sure about some low level arbitrary choices I've made and implementation details, so please, get back to me. I'll remove the debug prints and all that while treating your feedback.

Many thanks!