### PR TITLE
Apply the #1514 fix even on non-Windows platforms, and change all remaining cudaStreamSynchronize calls

### DIFF
--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -79,11 +79,12 @@ namespace dlib
     }
 // ----------------------------------------------------------------------------------------
 
-    // This should be pretty much the same as cudaStreamSynchronize, which for some
-    // reason makes training freeze in some cases.
-    // (see https://github.com/davisking/dlib/issues/1513)
     void synchronize_stream(cudaStream_t stream)
     {
+#if CUDA_VERSION == 10000
+        // This should be pretty much the same as cudaStreamSynchronize, which for some
+        // reason makes training freeze in some cases.
+        // (see https://github.com/davisking/dlib/issues/1513)
         while (true)
         {
             cudaError_t err = cudaStreamQuery(stream);
@@ -94,6 +95,9 @@ namespace dlib
             default: CHECK_CUDA(err);      // unexpected error: throw
             }
         }
+#else // CUDA_VERSION
+        cudaStreamSynchronize(stream);
+#endif // CUDA_VERSION
     }
 
     void gpu_data::

--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -96,7 +96,7 @@ namespace dlib
             }
         }
 #else // CUDA_VERSION
-        cudaStreamSynchronize(stream);
+        CHECK_CUDA(cudaStreamSynchronize(stream));
 #endif // CUDA_VERSION
     }
 

--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -118,9 +118,8 @@ namespace dlib
         }
     }
 
-#ifdef WIN32
     // This should be pretty much the same as cudaStreamSynchronize, which for some
-    // reason makes training freeze on some Windows machines.
+    // reason makes training freeze in some cases.
     // (see https://github.com/davisking/dlib/issues/1513)
     void synchronize_stream(cudaStream_t stream)
     {
@@ -135,7 +134,6 @@ namespace dlib
             }
         }
     }
-#endif // WIN32
 
     void gpu_data::
     async_copy_to_device() const
@@ -146,11 +144,7 @@ namespace dlib
             {
                 // Wait for any possible CUDA kernels that might be using our memory block to
                 // complete before we overwrite the memory.
-#ifdef WIN32
                 synchronize_stream(0);
-#else
-                CHECK_CUDA(cudaStreamSynchronize(0));
-#endif
 
                 device_in_use = false;
             }

--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -81,7 +81,7 @@ namespace dlib
 
     void synchronize_stream(cudaStream_t stream)
     {
-#if CUDA_VERSION == 10000
+#if CUDA_VERSION >= 9020 && CUDA_VERSION <= 10000
         // This should be pretty much the same as cudaStreamSynchronize, which for some
         // reason makes training freeze in some cases.
         // (see https://github.com/davisking/dlib/issues/1513)


### PR DESCRIPTION
As [it seems](https://github.com/davisking/dlib/issues/1513#issuecomment-447716981) that #1513 may occur also outside Windows (e.g., RHEL 7), make the #1514 fix apply on other platforms as well.