### PR TITLE
Fix bad_alloc exception when loading bmp images with negative height

### DIFF
--- a/dlib/image_loader/image_loader.h
+++ b/dlib/image_loader/image_loader.h
@@ -44,7 +44,7 @@ namespace dlib
             unsigned long bfReserved;
             unsigned long biSize;
             unsigned long biWidth;
-            long biHeight;
+            int32 biHeight;
             unsigned short biBitCount;
             unsigned long biCompression;
             /*


### PR DESCRIPTION
The 'long' type can be 32 bits or 64 bits depending on what compiler you are using (LLP64 vs LP64). If the long type is 64 bits the biHeight variable will receive a very big number when the bmp image height is negative, causing a std::bad_alloc exception when calling the 'image.set_size' method.

I think that would be a good idea to replace all numeric types with the ones declared in \<cstdint\>(C++11) and get rid of "../uintn.h".