### PR TITLE
add check against null pointer

### DIFF
--- a/dlib/image_loader/png_loader.cpp
+++ b/dlib/image_loader/png_loader.cpp
@@ -110,7 +110,12 @@ namespace dlib
 
     void png_loader::read_image( const char* filename )
     {
-        ld_.reset(new LibpngData);
+        LibpngData *pLdTmp = new LibpngData;
+        if ( pLdTmp == NULL )
+        {
+            throw image_load_error("png_loader: cannot create a new LibpngData");
+        }
+        ld_.reset(pLdTmp);
         if ( filename == NULL )
         {
             throw image_load_error("png_loader: invalid filename, it is NULL");


### PR DESCRIPTION
Hi all,
This is Qihoo360 CodeSafe Team, we found some bugs in dlib:

in some situation, such as memory exhausted, 'new LibpngData' will return a null pointer. Then it could cause a derefrence of null pointer in statement 'ld_->png_ptr_ = ...'.
we may need to check whether the return pointer of expression 'new LibpngData' is null or not.