### PR TITLE
Python Image and Rectangle Scaling

### DIFF
--- a/dlib/geometry/drectangle.h
+++ b/dlib/geometry/drectangle.h
@@ -441,6 +441,20 @@ namespace dlib
         return shrink_rect(rect, -width, -height);
     }
 
+    inline const drectangle scale_rect (
+        const drectangle& rect,
+        double scale
+    )
+    {
+        DLIB_ASSERT(scale > 0, "scale factor must be > 0");
+
+        long l = (long)std::round(rect.left()*scale);
+        long t = (long)std::round(rect.top()*scale);
+        long r = (long)std::round(rect.right()*scale);
+        long b = (long)std::round(rect.bottom()*scale);
+        return drectangle(l, t, r, b);
+    }
+
     inline drectangle set_rect_area (
         const drectangle& rect,
         double area

--- a/dlib/geometry/drectangle.h
+++ b/dlib/geometry/drectangle.h
@@ -448,10 +448,10 @@ namespace dlib
     {
         DLIB_ASSERT(scale > 0, "scale factor must be > 0");
 
-        long l = (long)std::round(rect.left()*scale);
-        long t = (long)std::round(rect.top()*scale);
-        long r = (long)std::round(rect.right()*scale);
-        long b = (long)std::round(rect.bottom()*scale);
+        double l = rect.left() * scale;
+        double t = rect.top() * scale;
+        double r = rect.right() * scale;
+        double b = rect.bottom() * scale;
         return drectangle(l, t, r, b);
     }
 

--- a/dlib/geometry/drectangle_abstract.h
+++ b/dlib/geometry/drectangle_abstract.h
@@ -587,6 +587,20 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    const drectangle scale_rect (
+        const drectangle& rect,
+        double scale
+    );
+    /*!
+        requires
+            - scale > 0
+        ensures
+            - return drectangle(rect.left() * scale, rect.top() * scale, rect.right() * scale, rect.bottom() * scale)
+              (i.e. resizes the given rectangle by multiplying all side coordinates with a scale factor)
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
     drectangle set_rect_area (
         const drectangle& rect,
         double area

--- a/dlib/geometry/rectangle.h
+++ b/dlib/geometry/rectangle.h
@@ -643,6 +643,22 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    inline const rectangle scale_rect (
+        const rectangle& rect,
+        double scale
+    )
+    {
+        DLIB_ASSERT(scale > 0, "scale factor must be > 0");
+
+        long l = (long)std::round(rect.left()*scale);
+        long t = (long)std::round(rect.top()*scale);
+        long r = (long)std::round(rect.right()*scale);
+        long b = (long)std::round(rect.bottom()*scale);
+        return rectangle(l, t, r, b);
+    }
+
+// ----------------------------------------------------------------------------------------
+
     inline const rectangle translate_rect (
         const rectangle& rect,
         const point& p

--- a/dlib/geometry/rectangle_abstract.h
+++ b/dlib/geometry/rectangle_abstract.h
@@ -611,6 +611,20 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    const rectangle scale_rect (
+        const rectangle& rect,
+        double scale
+    );
+    /*!
+        requires
+            - scale > 0
+        ensures
+            - return rectangle(rect.left() * scale, rect.top() * scale, rect.right() * scale, rect.bottom() * scale)
+              (i.e. resizes the given rectangle by multiplying all side coordinates with a scale factor)
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
     const rectangle translate_rect (
         const rectangle& rect,
         const point& p

--- a/tools/python/src/image2.cpp
+++ b/tools/python/src/image2.cpp
@@ -29,6 +29,20 @@ numpy_image<T> py_resize_image (
 // ----------------------------------------------------------------------------------------
 
 template <typename T>
+numpy_image<T> py_scale_image (
+    const numpy_image<T>& img,
+    double scale
+)
+{
+    DLIB_CASSERT(scale > 0, "Scale factor must be greater than 0");
+    numpy_image<T> out = img;
+    resize_image(scale, out);
+    return out;
+}
+
+// ----------------------------------------------------------------------------------------
+
+template <typename T>
 numpy_image<T> py_equalize_histogram (
     const numpy_image<T>& img
 )
@@ -535,6 +549,16 @@ void bind_image_classes2(py::module& m)
     m.def("resize_image", &py_resize_image<float>, py::arg("img"), py::arg("rows"), py::arg("cols"));
     m.def("resize_image", &py_resize_image<double>, docs, py::arg("img"), py::arg("rows"), py::arg("cols"));
     m.def("resize_image", &py_resize_image<rgb_pixel>, docs, py::arg("img"), py::arg("rows"), py::arg("cols"));
+
+    m.def("scale_image", &py_scale_image<int8_t>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<int16_t>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<int32_t>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<int64_t>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<float>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<double>, py::arg("img"), py::arg("scale"));
+    m.def("scale_image", &py_scale_image<rgb_pixel>, py::arg("img"), py::arg("scale"),
+        "Return img resized by scale factor"
+        );
 
     register_extract_image_chip(m);
 

--- a/tools/python/src/image2.cpp
+++ b/tools/python/src/image2.cpp
@@ -549,15 +549,14 @@ void bind_image_classes2(py::module& m)
     m.def("resize_image", &py_resize_image<float>, py::arg("img"), py::arg("rows"), py::arg("cols"));
     m.def("resize_image", &py_resize_image<double>, docs, py::arg("img"), py::arg("rows"), py::arg("cols"));
     m.def("resize_image", &py_resize_image<rgb_pixel>, docs, py::arg("img"), py::arg("rows"), py::arg("cols"));
-
-    m.def("scale_image", &py_scale_image<int8_t>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<int16_t>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<int32_t>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<int64_t>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<float>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<double>, py::arg("img"), py::arg("scale"));
-    m.def("scale_image", &py_scale_image<rgb_pixel>, py::arg("img"), py::arg("scale"),
-        "Return img resized by scale factor"
+    m.def("resize_image", &py_scale_image<int8_t>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<int16_t>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<int32_t>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<int64_t>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<float>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<double>, py::arg("img"), py::arg("scale"));
+    m.def("resize_image", &py_scale_image<rgb_pixel>, py::arg("img"), py::arg("scale"),
+        "Resizes img, using bilinear interpolation, to have the new size (img rows * scale, img cols * scale)"
         );
 
     register_extract_image_chip(m);

--- a/tools/python/src/rectangles.cpp
+++ b/tools/python/src/rectangles.cpp
@@ -290,6 +290,11 @@ ensures \n\
   (i.e. grows the given rectangle by expanding its border by num)",
         py::arg("rect"), py::arg("num"));
 
+    m.def("scale_rect", [](const rectangle& rect, double scale){return scale_rect(rect,scale);},
+"- return scale_rect(rect, scale) \n\
+(i.e. resizes the given rectangle by a scale factor)",
+        py::arg("rect"), py::arg("scale"));
+
     m.def("centered_rect", [](const point& p, unsigned long width, unsigned long height) {
         return centered_rect(p, width, height); },
         py::arg("p"), py::arg("width"), py::arg("height"));


### PR DESCRIPTION
Added a python function `scale_image` that uses dlib `resize_image` to do scaling. Not sure if this is OK as its own function or rather should just be another signature of `resize_image` binding?

I often have to down scale large images in order to fit into graphics memory for cnn face detection but then want to use the original full size image for pose prediction. I have added `scale_rect` for rectangle and drectangle which accepts a scale factor so that the detected face rect can be rescaled back to fit the face in the original full size image.