### PR TITLE
add python bindings for update_noscale method of the correlation tracker

### DIFF
--- a/tools/python/src/correlation_tracker.cpp
+++ b/tools/python/src/correlation_tracker.cpp
@@ -82,6 +82,45 @@ double update_guess (
     }
 }
 
+double update_noscale (
+    correlation_tracker& tracker,
+    py::array img
+)
+{
+    if (is_image<unsigned char>(img))
+    {
+        return tracker.update_noscale(numpy_image<unsigned char>(img));
+    }
+    else if (is_image<rgb_pixel>(img))
+    {
+        return tracker.update_noscale(numpy_image<rgb_pixel>(img));
+    }
+    else
+    {
+        throw dlib::error("Unsupported image type, must be 8bit gray or RGB image.");
+    }
+}
+
+double update_noscale_guess (
+    correlation_tracker& tracker,
+    py::array img,
+    const drectangle& bounding_box
+)
+{
+    if (is_image<unsigned char>(img))
+    {
+        return tracker.update_noscale(numpy_image<unsigned char>(img), bounding_box);
+    }
+    else if (is_image<rgb_pixel>(img))
+    {
+        return tracker.update_noscale(numpy_image<rgb_pixel>(img), bounding_box);
+    }
+    else
+    {
+        throw dlib::error("Unsupported image type, must be 8bit gray or RGB image.");
+    }
+}
+
 double update_guess_rec (
     correlation_tracker& tracker,
     py::array img,
@@ -148,6 +187,28 @@ void bind_correlation_tracker(py::module &m)
                   confident the tracker is that the object is inside #get_position(). \n\
                   Larger values indicate higher confidence.")
         .def("update", &::update_guess_rec, py::arg("image"), py::arg("guess"), "\
+            requires \n\
+                - image is a numpy ndarray containing either an 8bit grayscale or RGB image. \n\
+                - get_position().is_empty() == false \n\
+                  (i.e. you must have started tracking by calling start_track()) \n\
+            ensures \n\
+                - When searching for the object in img, we search in the area around the \n\
+                  provided guess. \n\
+                - #get_position() == the new predicted location of the object in img.  This \n\
+                  location will be a copy of guess that has been translated and scaled \n\
+                  appropriately based on the content of img so that it, hopefully, bounds \n\
+                  the object in img. \n\
+                - Returns the peak to side-lobe ratio.  This is a number that measures how \n\
+                  confident the tracker is that the object is inside #get_position(). \n\
+                  Larger values indicate higher confidence.")
+        .def("update_noscale", &::update_noscale, py::arg("image"), "\
+            requires \n\
+                - image is a numpy ndarray containing either an 8bit grayscale or RGB image. \n\
+                - get_position().is_empty() == false \n\
+                  (i.e. you must have started tracking by calling start_track()) \n\
+            ensures \n\
+                - performs: return update_noscale(img, get_position())")
+        .def("update_noscale", &::update_noscale_guess, py::arg("image"), py::arg("guess"), "\
             requires \n\
                 - image is a numpy ndarray containing either an 8bit grayscale or RGB image. \n\
                 - get_position().is_empty() == false \n\


### PR DESCRIPTION
Hi,

I've updated python bindings for correlation tracker a little bit. Now there are two new functions: `update_noscale` and `update_noscale_guess`.