### PR TITLE
Remove redundant line

### DIFF
--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -150,7 +150,7 @@ namespace dlib
             double seconds = delta_t/delta_val * std::abs(target_val - cur);
 
             std::ios::fmtflags oldflags = std::cout.flags();  
-            std::cout.flags(); 
+
             std::cout.setf(std::ios::fixed,std::ios::floatfield);
             std::streamsize ss;
 


### PR DESCRIPTION
With C++17 enabled on VS15.6+, this triggered a nodiscard warning which led to failed builds when warnings as errors is enabled.