### PR TITLE
WIP: Shape Predictor metrics

### DIFF
--- a/dlib/image_processing/shape_predictor.h
+++ b/dlib/image_processing/shape_predictor.h
@@ -9,7 +9,6 @@
 #include "../matrix.h"
 #include "../geometry.h"
 #include "../pixel.h"
-#include "../tuple.h"
 #include "../statistics.h"
 #include <utility>
 
@@ -436,11 +435,23 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
+    struct shape_predictor_statistics
+    {
+        shape_predictor_statistics( running_stats<double> error_across_landmarks,
+                                    std::vector< running_stats<double> > error_by_landmark)
+                                        : error_across_landmarks(error_across_landmarks),
+                                          error_by_landmark(error_by_landmark)
+        {}
+
+        running_stats<double> error_across_landmarks;
+        std::vector< running_stats<double> > error_by_landmark;
+    };
+
+
     template <
         typename image_array
         >
-    dlib::tuple<running_stats<double>, std::vector<running_stats<double>>>
-        test_shape_predictor_with_detailed_statistics (
+    shape_predictor_statistics test_shape_predictor_with_detailed_statistics (
             const shape_predictor& sp,
             const image_array& images,
             const std::vector<std::vector<full_object_detection> >& objects,
@@ -504,11 +515,7 @@ namespace dlib
             }
         }
 
-        dlib::tuple<running_stats<double>, std::vector<running_stats<double>>> result;
-        result.get<0>() = rs;
-        result.get<1>() = rs_by_landmark;
-
-        return result;
+        return shape_predictor_statistics(rs, rs_by_landmark);
     }
 
 // ----------------------------------------------------------------------------------------
@@ -516,8 +523,7 @@ namespace dlib
     template <
         typename image_array
         >
