### PR TITLE
Add related works section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ This library is licensed under the Boost Software License, which can be found in
 
 This research is based in part upon work supported by the Office of the Director of National Intelligence (ODNI), Intelligence Advanced Research Projects Activity (IARPA) under contract number 2014-14071600010. The views and conclusions contained herein are those of the authors and should not be interpreted as necessarily representing the official policies or endorsements, either expressed or implied, of ODNI, IARPA, or the U.S. Government.
 
+## related works
+
+- dlib-serving <https://github.com/c9s/dlib-serving> 


### PR DESCRIPTION
Hi Davis,

I am working on a gRPC server wrapper that runs dlib as the model serving service, therefore I added the related work section in the readme.  Hope you like it.

Thanks,
c9s