### PR TITLE
Set CMake policy CMP0048 to NEW when available.

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -5,6 +5,11 @@
 
 
 cmake_minimum_required(VERSION 2.8.12)
+
+if(POLICY CMP0048)
+   cmake_policy(SET CMP0048 NEW)
+endif()
+
 project(dlib)
 
 set(CPACK_PACKAGE_NAME "dlib")


### PR DESCRIPTION
When using dlib as explain in examples/CMakeLists.txt, from a CMake project with cmake minimum required version >= 3.0, this warning is displayed:  
```
CMake Warning (dev) at /home/facug91/dlib/dlib/CMakeLists.txt:9 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
This warning is for project developers.  Use -Wno-dev to suppress it.
```

As dlib uses it's own version variables, there's no need to use version in the project command, so simple setting this policy to NEW avoids the warnings (and setting it to OLD is deprecated since version 3.3 https://cmake.org/cmake/help/v3.12/policy/CMP0048.html).
