### PR TITLE
Fix #787: find MKL FFT with CMake on Windows

### DIFF
--- a/dlib/cmake_utils/find_blas.cmake
+++ b/dlib/cmake_utils/find_blas.cmake
@@ -312,6 +312,20 @@ elseif(WIN32 AND NOT MINGW)
 
    INCLUDE (CheckFunctionExists)
 
+   # Get mkl_include_dir
+   set(mkl_include_search_path
+      "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries_*/windows/mkl/include"
+      "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries_*/windows/compiler/include"
+      "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/compiler/include"
+      "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/mkl/include"
+      "C:/Program Files (x86)/Intel/Composer XE/mkl/include"
+      "C:/Program Files (x86)/Intel/Composer XE/compiler/include"
+      "C:/Program Files/Intel/Composer XE/mkl/include"
+      "C:/Program Files/Intel/Composer XE/compiler/include"
+      )
+   find_path(mkl_include_dir mkl_version.h ${mkl_include_search_path})
+   mark_as_advanced(mkl_include_dir)
+
    # Search for the needed libraries from the MKL.  
    find_library(mkl_core mkl_core ${mkl_search_path})
    set(mkl_libs ${mkl_intel} ${mkl_core})
@@ -333,6 +347,7 @@ elseif(WIN32 AND NOT MINGW)
       set(lapack_libraries ${mkl_libs})
       set(blas_found 1)
       set(lapack_found 1)
+      set(found_intel_mkl 1)
       message(STATUS "Found Intel MKL BLAS/LAPACK library")
 
       # Make sure the version of the Intel MKL we found is compatible with
@@ -346,6 +361,11 @@ elseif(WIN32 AND NOT MINGW)
          set(lapack_found 0)
       endif()
    endif()
+
+   if (found_intel_mkl AND mkl_include_dir)
+      set(found_intel_mkl_headers 1)
+   endif()
+
 endif()
 
 


### PR DESCRIPTION
Issue #787 was closed, because no PR was made, but the bug in the CMake remained.  
The problem was that on Windows, CMake script was not looking up for mkl headers path. I've just added quite the same code used on UNIX, with different hint paths.

I need this for the tracker module, and there's where I've tried it. I've also compiled and run all tests.

Anyway, there was a test that failed, but it doesn't seem to have anything to do with this change. This is the exact error message:  
```
Error occurred at line 108.  
Error occurred in file c:\dlib\dlib\test\is_same_object.cpp.  
Failing expression was is_same_object(a,b) == false.  
```