-    dlib::tuple<running_stats<double>, std::vector<running_stats<double>>>
-        test_shape_predictor_with_detailed_statistics (
+    shape_predictor_statistics test_shape_predictor_with_detailed_statistics (
         const shape_predictor& sp,
         const image_array& images,
         const std::vector<std::vector<full_object_detection> >& objects
@@ -539,9 +545,9 @@ namespace dlib
         const std::vector<std::vector<double> >& scales
     )
     {
-        dlib::tuple<running_stats<double>, std::vector<running_stats<double>>> result =
+        shape_predictor_statistics result =
             test_shape_predictor_with_detailed_statistics(sp, images, objects, scales);
-        running_stats<double> overall_statistics = result.get<0>();
+        running_stats<double> overall_statistics = result.error_across_landmarks;
         return overall_statistics.mean();
     }
 

--- a/dlib/image_processing/shape_predictor_abstract.h
+++ b/dlib/image_processing/shape_predictor_abstract.h
@@ -124,11 +124,18 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------
 
+    struct shape_predictor_statistics {
+        shape_predictor_statistics( running_stats<double> error_across_landmarks,
+                                    std::vector< running_stats<double> > error_by_landmark );
+        running_stats<double>                error_across_landmarks;
+        std::vector< running_stats<double> > error_by_landmark;
+    };
+
+
     template <
         typename image_array
         >
-    dlib::tuple< running_statistics<double>, std::vector<running_statistics<double>> >
-        test_shape_predictor_with_detailed_statistics (
+    shape_predictor_statistics test_shape_predictor_with_detailed_statistics (
             const shape_predictor& sp,
             const image_array& images,
             const std::vector<std::vector<full_object_detection> >& objects,
@@ -153,10 +160,10 @@ namespace dlib
               valid i and j we perform:
                 sp(images[i], objects[i][j].get_rect())
               and compare the result with the truth part positions in objects[i][j].
-              The first member of the returned tuple tracks the error statistics across
-              all landmarks, the second member tracks the error statistics for each
-              landmark individually. The error is measured in pixels, unless scales
-              are provided (for scaled error, see below).
+              The returned struct captures the error distribution for each landmark
+              separately, and also separately tracks the error distribution across
+              landmarks.  The error is measured in pixels, unless scales are provided
+              (for scaled error, see below).
             - Note that any parts in objects that are set to OBJECT_PART_NOT_PRESENT are
               simply ignored.
             - if (scales.size() != 0) then
@@ -172,8 +179,7 @@ namespace dlib
     template <
         typename image_array
         >
-    dlib::tuple< running_statistics<double>, std::vector<running_statistics<double>> >
-        test_shape_predictor_with_detailed_statistics (
+    shape_predictor_statistics test_shape_predictor_with_detailed_statistics (
             const shape_predictor& sp,
             const image_array& images,
             const std::vector<std::vector<full_object_detection> >& objects

--- a/dlib/test/face.cpp
+++ b/dlib/test/face.cpp
@@ -72,6 +72,16 @@ namespace
 
             print_spinner();
 
+            dlib::tuple< running_stats<double>, std::vector< running_stats<double> > >
+                full_stats = test_shape_predictor_with_detailed_statistics(sp, images, objects);
+
+            double mean_overall_error = full_stats.get<0>().mean();
+            long landmark_error_count = full_stats.get<1>().size();
+            DLIB_TEST(mean_overall_error == 0);
+            DLIB_TEST(landmark_error_count == 68);
+
+            print_spinner();
+
             // While we are here, make sure the default face detector works
             std::vector<rectangle> dets = detector(images[0]);
             DLIB_TEST(dets.size() == 3);

--- a/dlib/test/face.cpp
+++ b/dlib/test/face.cpp
@@ -67,18 +67,42 @@ namespace
 
             print_spinner();
 
-            // It should have been able to perfectly fit the data
-            DLIB_TEST(test_shape_predictor(sp, images, objects) == 0);
+            shape_predictor_statistics full_stats =
+                test_shape_predictor_with_detailed_statistics(sp, images, objects);
+
+            double summary_mean =
+                test_shape_predictor(sp, images, objects);
 
             print_spinner();
 
-            dlib::tuple< running_stats<double>, std::vector< running_stats<double> > >
-                full_stats = test_shape_predictor_with_detailed_statistics(sp, images, objects);
+            // It should have been able to perfectly fit the data
+            DLIB_TEST(summary_mean == 0);
+            DLIB_TEST(summary_mean == full_stats.error_across_landmarks.mean());
 
-            double mean_overall_error = full_stats.get<0>().mean();
-            long landmark_error_count = full_stats.get<1>().size();
-            DLIB_TEST(mean_overall_error == 0);
-            DLIB_TEST(landmark_error_count == 68);
+            print_spinner();
+
+            long landmark_error_count = full_stats.error_by_landmark.size();
+            int number_of_landmarks = 68;
+            DLIB_TEST(landmark_error_count == number_of_landmarks);
+
+            print_spinner();
+
+            int number_of_samples = 0;
+            for (unsigned long i = 0; i < objects.size(); ++i)
+            {
+                number_of_samples += objects[i].size();
+            }
+
+            print_spinner();
+
+            DLIB_TEST(full_stats.error_across_landmarks.current_n() ==
+                                    (number_of_landmarks * number_of_samples));
+            for (unsigned long k = 0; k < 68; ++k)
+            {
+                running_stats<double> landmark_stats = full_stats.error_by_landmark.at(k);
+                DLIB_TEST(landmark_stats.current_n() == number_of_samples);
+                DLIB_TEST(landmark_stats.mean()      == 0);
+            }
 
             print_spinner();
 
@@ -86,6 +110,7 @@ namespace
             std::vector<rectangle> dets = detector(images[0]);
             DLIB_TEST(dets.size() == 3);
 
+            print_spinner();
 
             /*
             // visualize the detections

--- a/python_examples/train_shape_predictor.py
+++ b/python_examples/train_shape_predictor.py
@@ -91,11 +91,26 @@ testing_xml_path = os.path.join(faces_folder, "testing_with_face_landmarks.xml")
 print("Testing accuracy: {}".format(
     dlib.test_shape_predictor(testing_xml_path, "predictor.dat")))
 
+
+# You can also ask it for more detailed statistics. The returned object provides
+# statistics for the total error as well as for each individual landmark separately.
+stats = dlib.test_shape_predictor_with_stats(testing_xml_path, "predictor.dat")
+print("Mean error across landmarks: {}".format(stats.error_across_landmarks.mean()))
+print("Standard deviation of error across all landmarks: {}".format(
+    stats.error_across_landmarks.stddev()))
+for idx, landmark_stats in enumerate(stats.error_by_landmark):
+    print("Landmark [{}]: mean: {}, std-dev: {}".format(
+        idx, landmark_stats.mean(), landmark_stats.stddev()))
+    # Just an example, don't fill the screen
+    if idx > 9:
+        break
+
 # Now let's use it as you would in a normal application.  First we will load it
 # from disk. We also need to load a face detector to provide the initial
 # estimate of the facial location.
 predictor = dlib.shape_predictor("predictor.dat")
 detector = dlib.get_frontal_face_detector()
+
 
 # Now let's run the detector and shape_predictor over the images in the faces
 # folder and display the results.

--- a/tools/python/CMakeLists.txt
+++ b/tools/python/CMakeLists.txt
@@ -50,6 +50,7 @@ set(python_srcs
    src/rectangles.cpp
    src/object_detection.cpp
    src/shape_predictor.cpp
+   src/statistics.cpp
    src/correlation_tracker.cpp
    src/face_recognition.cpp
    src/cnn_face_detector.cpp

--- a/tools/python/src/dlib.cpp
+++ b/tools/python/src/dlib.cpp
@@ -30,6 +30,7 @@ void bind_global_optimization(py::module& m);
 void bind_numpy_returns(py::module& m);
 void bind_image_dataset_metadata(py::module& m);
 void bind_line(py::module& m);
+void bind_statistics(py::module& m);
 
 #ifndef DLIB_NO_GUI_SUPPORT
 void bind_gui(py::module& m);
@@ -104,6 +105,7 @@ PYBIND11_MODULE(dlib, m)
     bind_global_optimization(m);
     bind_numpy_returns(m);
     bind_svm_c_trainer(m);
+    bind_statistics(m);
 #ifndef DLIB_NO_GUI_SUPPORT
     bind_gui(m);
 #endif

--- a/tools/python/src/shape_predictor.cpp
+++ b/tools/python/src/shape_predictor.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2014  Davis E. King (davis@dlib.net)
 // License: Boost Software License   See LICENSE.txt for the full license.
 
+#include <pybind11/stl.h>
 #include "opaque_types.h"
 #include <dlib/python.h>
 #include <dlib/geometry.h>
@@ -227,6 +228,12 @@ ensures \n\
       a single full_object_detection.")
         .def("save", save_shape_predictor, py::arg("predictor_output_filename"), "Save a shape_predictor to the provided path.")
         .def(py::pickle(&getstate<type>, &setstate<type>));
+    }
+    {
+    py::class_<shape_predictor_statistics>(m, "shape_predictor_statistics")
+        .def(py::init<running_stats<double>, std::vector<running_stats<double>>>())
+        .def_readwrite("error_across_landmarks", &shape_predictor_statistics::error_across_landmarks)
+        .def_readwrite("error_by_landmark",      &shape_predictor_statistics::error_by_landmark);
     }
     {
     m.def("train_shape_predictor", train_shape_predictor_on_images_py,

--- a/tools/python/src/shape_predictor.cpp
+++ b/tools/python/src/shape_predictor.cpp
@@ -99,7 +99,7 @@ inline shape_predictor train_shape_predictor_on_images_py (
 }
 
 
-inline double test_shape_predictor_with_images_py (
+inline shape_predictor_statistics test_shape_predictor_with_images_py (
         const py::list& pyimages,
         const py::list& pydetections,
         const py::list& pyscales,
@@ -142,7 +142,20 @@ inline double test_shape_predictor_with_images_py (
     return test_shape_predictor_with_images(images, detections, scales, predictor);
 }
 
-inline double test_shape_predictor_with_images_no_scales_py (
+inline double simple_test_shape_predictor_with_images_py (
+        const py::list& pyimages,
+        const py::list& pydetections,
+        const py::list& pyscales,
+        const shape_predictor& predictor
+)
+{
+    shape_predictor_statistics result =
+        test_shape_predictor_with_images_py( pyimages, pydetections, pyscales, predictor );
+    return result.error_across_landmarks.mean();
+}
+
+
+inline shape_predictor_statistics test_shape_predictor_with_images_no_scales_py (
         const py::list& pyimages,
         const py::list& pydetections,
         const shape_predictor& predictor
@@ -151,6 +164,18 @@ inline double test_shape_predictor_with_images_no_scales_py (
     py::list pyscales;
     return test_shape_predictor_with_images_py(pyimages, pydetections, pyscales, predictor);
 }
+
+inline double simple_test_shape_predictor_with_images_no_scales_py (
+        const py::list& pyimages,
+        const py::list& pydetections,
+        const shape_predictor& predictor
+)
+{
+    shape_predictor_statistics result =
+        test_shape_predictor_with_images_no_scales_py( pyimages, pydetections, predictor );
+    return result.error_across_landmarks.mean();
+}
+
 
 // ----------------------------------------------------------------------------------------
 
@@ -264,7 +289,7 @@ ensures \n\
       XML format produced by dlib's save_image_dataset_metadata() routine. \n\
     - The trained shape predictor is serialized to the file predictor_output_filename.");
 
-    m.def("test_shape_predictor", test_shape_predictor_py,
+    m.def("test_shape_predictor", simple_test_shape_predictor_py,
         py::arg("dataset_filename"), py::arg("predictor_filename"),
 "ensures \n\
     - Loads an image dataset from dataset_filename.  We assume dataset_filename is \n\
@@ -278,7 +303,7 @@ ensures \n\
       shape_predictor_trainer() routine.  Therefore, see the documentation \n\
       for shape_predictor_trainer() for a detailed definition of the mean average error.");
 
-    m.def("test_shape_predictor", test_shape_predictor_with_images_no_scales_py,
+    m.def("test_shape_predictor", simple_test_shape_predictor_with_images_no_scales_py,
             py::arg("images"), py::arg("detections"), py::arg("shape_predictor"),
 "requires \n\
     - len(images) == len(object_detections) \n\
@@ -295,7 +320,7 @@ ensures \n\
       for shape_predictor_trainer() for a detailed definition of the mean average error.");
 
 
-    m.def("test_shape_predictor", test_shape_predictor_with_images_py,
+    m.def("test_shape_predictor", simple_test_shape_predictor_with_images_py,
             py::arg("images"), py::arg("detections"), py::arg("scales"), py::arg("shape_predictor"),
 "requires \n\
     - len(images) == len(object_detections) \n\
@@ -314,5 +339,57 @@ ensures \n\
       return value of this function is identical to that of dlib's \n\
       shape_predictor_trainer() routine.  Therefore, see the documentation \n\
       for shape_predictor_trainer() for a detailed definition of the mean average error.");
+    }
+    {
+    m.def("test_shape_predictor_with_stats", test_shape_predictor_py,
+        py::arg("dataset_filename"), py::arg("predictor_filename"),
+"ensures \n\
+    - Loads an image dataset from dataset_filename.  We assume dataset_filename is \n\
+      a file using the XML format written by save_image_dataset_metadata(). \n\
+    - Loads a shape_predictor from the file predictor_filename.  This means \n\
+      predictor_filename should be a file produced by the train_shape_predictor() \n\
+      routine. \n\
+    - This function tests the predictor against the dataset and returns a \n\
+      shape_predictor_statistics object. This encapsulates the error across \n\
+      all landmarks, as well as the error for each individual landmark. Error \n\
+      is reported as a running_stats object (instead of just mean), so you can \n\
+      better understand the distribution of the prediction error.");
+
+    m.def("test_shape_predictor_with_stats", test_shape_predictor_with_images_no_scales_py,
+            py::arg("images"), py::arg("detections"), py::arg("shape_predictor"),
+"requires \n\
+    - len(images) == len(object_detections) \n\
+    - images should be a list of numpy matrices that represent images, either RGB or grayscale. \n\
+    - object_detections should be a list of lists of dlib.full_object_detection objects. \
+      Each dlib.full_object_detection contains the bounding box and the lists of points that make up the object parts.\n\
+ ensures \n\
+    - shape_predictor should be a file produced by the train_shape_predictor()  \n\
+      routine. \n\
+    - This function tests the predictor against the dataset and returns a \n\
+      shape_predictor_statistics object. This encapsulates the error across \n\
+      all landmarks, as well as the error for each individual landmark. Error \n\
+      is reported as a running_stats object (instead of just mean), so you can \n\
+      better understand the distribution of the prediction error.");
+
+
+    m.def("test_shape_predictor_with_stats", test_shape_predictor_with_images_py,
+            py::arg("images"), py::arg("detections"), py::arg("scales"), py::arg("shape_predictor"),
+"requires \n\
+    - len(images) == len(object_detections) \n\
+    - len(object_detections) == len(scales) \n\
+    - for every sublist in object_detections: len(object_detections[i]) == len(scales[i]) \n\
+    - scales is a list of floating point scales that each predicted part location \
+      should be divided by. Useful for normalization. \n\
+    - images should be a list of numpy matrices that represent images, either RGB or grayscale. \n\
+    - object_detections should be a list of lists of dlib.full_object_detection objects. \
+      Each dlib.full_object_detection contains the bounding box and the lists of points that make up the object parts.\n\
+ ensures \n\
+    - shape_predictor should be a file produced by the train_shape_predictor()  \n\
+      routine. \n\
+    - This function tests the predictor against the dataset and returns a \n\
+      shape_predictor_statistics object. This encapsulates the error across \n\
+      all landmarks, as well as the error for each individual landmark. Error \n\
+      is reported as a running_stats object (instead of just mean), so you can \n\
+      better understand the distribution of the prediction error.");
     }
 }

--- a/tools/python/src/shape_predictor.h
+++ b/tools/python/src/shape_predictor.h
@@ -214,7 +214,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename image_array>
-    inline double test_shape_predictor_with_images (
+    inline shape_predictor_statistics test_shape_predictor_with_images (
             image_array& images,
             std::vector<std::vector<full_object_detection> >& detections,
             std::vector<std::vector<double> >& scales,
@@ -227,12 +227,12 @@ namespace dlib
             throw error("The list of scales must have the same length as the list of detections.");
 
         if (scales.size() > 0)
-            return test_shape_predictor(predictor, images, detections, scales);
+            return test_shape_predictor_with_detailed_statistics(predictor, images, detections, scales);
         else
-            return test_shape_predictor(predictor, images, detections);
+            return test_shape_predictor_with_detailed_statistics(predictor, images, detections);
     }
 
-    inline double test_shape_predictor_py (
+    inline shape_predictor_statistics test_shape_predictor_py (
         const std::string& dataset_filename,
         const std::string& predictor_filename
     )
@@ -250,6 +250,16 @@ namespace dlib
 
         return test_shape_predictor_with_images(images, objects, scales, predictor);
     }
+
+    inline double simple_test_shape_predictor_py (
+        const std::string& dataset_filename,
+        const std::string& predictor_filename
+    )
+    {
+        shape_predictor_statistics result = test_shape_predictor_py(dataset_filename, predictor_filename);
+        return result.error_across_landmarks.mean();
+    }
+
 
 // ----------------------------------------------------------------------------------------
 

--- a/tools/python/src/statistics.cpp
+++ b/tools/python/src/statistics.cpp
@@ -1,0 +1,31 @@
+#include <pybind11/operators.h>
+#include <dlib/python.h>
+#include "dlib/pixel.h"
+#include <dlib/image_transforms.h>
+#include <dlib/statistics.h>
+
+using namespace dlib;
+using namespace std;
+
+namespace py = pybind11;
+
+// ----------------------------------------------------------------------------------------
+
+void bind_statistics(py::module& m)
+{
+    py::class_<running_stats<double>>(m, "running_stats")
+        .def(py::init<>())
+        .def("clear",       &running_stats<double>::clear       )
+        .def("add",         &running_stats<double>::add         )
+        .def("current_n",   &running_stats<double>::current_n   )
+        .def("mean",        &running_stats<double>::mean        )
+        .def("max",         &running_stats<double>::max         )
+        .def("min",         &running_stats<double>::min         )
+        .def("variance",    &running_stats<double>::variance    )
+        .def("stddev",      &running_stats<double>::stddev      )
+        .def("skewness",    &running_stats<double>::skewness    )
+        .def("ex_kurtosis", &running_stats<double>::ex_kurtosis )
+        .def("scale",       &running_stats<double>::scale       )
+        .def("stddev",      &running_stats<double>::stddev      )
+        .def(py::self + py::self);
+}


### PR DESCRIPTION
This is a work-in-progress, but I wanted to get your feedback on my approach to #1299 before I spent more time fleshing it out. Think of this as an initial rough sketch ;)

The goal is to provide more nuanced error metrics while testing a shape_predictor. We now return a running_statistics object for both the overall error and for each individual landmark, which you can interrogate for min, max, average, etc.

Things about this I'm not thrilled about:

 - to maintain backwards compatibility, I had to basically double the number of relevant function signatures, and chain the old implementations to the new ones. This feels a little awkward, since a further orthogonal change will double or triple the number of signatures again. All these signatures may make it hard for developers using the library to find the right version, and will also need to dealt with on the python binding layer. It seems like there should be a better pattern to signal optional behavior with less overhead?

 - I'm unsure about the return type -- I thought about creating a new class, or hand-picking specific values from running_statistics, but didn't have a strong perspective either way. I went with the simplest thing for now, happy to revisit.

 - I mimicked the existing test case, but was unsure if I should do something stronger. It felt like verifying the mathematical properties (i.e. total min is min of all errors, etc) was going beyond testing the actual implementation of how errors were computed and returned.

Things I still need to do:

 - wire this up to the python layer
 - extend the example code to demonstrate how to use this

Very open to feedback. I'm comfortable in C++ but don't live in it, so also open to stylistic / idiomatic suggestions.

Thoughts?

Ankur