### PR TITLE
Add U-net style skip connections to the semantic-segmentation example

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2317,7 +2317,10 @@ namespace dlib
                             t2.nr(),
                             t2.nc());
 
-            tt::copy_tensor(false, output, 0, resize_if_needed(t1, t2.nr(), t2.nc(), tt::resize_bilinear), 0, t1.k());
+            // tt::resize_bilinear is overloaded, so let's resolve the ambiguity
+            const auto resize = [](tensor& d, const tensor& s) { tt::resize_bilinear(d, s); };
+
+            tt::copy_tensor(false, output, 0, resize_if_needed(t1, t2.nr(), t2.nc(), resize), 0, t1.k());
             tt::copy_tensor(false, output, t1.k(), t2, 0, t2.k());
         }
 
@@ -2332,8 +2335,11 @@ namespace dlib
             const auto nr = gradient_input.nr();
             const auto nc = gradient_input.nc();
 
-            tt::copy_tensor(true, resize_if_needed(t1, nr, nc, tt::resize_bilinear_gradient), 0, gradient_input, 0, t1.k());
-            tt::copy_tensor(true, resize_if_needed(t2, nr, nc, tt::resize_bilinear_gradient), 0, gradient_input, t1.k(), t2.k());
+            // tt::resize_bilinear_gradient is overloaded, so let's resolve the ambiguity
+            const auto resize = [](tensor& d, const tensor& s) { tt::resize_bilinear_gradient(d, s); };
+
+            tt::copy_tensor(true, resize_if_needed(t1, nr, nc, resize), 0, gradient_input, 0, t1.k());
+            tt::copy_tensor(true, resize_if_needed(t2, nr, nc, resize), 0, gradient_input, t1.k(), t2.k());
         }
 
         const tensor& get_layer_params() const { return params; }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2290,6 +2290,120 @@ namespace dlib
     template <
         template<typename> class tag
         >
+    class concat_prev_
+    {
+    public:
+        const static unsigned long id = tag_id<tag>::id;
+
+        concat_prev_() 
+        {
+        }
+
+        template <typename SUBNET>
+        void setup (const SUBNET& /*sub*/)
+        {
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            auto&& t1 = sub.get_output();
+            auto&& t2 = layer<tag>(sub).get_output();
+
+            DLIB_CASSERT(t1.num_samples() == t2.num_samples());
+            DLIB_CASSERT(t1.nr() == t2.nr());
+            DLIB_CASSERT(t1.nc() == t2.nc());
+
+            output.set_size(t1.num_samples(),
+                            t1.k()+t2.k(),
+                            t1.nr(),
+                            t1.nc());
+
+            tt::copy_tensor(false, output, 0, t1, 0, t1.k());
+            tt::copy_tensor(false, output, t1.k(), t2, 0, t2.k());
+        }
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
+        {
+            auto& t1 = sub.get_gradient_input();
+            auto& t2 = layer<tag>(sub).get_gradient_input();
+
+            DLIB_CASSERT(t1.k() + t2.k() == gradient_input.k());
+
+            tt::copy_tensor(true, t1, 0, gradient_input, 0, t1.k());
+            tt::copy_tensor(true, t2, 0, gradient_input, t1.k(), t2.k());
+        }
+
+        const tensor& get_layer_params() const { return params; }
+        tensor& get_layer_params() { return params; }
+
+        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
+
+        friend void serialize(const concat_prev_& , std::ostream& out)
+        {
+            serialize("concat_prev_", out);
+        }
+
+        friend void deserialize(concat_prev_& , std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            if (version != "concat_prev_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::concat_prev_.");
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const concat_prev_& item)
+        {
+            out << "concat_prev"<<id;
+            return out;
+        }
+
+        friend void to_xml(const concat_prev_& item, std::ostream& out)
+        {
+            out << "<concat_prev tag='"<<id<<"'/>\n";
+        }
+
+    private:
+        resizable_tensor params;
+    };
+
+    template <
+        template<typename> class tag,
+        typename SUBNET
+        >
+    using concat_prev = add_layer<concat_prev_<tag>, SUBNET>;
+
+    template <typename SUBNET> using concat_prev1  = concat_prev<tag1, SUBNET>;
+    template <typename SUBNET> using concat_prev2  = concat_prev<tag2, SUBNET>;
+    template <typename SUBNET> using concat_prev3  = concat_prev<tag3, SUBNET>;
+    template <typename SUBNET> using concat_prev4  = concat_prev<tag4, SUBNET>;
+    template <typename SUBNET> using concat_prev5  = concat_prev<tag5, SUBNET>;
+    template <typename SUBNET> using concat_prev6  = concat_prev<tag6, SUBNET>;
+    template <typename SUBNET> using concat_prev7  = concat_prev<tag7, SUBNET>;
+    template <typename SUBNET> using concat_prev8  = concat_prev<tag8, SUBNET>;
+    template <typename SUBNET> using concat_prev9  = concat_prev<tag9, SUBNET>;
+    template <typename SUBNET> using concat_prev10 = concat_prev<tag10, SUBNET>;
+
+#if 0
+    using concat_prev1_  = concat_prev_<tag1>;
+    using concat_prev2_  = concat_prev_<tag2>;
+    using concat_prev3_  = concat_prev_<tag3>;
+    using concat_prev4_  = concat_prev_<tag4>;
+    using concat_prev5_  = concat_prev_<tag5>;
+    using concat_prev6_  = concat_prev_<tag6>;
+    using concat_prev7_  = concat_prev_<tag7>;
+    using concat_prev8_  = concat_prev_<tag8>;
+    using concat_prev9_  = concat_prev_<tag9>;
+    using concat_prev10_ = concat_prev_<tag10>;
+#endif
+
+// ----------------------------------------------------------------------------------------
+
+    template <
+        template<typename> class tag
+        >
     class mult_prev_
     {
     public:

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2317,7 +2317,7 @@ namespace dlib
                             t2.nr(),
                             t2.nc());
 
-            tt::copy_tensor(false, output, 0, resize_if_needed(t1, t2.nr(), t2.nc()), 0, t1.k());
+            tt::copy_tensor(false, output, 0, resize_if_needed(t1, t2.nr(), t2.nc(), tt::resize_bilinear), 0, t1.k());
             tt::copy_tensor(false, output, t1.k(), t2, 0, t2.k());
         }
 
@@ -2332,8 +2332,8 @@ namespace dlib
             const auto nr = gradient_input.nr();
             const auto nc = gradient_input.nc();
 
-            tt::copy_tensor(true, resize_if_needed(t1, nr, nc), 0, gradient_input, 0, t1.k()); 
-            tt::copy_tensor(true, resize_if_needed(t2, nr, nc), 0, gradient_input, t1.k(), t2.k());
+            tt::copy_tensor(true, resize_if_needed(t1, nr, nc, tt::resize_bilinear_gradient), 0, gradient_input, 0, t1.k());
+            tt::copy_tensor(true, resize_if_needed(t2, nr, nc, tt::resize_bilinear_gradient), 0, gradient_input, t1.k(), t2.k());
         }
 
         const tensor& get_layer_params() const { return params; }
@@ -2371,7 +2371,7 @@ namespace dlib
 
         // Handle both tensor& and const tensor& inputs and outputs using this template function.
         template <typename TENSOR>
-        TENSOR& resize_if_needed(TENSOR& input, int nr, int nc)
+        TENSOR& resize_if_needed(TENSOR& input, int nr, int nc, const std::function<void(tensor&,const tensor&)>& resize)
         {
             if (input.nr() == nr && input.nc() == nc) {
                 // Great - we don't need to do anything at all!
@@ -2384,7 +2384,7 @@ namespace dlib
             DLIB_CASSERT(std::abs(input.nc() - nc) <= 1);
 
             resize_temp.set_size(input.num_samples(), input.k(), nr, nc);
-            tt::resize_bilinear(resize_temp, input);
+            resize(resize_temp, input);
             return resize_temp;
         }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2311,15 +2311,25 @@ namespace dlib
             auto&& t2 = layer<tag>(sub).get_output();
 
             DLIB_CASSERT(t1.num_samples() == t2.num_samples());
-            DLIB_CASSERT(t1.nr() == t2.nr());
-            DLIB_CASSERT(t1.nc() == t2.nc());
 
-            output.set_size(t1.num_samples(),
-                            t1.k()+t2.k(),
-                            t1.nr(),
-                            t1.nc());
+            output.set_size(t2.num_samples(),
+                            t1.k() + t2.k(),
+                            t2.nr(),
+                            t2.nc());
 
-            tt::copy_tensor(false, output, 0, t1, 0, t1.k());
+            if (t1.nr() != t2.nr() || t1.nc() != t2.nc())
+            {
+                // resize t1 to size of t2 - TODO: try to optimize this maybe?
+                dlib::resizable_tensor temp;
+                temp.set_size(t1.num_samples(), t1.k(), t2.nr(), t2.nc());
+                tt::resize_bilinear(temp, t1);
+                tt::copy_tensor(false, output, 0, temp, 0, t1.k());
+            }
+            else
+            {
+                tt::copy_tensor(false, output, 0, t1, 0, t1.k());
+            }
+
             tt::copy_tensor(false, output, t1.k(), t2, 0, t2.k());
         }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2290,12 +2290,12 @@ namespace dlib
     template <
         template<typename> class tag
         >
-    class concat_prev_
+    class resize_to_prev_
     {
     public:
         const static unsigned long id = tag_id<tag>::id;
 
-        concat_prev_() 
+        resize_to_prev_()
         {
         }
 
@@ -2307,33 +2307,42 @@ namespace dlib
         template <typename SUBNET>
         void forward(const SUBNET& sub, resizable_tensor& output)
         {
-            auto&& t1 = sub.get_output();
-            auto&& t2 = layer<tag>(sub).get_output();
+            auto& t = sub.get_output();
+            auto& prev = layer<tag>(sub).get_output();
 
-            DLIB_CASSERT(t1.num_samples() == t2.num_samples());
+            DLIB_CASSERT(t.num_samples() == prev.num_samples());
 
-            output.set_size(t2.num_samples(),
-                            t1.k() + t2.k(),
-                            t2.nr(),
-                            t2.nc());
+            output.set_size(t.num_samples(),
+                            t.k(),
+                            prev.nr(),
+                            prev.nc());
 
-            tt::copy_tensor(false, output, 0, resize_if_needed(t1, t2.nr(), t2.nc(), direction::forward), 0, t1.k());
-            tt::copy_tensor(false, output, t1.k(), t2, 0, t2.k());
+            if (t.nr() == prev.nr() && t.nc() == prev.nc())
+            {
+                tt::copy_tensor(false, output, 0, t, 0, t.k());
+            }
+            else
+            {
+                tt::resize_bilinear(output, t);
+            }
         }
 
         template <typename SUBNET>
         void backward(const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
         {
-            auto& t1 = sub.get_gradient_input();
-            auto& t2 = layer<tag>(sub).get_gradient_input();
+            auto& t = sub.get_gradient_input();
 
-            DLIB_CASSERT(t1.k() + t2.k() == gradient_input.k());
+            DLIB_CASSERT(t.k() == gradient_input.k());
+            DLIB_CASSERT(t.num_samples() == gradient_input.num_samples());
 
-            const auto nr = gradient_input.nr();
-            const auto nc = gradient_input.nc();
-
-            tt::copy_tensor(true, resize_if_needed(t1, nr, nc, direction::backward), 0, gradient_input, 0, t1.k());
-            tt::copy_tensor(true, resize_if_needed(t2, nr, nc, direction::backward), 0, gradient_input, t1.k(), t2.k());
+            if (t.nr() == gradient_input.nr() && t.nc() == gradient_input.nc())
+            {
+                tt::copy_tensor(true, t, 0, gradient_input, 0, t.k());
+            }
+            else
+            {
+                tt::resize_bilinear_gradient(t, gradient_input);
+            }
         }
 
         const tensor& get_layer_params() const { return params; }
@@ -2342,98 +2351,39 @@ namespace dlib
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }
         inline dpoint map_output_to_input (const dpoint& p) const { return p; }
 
-        friend void serialize(const concat_prev_& , std::ostream& out)
+        friend void serialize(const resize_to_prev_& , std::ostream& out)
         {
-            serialize("concat_prev_", out);
+            serialize("resize_to_prev_", out);
         }
 
-        friend void deserialize(concat_prev_& , std::istream& in)
+        friend void deserialize(resize_to_prev_& , std::istream& in)
         {
             std::string version;
             deserialize(version, in);
-            if (version != "concat_prev_")
-                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::concat_prev_.");
+            if (version != "resize_to_prev_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_to_prev_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const concat_prev_& item)
+        friend std::ostream& operator<<(std::ostream& out, const resize_to_prev_& item)
         {
-            out << "concat_prev"<<id;
+            out << "resize_to_prev"<<id;
             return out;
         }
 
-        friend void to_xml(const concat_prev_& item, std::ostream& out)
+        friend void to_xml(const resize_to_prev_& item, std::ostream& out)
         {
-            out << "<concat_prev tag='"<<id<<"'/>\n";
+            out << "<resize_to_prev tag='"<<id<<"'/>\n";
         }
 
     private:
         resizable_tensor params;
-
-        enum class direction { forward, backward };
-
-        // Handle both tensor& and const tensor& inputs and outputs using this template function.
-        template <typename TENSOR>
-        TENSOR& resize_if_needed(TENSOR& input, int nr, int nc, direction direction)
-        {
-            if (input.nr() == nr && input.nc() == nc) {
-                // Great - we don't need to do anything at all!
-                return input;
-            }
-
-            // In U-net style usage, the matrix sizes should differ only very little, if at all.
-            // In other possible applications however, this requirement may need to be relaxed.
-            DLIB_CASSERT(std::abs(input.nr() - nr) <= 1);
-            DLIB_CASSERT(std::abs(input.nc() - nc) <= 1);
-
-            resize_temp.set_size(input.num_samples(), input.k(), nr, nc);
-
-            if (direction == direction::forward) {
-                tt::resize_bilinear(resize_temp, input);
-            }
-            else if (direction == direction::backward) {
-                std::fill(resize_temp.begin(), resize_temp.end(), 0.f);
-                tt::resize_bilinear_gradient(resize_temp, input);
-            }
-            else {
-                DLIB_CASSERT(direction == direction::forward
-                          || direction == direction::backward);
-            }
-
-            return resize_temp;
-        }
-
-        resizable_tensor resize_temp;
     };
 
     template <
         template<typename> class tag,
         typename SUBNET
         >
-    using concat_prev = add_layer<concat_prev_<tag>, SUBNET>;
-
-    template <typename SUBNET> using concat_prev1  = concat_prev<tag1, SUBNET>;
-    template <typename SUBNET> using concat_prev2  = concat_prev<tag2, SUBNET>;
-    template <typename SUBNET> using concat_prev3  = concat_prev<tag3, SUBNET>;
-    template <typename SUBNET> using concat_prev4  = concat_prev<tag4, SUBNET>;
-    template <typename SUBNET> using concat_prev5  = concat_prev<tag5, SUBNET>;
-    template <typename SUBNET> using concat_prev6  = concat_prev<tag6, SUBNET>;
-    template <typename SUBNET> using concat_prev7  = concat_prev<tag7, SUBNET>;
-    template <typename SUBNET> using concat_prev8  = concat_prev<tag8, SUBNET>;
-    template <typename SUBNET> using concat_prev9  = concat_prev<tag9, SUBNET>;
-    template <typename SUBNET> using concat_prev10 = concat_prev<tag10, SUBNET>;
-
-#if 0
-    using concat_prev1_  = concat_prev_<tag1>;
-    using concat_prev2_  = concat_prev_<tag2>;
-    using concat_prev3_  = concat_prev_<tag3>;
-    using concat_prev4_  = concat_prev_<tag4>;
-    using concat_prev5_  = concat_prev_<tag5>;
-    using concat_prev6_  = concat_prev_<tag6>;
-    using concat_prev7_  = concat_prev_<tag7>;
-    using concat_prev8_  = concat_prev_<tag8>;
-    using concat_prev9_  = concat_prev_<tag9>;
-    using concat_prev10_ = concat_prev_<tag10>;
-#endif
+    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2391,12 +2391,12 @@ namespace dlib
     template <
         template<typename> class tag
         >
-    class resize_to_prev_
+    class resize_prev_to_tagged_
     {
     public:
         const static unsigned long id = tag_id<tag>::id;
 
-        resize_to_prev_()
+        resize_prev_to_tagged_()
         {
         }
 
@@ -2408,41 +2408,41 @@ namespace dlib
         template <typename SUBNET>
         void forward(const SUBNET& sub, resizable_tensor& output)
         {
-            auto& t = sub.get_output();
-            auto& prev = layer<tag>(sub).get_output();
+            auto& prev = sub.get_output();
+            auto& tagged = layer<tag>(sub).get_output();
 
-            DLIB_CASSERT(t.num_samples() == prev.num_samples());
+            DLIB_CASSERT(prev.num_samples() == tagged.num_samples());
 
-            output.set_size(t.num_samples(),
-                            t.k(),
-                            prev.nr(),
-                            prev.nc());
+            output.set_size(prev.num_samples(),
+                            prev.k(),
+                            tagged.nr(),
+                            tagged.nc());
 
-            if (t.nr() == prev.nr() && t.nc() == prev.nc())
+            if (prev.nr() == tagged.nr() && prev.nc() == tagged.nc())
             {
-                tt::copy_tensor(false, output, 0, t, 0, t.k());
+                tt::copy_tensor(false, output, 0, prev, 0, prev.k());
             }
             else
             {
-                tt::resize_bilinear(output, t);
+                tt::resize_bilinear(output, prev);
             }
         }
 
         template <typename SUBNET>
         void backward(const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
         {
-            auto& t = sub.get_gradient_input();
+            auto& prev = sub.get_gradient_input();
 
-            DLIB_CASSERT(t.k() == gradient_input.k());
-            DLIB_CASSERT(t.num_samples() == gradient_input.num_samples());
+            DLIB_CASSERT(prev.k() == gradient_input.k());
+            DLIB_CASSERT(prev.num_samples() == gradient_input.num_samples());
 
-            if (t.nr() == gradient_input.nr() && t.nc() == gradient_input.nc())
+            if (prev.nr() == gradient_input.nr() && prev.nc() == gradient_input.nc())
             {
-                tt::copy_tensor(true, t, 0, gradient_input, 0, t.k());
+                tt::copy_tensor(true, prev, 0, gradient_input, 0, prev.k());
             }
             else
             {
-                tt::resize_bilinear_gradient(t, gradient_input);
+                tt::resize_bilinear_gradient(prev, gradient_input);
             }
         }
 
@@ -2452,28 +2452,28 @@ namespace dlib
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }
         inline dpoint map_output_to_input (const dpoint& p) const { return p; }
 
-        friend void serialize(const resize_to_prev_& , std::ostream& out)
+        friend void serialize(const resize_prev_to_tagged_& , std::ostream& out)
         {
-            serialize("resize_to_prev_", out);
+            serialize("resize_prev_to_tagged_", out);
         }
 
-        friend void deserialize(resize_to_prev_& , std::istream& in)
+        friend void deserialize(resize_prev_to_tagged_& , std::istream& in)
         {
             std::string version;
             deserialize(version, in);
-            if (version != "resize_to_prev_")
-                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_to_prev_.");
+            if (version != "resize_prev_to_tagged_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_prev_to_tagged_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const resize_to_prev_& item)
+        friend std::ostream& operator<<(std::ostream& out, const resize_prev_to_tagged_& item)
         {
-            out << "resize_to_prev"<<id;
+            out << "resize_prev_to_tagged"<<id;
             return out;
         }
 
-        friend void to_xml(const resize_to_prev_& item, std::ostream& out)
+        friend void to_xml(const resize_prev_to_tagged_& item, std::ostream& out)
         {
-            out << "<resize_to_prev tag='"<<id<<"'/>\n";
+            out << "<resize_prev_to_tagged tag='"<<id<<"'/>\n";
         }
 
     private:
@@ -2484,7 +2484,7 @@ namespace dlib
         template<typename> class tag,
         typename SUBNET
         >
-    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
+    using resize_prev_to_tagged = add_layer<resize_prev_to_tagged_<tag>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2290,106 +2290,6 @@ namespace dlib
     template <
         template<typename> class tag
         >
-    class resize_to_prev_
-    {
-    public:
-        const static unsigned long id = tag_id<tag>::id;
-
-        resize_to_prev_()
-        {
-        }
-
-        template <typename SUBNET>
-        void setup (const SUBNET& /*sub*/)
-        {
-        }
-
-        template <typename SUBNET>
-        void forward(const SUBNET& sub, resizable_tensor& output)
-        {
-            auto& t = sub.get_output();
-            auto& prev = layer<tag>(sub).get_output();
-
-            DLIB_CASSERT(t.num_samples() == prev.num_samples());
-
-            output.set_size(t.num_samples(),
-                            t.k(),
-                            prev.nr(),
-                            prev.nc());
-
-            if (t.nr() == prev.nr() && t.nc() == prev.nc())
-            {
-                tt::copy_tensor(false, output, 0, t, 0, t.k());
-            }
-            else
-            {
-                tt::resize_bilinear(output, t);
-            }
-        }
-
-        template <typename SUBNET>
-        void backward(const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
-        {
-            auto& t = sub.get_gradient_input();
-
-            DLIB_CASSERT(t.k() == gradient_input.k());
-            DLIB_CASSERT(t.num_samples() == gradient_input.num_samples());
-
-            if (t.nr() == gradient_input.nr() && t.nc() == gradient_input.nc())
-            {
-                tt::copy_tensor(true, t, 0, gradient_input, 0, t.k());
-            }
-            else
-            {
-                tt::resize_bilinear_gradient(t, gradient_input);
-            }
-        }
-
-        const tensor& get_layer_params() const { return params; }
-        tensor& get_layer_params() { return params; }
-
-        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
-        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
-
-        friend void serialize(const resize_to_prev_& , std::ostream& out)
-        {
-            serialize("resize_to_prev_", out);
-        }
-
-        friend void deserialize(resize_to_prev_& , std::istream& in)
-        {
-            std::string version;
-            deserialize(version, in);
-            if (version != "resize_to_prev_")
-                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_to_prev_.");
-        }
-
-        friend std::ostream& operator<<(std::ostream& out, const resize_to_prev_& item)
-        {
-            out << "resize_to_prev"<<id;
-            return out;
-        }
-
-        friend void to_xml(const resize_to_prev_& item, std::ostream& out)
-        {
-            out << "<resize_to_prev tag='"<<id<<"'/>\n";
-        }
-
-    private:
-        resizable_tensor params;
-    };
-
-    template <
-        template<typename> class tag,
-        typename SUBNET
-        >
-    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
-
-// ----------------------------------------------------------------------------------------
-
-    template <
-        template<typename> class tag
-        >
     class mult_prev_
     {
     public:
@@ -2485,6 +2385,106 @@ namespace dlib
     using mult_prev8_  = mult_prev_<tag8>;
     using mult_prev9_  = mult_prev_<tag9>;
     using mult_prev10_ = mult_prev_<tag10>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <
+        template<typename> class tag
+        >
+    class resize_to_prev_
+    {
+    public:
+        const static unsigned long id = tag_id<tag>::id;
+
+        resize_to_prev_()
+        {
+        }
+
+        template <typename SUBNET>
+        void setup (const SUBNET& /*sub*/)
+        {
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            auto& t = sub.get_output();
+            auto& prev = layer<tag>(sub).get_output();
+
+            DLIB_CASSERT(t.num_samples() == prev.num_samples());
+
+            output.set_size(t.num_samples(),
+                            t.k(),
+                            prev.nr(),
+                            prev.nc());
+
+            if (t.nr() == prev.nr() && t.nc() == prev.nc())
+            {
+                tt::copy_tensor(false, output, 0, t, 0, t.k());
+            }
+            else
+            {
+                tt::resize_bilinear(output, t);
+            }
+        }
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& /*params_grad*/)
+        {
+            auto& t = sub.get_gradient_input();
+
+            DLIB_CASSERT(t.k() == gradient_input.k());
+            DLIB_CASSERT(t.num_samples() == gradient_input.num_samples());
+
+            if (t.nr() == gradient_input.nr() && t.nc() == gradient_input.nc())
+            {
+                tt::copy_tensor(true, t, 0, gradient_input, 0, t.k());
+            }
+            else
+            {
+                tt::resize_bilinear_gradient(t, gradient_input);
+            }
+        }
+
+        const tensor& get_layer_params() const { return params; }
+        tensor& get_layer_params() { return params; }
+
+        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
+
+        friend void serialize(const resize_to_prev_& , std::ostream& out)
+        {
+            serialize("resize_to_prev_", out);
+        }
+
+        friend void deserialize(resize_to_prev_& , std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            if (version != "resize_to_prev_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_to_prev_.");
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const resize_to_prev_& item)
+        {
+            out << "resize_to_prev"<<id;
+            return out;
+        }
+
+        friend void to_xml(const resize_to_prev_& item, std::ostream& out)
+        {
+            out << "<resize_to_prev tag='"<<id<<"'/>\n";
+        }
+
+    private:
+        resizable_tensor params;
+    };
+
+    template <
+        template<typename> class tag,
+        typename SUBNET
+        >
+    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -2387,30 +2387,30 @@ namespace dlib
     template <
         template<typename> class tag
         >
-    class resize_to_prev_
+    class resize_prev_to_tagged_
     {
         /*!
             WHAT THIS OBJECT REPRESENTS
                 This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
-                defined above.  This layer resizes the output channels of the tagged layer to
-                have the same number of rows and columns as the output of the previous layer.
+                defined above.  This layer resizes the output channels of the previous layer
+                to have the same number of rows and columns as the output of the tagged layer.
 
                 This layer uses bilinear interpolation. If the sizes match already, then it
                 simply copies the data.
 
-                Therefore, you supply a tag via resize_to_prev's template argument that tells
-                it what layer to use for the target size.
+                Therefore, you supply a tag via resize_prev_to_tagged's template argument that
+                tells it what layer to use for the target size.
 
-                If tensor A is resized to size of tensor B, then a tensor C is produced such
-                that:
-                    - C.num_samples() == A.num_samples()
-                    - C.k()  == A.k()
-                    - C.nr() == B.nr()
-                    - C.nc() == B.nc()
+                If tensor PREV is resized to size of tensor TAGGED, then a tensor OUT is
+                produced such that:
+                    - OUT.num_samples() == PREV.num_samples()
+                    - OUT.k()  == PREV.k()
+                    - OUT.nr() == TAGGED.nr()
+                    - OUT.nc() == TAGGED.nc()
         !*/
 
     public:
-        resize_to_prev_(
+        resize_prev_to_tagged_(
         ); 
 
         template <typename SUBNET> void setup(const SUBNET& sub);
@@ -2430,7 +2430,7 @@ namespace dlib
         template<typename> class tag,
         typename SUBNET
         >
-    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
+    using resize_prev_to_tagged = add_layer<resize_prev_to_tagged_<tag>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -2387,6 +2387,56 @@ namespace dlib
     template <
         template<typename> class tag
         >
+    class resize_to_prev_
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
+                defined above.  This layer resizes the output channels of the tagged layer to
+                have the same number of rows and columns as the output of the previous layer.
+
+                This layer uses bilinear interpolation. If the sizes match already, then it
+                simply copies the data.
+
+                Therefore, you supply a tag via resize_to_prev's template argument that tells
+                it what layer to use for the target size.
+
+                If tensor A is resized to size of tensor B, then a tensor C is produced such
+                that:
+                    - C.num_samples() == A.num_samples()
+                    - C.k()  == A.k()
+                    - C.nr() == B.nr()
+                    - C.nc() == B.nc()
+        !*/
+
+    public:
+        resize_to_prev_(
+        ); 
+
+        template <typename SUBNET> void setup(const SUBNET& sub);
+        template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& output);
+        template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
+        dpoint map_input_to_output(dpoint p) const;
+        dpoint map_output_to_input(dpoint p) const;
+        const tensor& get_layer_params() const; 
+        tensor& get_layer_params(); 
+        /*!
+            These functions are implemented as described in the EXAMPLE_COMPUTATIONAL_LAYER_ interface.
+        !*/
+    };
+
+
+    template <
+        template<typename> class tag,
+        typename SUBNET
+        >
+    using resize_to_prev = add_layer<resize_to_prev_<tag>, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <
+        template<typename> class tag
+        >
     class scale_
     {
         /*!

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -1910,7 +1910,7 @@ namespace
     template <typename SUBNET> 
     using pres  = prelu<add_prev1<bn_con<con<8,3,3,1,1,prelu<bn_con<con<8,3,3,1,1,tag1<SUBNET>>>>>>>>;
 
-    void test_visit_funcions()
+    void test_visit_functions()
     {
         using net_type2 = loss_multiclass_log<fc<10,
             avg_pool_everything<
@@ -3243,7 +3243,7 @@ namespace
             test_batch_normalize_conv();
             test_basic_tensor_ops();
             test_layers();
-            test_visit_funcions();
+            test_visit_functions();
             test_copy_tensor_cpu();
             test_copy_tensor_add_to_cpu();
             test_concat();

--- a/examples/dnn_semantic_segmentation_ex.cpp
+++ b/examples/dnn_semantic_segmentation_ex.cpp
@@ -17,8 +17,6 @@
 
     An alternative to steps 2-4 above is to download a pre-trained network
     from here: http://dlib.net/files/semantic_segmentation_voc2012net_v2.dnn
-    (or http://dlib.net/files/semantic_segmentation_voc2012net_v2_limited_layer_count.dnn,
-     if using a Microsoft Visual C++ compiler)
 
     It would be a good idea to become familiar with dlib's DNN tooling before reading this
     example.  So you should read dnn_introduction_ex.cpp and dnn_introduction2_ex.cpp

--- a/examples/dnn_semantic_segmentation_ex.cpp
+++ b/examples/dnn_semantic_segmentation_ex.cpp
@@ -17,6 +17,8 @@
 
     An alternative to steps 2-4 above is to download a pre-trained network
     from here: http://dlib.net/files/semantic_segmentation_voc2012net_v2.dnn
+    (or http://dlib.net/files/semantic_segmentation_voc2012net_v2_limited_layer_count.dnn,
+     if using a Microsoft Visual C++ compiler)
 
     It would be a good idea to become familiar with dlib's DNN tooling before reading this
     example.  So you should read dnn_introduction_ex.cpp and dnn_introduction2_ex.cpp
@@ -111,16 +113,16 @@ int main(int argc, char** argv) try
         cout << "You call this program like this: " << endl;
         cout << "./dnn_semantic_segmentation_train_ex /path/to/images" << endl;
         cout << endl;
-        cout << "You will also need a trained 'semantic_segmentation_voc2012net_v2.dnn' file." << endl;
+        cout << "You will also need a trained '" << semantic_segmentation_net_filename << "' file." << endl;
         cout << "You can either train it yourself (see example program" << endl;
         cout << "dnn_semantic_segmentation_train_ex), or download a" << endl;
-        cout << "copy from here: http://dlib.net/files/semantic_segmentation_voc2012net_v2.dnn" << endl;
+        cout << "copy from here: http://dlib.net/files/" << semantic_segmentation_net_filename << endl;
         return 1;
     }
 
     // Read the file containing the trained network from the working directory.
     anet_type net;
-    deserialize("semantic_segmentation_voc2012net_v2.dnn") >> net;
+    deserialize(semantic_segmentation_net_filename) >> net;
 
     // Show inference results in a window.
     image_window win;

--- a/examples/dnn_semantic_segmentation_ex.cpp
+++ b/examples/dnn_semantic_segmentation_ex.cpp
@@ -16,7 +16,7 @@
        ./dnn_semantic_segmentation_ex /path/to/VOC2012-or-other-images
 
     An alternative to steps 2-4 above is to download a pre-trained network
-    from here: http://dlib.net/files/semantic_segmentation_voc2012net.dnn
+    from here: http://dlib.net/files/semantic_segmentation_voc2012net_v2.dnn
 
     It would be a good idea to become familiar with dlib's DNN tooling before reading this
     example.  So you should read dnn_introduction_ex.cpp and dnn_introduction2_ex.cpp
@@ -111,16 +111,16 @@ int main(int argc, char** argv) try
         cout << "You call this program like this: " << endl;
         cout << "./dnn_semantic_segmentation_train_ex /path/to/images" << endl;
         cout << endl;
-        cout << "You will also need a trained 'semantic_segmentation_voc2012net.dnn' file." << endl;
+        cout << "You will also need a trained 'semantic_segmentation_voc2012net_v2.dnn' file." << endl;
         cout << "You can either train it yourself (see example program" << endl;
         cout << "dnn_semantic_segmentation_train_ex), or download a" << endl;
-        cout << "copy from here: http://dlib.net/files/semantic_segmentation_voc2012net.dnn" << endl;
+        cout << "copy from here: http://dlib.net/files/semantic_segmentation_voc2012net_v2.dnn" << endl;
         return 1;
     }
 
     // Read the file containing the trained network from the working directory.
     anet_type net;
-    deserialize("semantic_segmentation_voc2012net.dnn") >> net;
+    deserialize("semantic_segmentation_voc2012net_v2.dnn") >> net;
 
     // Show inference results in a window.
     image_window win;

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -179,21 +179,35 @@ template <typename SUBNET> using alevel4t = dlib::repeat<2,ares64,ares_up<64,SUB
 
 // training network type
 using net_type = dlib::loss_multiclass_log_per_pixel<
-                            dlib::cont<class_count,7,7,2,2,
-                            level4t<level3t<level2t<level1t<
-                            level1<level2<level3<level4<
-                            dlib::max_pool<3,3,2,2,dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
+                            dlib::con<class_count,1,1,1,1,
+                            dlib::concat_prev7<dlib::cont<class_count,7,7,2,2,
+                            dlib::concat_prev6<level4t<
+                            dlib::concat_prev5<level3t<
+                            dlib::concat_prev4<level2t<
+                            dlib::concat_prev3<level1t<
+                            level1<dlib::tag3<
+                            level2<dlib::tag4<
+                            level3<dlib::tag5<
+                            level4<dlib::max_pool<3,3,2,2,dlib::tag6<
+                            dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,dlib::tag7<
                             dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                            >>>>>>>>>>>>>>;
+                            >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = dlib::loss_multiclass_log_per_pixel<
-                            dlib::cont<class_count,7,7,2,2,
-                            alevel4t<alevel3t<alevel2t<alevel1t<
-                            alevel1<alevel2<alevel3<alevel4<
-                            dlib::max_pool<3,3,2,2,dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
+                            dlib::con<class_count,1,1,1,1,
+                            dlib::concat_prev7<dlib::cont<class_count,7,7,2,2,
+                            dlib::concat_prev6<alevel4t<
+                            dlib::concat_prev5<alevel3t<
+                            dlib::concat_prev4<alevel2t<
+                            dlib::concat_prev3<alevel1t<
+                            alevel1<dlib::tag3<
+                            alevel2<dlib::tag4<
+                            alevel3<dlib::tag5<
+                            alevel4<dlib::max_pool<3,3,2,2,dlib::tag6<
+                            dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,dlib::tag7<
                             dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                            >>>>>>>>>>>>>>;
+                            >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -145,34 +145,34 @@ template <int N, typename SUBNET> using ares_up   = dlib::relu<residual_up<block
 
 // ----------------------------------------------------------------------------------------
 
-template <typename SUBNET> using res512 = res<512, SUBNET>;
-template <typename SUBNET> using res256 = res<256, SUBNET>;
-template <typename SUBNET> using res128 = res<128, SUBNET>;
-template <typename SUBNET> using res64  = res<64, SUBNET>;
-template <typename SUBNET> using ares512 = ares<512, SUBNET>;
-template <typename SUBNET> using ares256 = ares<256, SUBNET>;
-template <typename SUBNET> using ares128 = ares<128, SUBNET>;
-template <typename SUBNET> using ares64  = ares<64, SUBNET>;
+template <typename SUBNET> using res64 = res<64,SUBNET>;
+template <typename SUBNET> using res128 = res<128,SUBNET>;
+template <typename SUBNET> using res256 = res<256,SUBNET>;
+template <typename SUBNET> using res512 = res<512,SUBNET>;
+template <typename SUBNET> using ares64 = ares<64,SUBNET>;
+template <typename SUBNET> using ares128 = ares<128,SUBNET>;
+template <typename SUBNET> using ares256 = ares<256,SUBNET>;
+template <typename SUBNET> using ares512 = ares<512,SUBNET>;
 
-template <typename SUBNET> using level1 = dlib::repeat<2,res512,res_down<512,SUBNET>>;
-template <typename SUBNET> using level2 = dlib::repeat<2,res256,res_down<256,SUBNET>>;
-template <typename SUBNET> using level3 = dlib::repeat<2,res128,res_down<128,SUBNET>>;
-template <typename SUBNET> using level4 = dlib::repeat<2,res64,res<64,SUBNET>>;
+template <typename SUBNET> using level1 = dlib::repeat<2,res64,res<64,SUBNET>>;
+template <typename SUBNET> using level2 = dlib::repeat<2,res128,res_down<128,SUBNET>>;
+template <typename SUBNET> using level3 = dlib::repeat<2,res256,res_down<256,SUBNET>>;
+template <typename SUBNET> using level4 = dlib::repeat<2,res512,res_down<512,SUBNET>>;
 
-template <typename SUBNET> using alevel1 = dlib::repeat<2,ares512,ares_down<512,SUBNET>>;
-template <typename SUBNET> using alevel2 = dlib::repeat<2,ares256,ares_down<256,SUBNET>>;
-template <typename SUBNET> using alevel3 = dlib::repeat<2,ares128,ares_down<128,SUBNET>>;
-template <typename SUBNET> using alevel4 = dlib::repeat<2,ares64,ares<64,SUBNET>>;
+template <typename SUBNET> using alevel1 = dlib::repeat<2,ares64,ares<64,SUBNET>>;
+template <typename SUBNET> using alevel2 = dlib::repeat<2,ares128,ares_down<128,SUBNET>>;
+template <typename SUBNET> using alevel3 = dlib::repeat<2,ares256,ares_down<256,SUBNET>>;
+template <typename SUBNET> using alevel4 = dlib::repeat<2,ares512,ares_down<512,SUBNET>>;
 
-template <typename SUBNET> using level1t = dlib::repeat<2,res512,res_up<512,SUBNET>>;
-template <typename SUBNET> using level2t = dlib::repeat<2,res256,res_up<256,SUBNET>>;
-template <typename SUBNET> using level3t = dlib::repeat<2,res128,res_up<128,SUBNET>>;
-template <typename SUBNET> using level4t = dlib::repeat<2,res64,res_up<64,SUBNET>>;
+template <typename SUBNET> using level1t = dlib::repeat<2,res64,res_up<64,SUBNET>>;
+template <typename SUBNET> using level2t = dlib::repeat<2,res128,res_up<128,SUBNET>>;
+template <typename SUBNET> using level3t = dlib::repeat<2,res256,res_up<256,SUBNET>>;
+template <typename SUBNET> using level4t = dlib::repeat<2,res512,res_up<512,SUBNET>>;
 
-template <typename SUBNET> using alevel1t = dlib::repeat<2,ares512,ares_up<512,SUBNET>>;
-template <typename SUBNET> using alevel2t = dlib::repeat<2,ares256,ares_up<256,SUBNET>>;
-template <typename SUBNET> using alevel3t = dlib::repeat<2,ares128,ares_up<128,SUBNET>>;
-template <typename SUBNET> using alevel4t = dlib::repeat<2,ares64,ares_up<64,SUBNET>>;
+template <typename SUBNET> using alevel1t = dlib::repeat<2,ares64,ares_up<64,SUBNET>>;
+template <typename SUBNET> using alevel2t = dlib::repeat<2,ares128,ares_up<128,SUBNET>>;
+template <typename SUBNET> using alevel3t = dlib::repeat<2,ares256,ares_up<256,SUBNET>>;
+template <typename SUBNET> using alevel4t = dlib::repeat<2,ares512,ares_up<512,SUBNET>>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -224,23 +224,23 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::relu<dlib::bn_con<dlib::cont<32,3,3,1,1,concat_utag0<
 #endif
                               dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,concat_utag1<
-                              level4t<
+                              level1t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
 #endif
-                              level3t<concat_utag3<level2t<
+                              level2t<concat_utag3<level3t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
 #endif
-                              level1t<level1<
+                              level4t<level4<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
 #endif
-                              level2<utag3<level3<
+                              level3<utag3<level2<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
 #endif
-                              level4<dlib::max_pool<3,3,2,2,utag1<
+                              level1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
@@ -259,23 +259,23 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::relu<dlib::affine<dlib::cont<32,3,3,1,1,concat_utag0<
 #endif
                               dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,concat_utag1<
-                              alevel4t<
+                              alevel1t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
 #endif
-                              alevel3t<concat_utag3<alevel2t<
+                              alevel2t<concat_utag3<alevel3t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
 #endif
-                              alevel1t<alevel1<
+                              alevel4t<alevel4<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
 #endif
-                              alevel2<utag3<alevel3<
+                              alevel3<utag3<alevel2<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
 #endif
-                              alevel4<dlib::max_pool<3,3,2,2,utag1<
+                              alevel1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -223,15 +223,14 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               dlib::relu<dlib::bn_con<dlib::cont<32,3,3,1,1,concat_utag0<
 #endif
-                              dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,concat_utag1<
-                              level1t<
-                              concat_utag2<
-                              level2t<concat_utag3<level3t<
-                              concat_utag4<
-                              level4t<level4<
-                              utag4<
-                              level3<utag3<level2<
-                              utag2<
+                              dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,
+                              concat_utag1<level1t<
+                              concat_utag2<level2t<
+                              concat_utag3<level3t<
+                              concat_utag4<level4t<
+                              level4<utag4<
+                              level3<utag3<
+                              level2<utag2<
                               level1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
@@ -250,15 +249,14 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               dlib::relu<dlib::affine<dlib::cont<32,3,3,1,1,concat_utag0<
 #endif
-                              dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,concat_utag1<
-                              alevel1t<
-                              concat_utag2<
-                              alevel2t<concat_utag3<alevel3t<
-                              concat_utag4<
-                              alevel4t<alevel4<
-                              utag4<
-                              alevel3<utag3<alevel2<
-                              utag2<
+                              dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,
+                              concat_utag1<alevel1t<
+                              concat_utag2<alevel2t<
+                              concat_utag3<alevel3t<
+                              concat_utag4<alevel4t<
+                              alevel4<utag4<
+                              alevel3<utag3<
+                              alevel2<utag2<
                               alevel1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -228,8 +228,7 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
 #endif
-                              level3t<concat_utag3<
-                              level2t<
+                              level3t<concat_utag3<level2t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
 #endif
@@ -237,16 +236,14 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
 #endif
-                              level2<utag3<
-                              level3<
+                              level2<utag3<level3<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
 #endif
                               level4<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              utag0<
-                              dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
+                              utag0<dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
 #endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
                               >>>>>>>>>>>>>>>>>>>>>
@@ -266,8 +263,7 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
 #endif
-                              alevel3t<concat_utag3<
-                              alevel2t<
+                              alevel3t<concat_utag3<alevel2t<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
 #endif
@@ -275,16 +271,14 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
 #endif
-                              alevel2<utag3<
-                              alevel3<
+                              alevel2<utag3<alevel3<
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
 #endif
                               alevel4<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              utag0<
-                              dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,
+                              utag0<dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,
 #endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
                               >>>>>>>>>>>>>>>>>>>>>

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -177,13 +177,13 @@ template <typename SUBNET> using alevel4t = dlib::repeat<2,ares512,ares_up<512,S
 // ----------------------------------------------------------------------------------------
 
 template <
-    template<typename> class TAG1,
-    template<typename> class TAG2,
+    template<typename> class TAGGED,
+    template<typename> class PREV_RESIZED,
     typename SUBNET
 >
 using resize_and_concat = dlib::add_layer<
-                          dlib::concat_<TAG1,TAG2>,
-                          TAG2<dlib::resize_to_prev<TAG1,SUBNET>>>;
+                          dlib::concat_<TAGGED,PREV_RESIZED>,
+                          PREV_RESIZED<dlib::resize_prev_to_tagged<TAGGED,SUBNET>>>;
 
 template <typename SUBNET> using utag1 = dlib::add_tag_layer<2100+1,SUBNET>;
 template <typename SUBNET> using utag2 = dlib::add_tag_layer<2100+2,SUBNET>;

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -344,26 +344,30 @@ template <typename SUBNET> using alevel4t = dlib::repeat<2,ares64,ares_up<64,SUB
 // training network type
 using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,7,7,2,2,concat_utag1<
-                              level4t<
-                              level3t<
-                              level2t<
-                              level1t<level1<
-                              level2<
-                              level3<
+                              level4t<concat_utag2<
+                              level3t<concat_utag3<
+                              level2t<concat_utag4<
+                              level1t<level1<utag4<
+                              level2<utag3<
+                              level3<utag2<
                               level4<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>;
+                              >>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,7,7,2,2,concat_utag1<
-                              alevel4t<alevel3t<alevel2t<alevel1t<
-                              alevel1<alevel2<alevel3<alevel4<
-                              dlib::max_pool<3,3,2,2,utag1<
+                              alevel4t<concat_utag2<
+                              alevel3t<concat_utag3<
+                              alevel2t<concat_utag4<
+                              alevel1t<alevel1<utag4<
+                              alevel2<utag3<
+                              alevel3<utag2<
+                              alevel4<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>;
+                              >>>>>>>>>>>>>>>>>>>>>>;
 #endif // fallback
 
 // ----------------------------------------------------------------------------------------

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -205,24 +205,14 @@ template <typename SUBNET> using concat_utag4 = resize_and_concat<utag4,utag4_,S
 
 // ----------------------------------------------------------------------------------------
 
-// Microsoft Visual C++ compilers choke when trying to build networks that are too deep.
-// So let's limit the depth a little. On the PASCAL VOC 2012 data, the accuracy hit is
-// not even very significant.
-
-#ifdef _MSC_VER
-#define LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES 1
-static const char* semantic_segmentation_net_filename = "semantic_segmentation_voc2012net_v2_limited_layer_count.dnn";
-#else
-#define LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES 0
 static const char* semantic_segmentation_net_filename = "semantic_segmentation_voc2012net_v2.dnn";
-#endif
+
+// ----------------------------------------------------------------------------------------
 
 // training network type
 using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,1,1,1,1,
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               dlib::relu<dlib::bn_con<dlib::cont<32,3,3,1,1,concat_utag0<
-#endif
                               dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,
                               concat_utag1<level1t<
                               concat_utag2<level2t<
@@ -233,22 +223,14 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               level2<utag2<
                               level1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
-#endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>>>>>
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              >>>>>>>>
-#endif
-                              ;
+                              >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,1,1,1,1,
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               dlib::relu<dlib::affine<dlib::cont<32,3,3,1,1,concat_utag0<
-#endif
                               dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,
                               concat_utag1<alevel1t<
                               concat_utag2<alevel2t<
@@ -259,15 +241,9 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
                               alevel2<utag2<
                               alevel1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,
-#endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>>>>>
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              >>>>>>>>
-#endif
-                              ;
+                              >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -211,8 +211,10 @@ template <typename SUBNET> using concat_utag4 = resize_and_concat<utag4,utag4_,S
 
 #ifdef _MSC_VER
 #define LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES 1
+static const char* semantic_segmentation_net_filename = "semantic_segmentation_voc2012net_v2_limited_layer_count.dnn";
 #else
 #define LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES 0
+static const char* semantic_segmentation_net_filename = "semantic_segmentation_voc2012net_v2.dnn";
 #endif
 
 // training network type

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -115,99 +115,97 @@ const Voc2012class& find_voc2012_class(Predicate predicate)
 // ----------------------------------------------------------------------------------------
 
 // Introduce the building blocks used to define the segmentation network.
-// The network first does residual downsampling (similar to the dnn_imagenet_(train_)ex 
-// example program), and then residual upsampling. The network could be improved e.g.
-// by introducing skip connections from the input image, and/or the first layers, to the
-// last layer(s).  (See Long et al., Fully Convolutional Networks for Semantic Segmentation,
-// https://people.eecs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf)
+// The network first does downsampling, and then upsampling, using
+// DenseNet-style blocks. In addition, U-net style skip connections are
+// employed.
 
-template <int N, template <typename> class BN, int stride, typename SUBNET> 
-using block = BN<dlib::con<N,3,3,1,1, dlib::relu<BN<dlib::con<N,3,3,stride,stride,SUBNET>>>>>;
+template <int N, template <typename> class BN, typename SUBNET>
+using dense_layer = BN<dlib::relu<dlib::con<N,3,3,1,1,SUBNET>>>;
 
-template <int N, template <typename> class BN, int stride, typename SUBNET> 
-using blockt = BN<dlib::cont<N,3,3,1,1,dlib::relu<BN<dlib::cont<N,3,3,stride,stride,SUBNET>>>>>;
+template <int N, template <typename> class BN, typename SUBNET>
+using dense_block = dlib::concat_prev1<dense_layer<N,BN,
+                    dlib::concat_prev2<dense_layer<N,BN,
+                    dlib::concat_prev3<dense_layer<N,BN,
+                    dlib::concat_prev4<dense_layer<N,BN,
+                    dlib::tag4<dlib::tag3<dlib::tag2<dlib::tag1<dense_layer<N,BN,SUBNET>>>>>>>>>>>>>;
 
-template <template <int,template<typename>class,int,typename> class block, int N, template<typename>class BN, typename SUBNET>
-using residual = dlib::add_prev1<block<N,BN,1,dlib::tag1<SUBNET>>>;
+template <int N, template <typename> class BN, typename SUBNET>
+using transition_down = BN<dlib::relu<dlib::con<N,1,1,1,1,dlib::max_pool<3,3,2,2,SUBNET>>>>;
 
-template <template <int,template<typename>class,int,typename> class block, int N, template<typename>class BN, typename SUBNET>
-using residual_down = dlib::add_prev2<dlib::avg_pool<2,2,2,2,dlib::skip1<dlib::tag2<block<N,BN,2,dlib::tag1<SUBNET>>>>>>;
+template <int N, template <typename> class BN, typename SUBNET> 
+using transition_up = dlib::cont<N,3,3,2,2,SUBNET>;
 
-template <template <int,template<typename>class,int,typename> class block, int N, template<typename>class BN, typename SUBNET>
-using residual_up = dlib::add_prev2<dlib::cont<N,2,2,2,2,dlib::skip1<dlib::tag2<blockt<N,BN,2,dlib::tag1<SUBNET>>>>>>;
-
-template <int N, typename SUBNET> using res       = dlib::relu<residual<block,N,dlib::bn_con,SUBNET>>;
-template <int N, typename SUBNET> using ares      = dlib::relu<residual<block,N,dlib::affine,SUBNET>>;
-template <int N, typename SUBNET> using res_down  = dlib::relu<residual_down<block,N,dlib::bn_con,SUBNET>>;
-template <int N, typename SUBNET> using ares_down = dlib::relu<residual_down<block,N,dlib::affine,SUBNET>>;
-template <int N, typename SUBNET> using res_up    = dlib::relu<residual_up<block,N,dlib::bn_con,SUBNET>>;
-template <int N, typename SUBNET> using ares_up   = dlib::relu<residual_up<block,N,dlib::affine,SUBNET>>;
+template <int N, typename SUBNET> using dense     = dense_block<N,dlib::bn_con,SUBNET>;
+template <int N, typename SUBNET> using adense    = dense_block<N,dlib::affine,SUBNET>;
+template <int N, typename SUBNET> using down	  = transition_down<N,dlib::bn_con,SUBNET>;
+template <int N, typename SUBNET> using adown     = transition_down<N,dlib::affine,SUBNET>;
+template <int N, typename SUBNET> using up        = dlib::cont<N,3,3,2,2,SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 
-template <typename SUBNET> using res512 = res<512, SUBNET>;
-template <typename SUBNET> using res256 = res<256, SUBNET>;
-template <typename SUBNET> using res128 = res<128, SUBNET>;
-template <typename SUBNET> using res64  = res<64, SUBNET>;
-template <typename SUBNET> using ares512 = ares<512, SUBNET>;
-template <typename SUBNET> using ares256 = ares<256, SUBNET>;
-template <typename SUBNET> using ares128 = ares<128, SUBNET>;
-template <typename SUBNET> using ares64  = ares<64, SUBNET>;
+template <typename SUBNET> using dense64 = dense<64,SUBNET>;
+template <typename SUBNET> using dense48 = dense<48,SUBNET>;
+template <typename SUBNET> using dense32 = dense<32,SUBNET>;
+template <typename SUBNET> using dense16  = dense<16,SUBNET>;
+template <typename SUBNET> using adense64 = dense<64,SUBNET>;
+template <typename SUBNET> using adense48 = dense<48,SUBNET>;
+template <typename SUBNET> using adense32 = dense<32,SUBNET>;
+template <typename SUBNET> using adense16  = dense<16,SUBNET>;
 
 
-template <typename SUBNET> using level1 = dlib::repeat<2,res512,res_down<512,SUBNET>>;
-template <typename SUBNET> using level2 = dlib::repeat<2,res256,res_down<256,SUBNET>>;
-template <typename SUBNET> using level3 = dlib::repeat<2,res128,res_down<128,SUBNET>>;
-template <typename SUBNET> using level4 = dlib::repeat<2,res64,res<64,SUBNET>>;
+template <typename SUBNET> using level1 = dlib::repeat<2,dense64,down<64,SUBNET>>;
+template <typename SUBNET> using level2 = dlib::repeat<2,dense48,down<48,SUBNET>>;
+template <typename SUBNET> using level3 = dlib::repeat<2,dense32,down<32,SUBNET>>;
+template <typename SUBNET> using level4 = dlib::repeat<2,dense16,down<16,SUBNET>>;
 
-template <typename SUBNET> using alevel1 = dlib::repeat<2,ares512,ares_down<512,SUBNET>>;
-template <typename SUBNET> using alevel2 = dlib::repeat<2,ares256,ares_down<256,SUBNET>>;
-template <typename SUBNET> using alevel3 = dlib::repeat<2,ares128,ares_down<128,SUBNET>>;
-template <typename SUBNET> using alevel4 = dlib::repeat<2,ares64,ares<64,SUBNET>>;
+template <typename SUBNET> using alevel1 = dlib::repeat<2,adense64,adown<64,SUBNET>>;
+template <typename SUBNET> using alevel2 = dlib::repeat<2,adense48,adown<48,SUBNET>>;
+template <typename SUBNET> using alevel3 = dlib::repeat<2,adense32,adown<32,SUBNET>>;
+template <typename SUBNET> using alevel4 = dlib::repeat<2,adense16,adown<16,SUBNET>>;
 
-template <typename SUBNET> using level1t = dlib::repeat<2,res512,res_up<512,SUBNET>>;
-template <typename SUBNET> using level2t = dlib::repeat<2,res256,res_up<256,SUBNET>>;
-template <typename SUBNET> using level3t = dlib::repeat<2,res128,res_up<128,SUBNET>>;
-template <typename SUBNET> using level4t = dlib::repeat<2,res64,res_up<64,SUBNET>>;
+template <typename SUBNET> using level1t = dlib::repeat<2,dense64,up<64,SUBNET>>;
+template <typename SUBNET> using level2t = dlib::repeat<2,dense48,up<48,SUBNET>>;
+template <typename SUBNET> using level3t = dlib::repeat<2,dense32,up<32,SUBNET>>;
+template <typename SUBNET> using level4t = dlib::repeat<2,dense16,up<16,SUBNET>>;
 
-template <typename SUBNET> using alevel1t = dlib::repeat<2,ares512,ares_up<512,SUBNET>>;
-template <typename SUBNET> using alevel2t = dlib::repeat<2,ares256,ares_up<256,SUBNET>>;
-template <typename SUBNET> using alevel3t = dlib::repeat<2,ares128,ares_up<128,SUBNET>>;
-template <typename SUBNET> using alevel4t = dlib::repeat<2,ares64,ares_up<64,SUBNET>>;
+template <typename SUBNET> using alevel1t = dlib::repeat<2,adense64,up<64,SUBNET>>;
+template <typename SUBNET> using alevel2t = dlib::repeat<2,adense48,up<48,SUBNET>>;
+template <typename SUBNET> using alevel3t = dlib::repeat<2,adense32,up<32,SUBNET>>;
+template <typename SUBNET> using alevel4t = dlib::repeat<2,adense16,up<16,SUBNET>>;
 
 // ----------------------------------------------------------------------------------------
 
 // training network type
 using net_type = dlib::loss_multiclass_log_per_pixel<
                             dlib::con<class_count,1,1,1,1,
-                            dlib::concat_prev7<dlib::cont<class_count,7,7,2,2,
-                            dlib::concat_prev6<level4t<
-                            dlib::concat_prev5<level3t<
-                            dlib::concat_prev4<level2t<
-                            dlib::concat_prev3<level1t<
-                            level1<dlib::tag3<
-                            level2<dlib::tag4<
-                            level3<dlib::tag5<
-                            level4<dlib::max_pool<3,3,2,2,dlib::tag6<
-                            dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,dlib::tag7<
+                            dlib::concat_prev9<dlib::cont<class_count,7,7,2,2,
+                            dlib::concat_prev8<level4t<
+                            dlib::concat_prev7<level3t<
+                            dlib::concat_prev6<level2t<
+                            dlib::concat_prev5<level1t<
+                            level1<dlib::tag5<
+                            level2<dlib::tag6<
+                            level3<dlib::tag7<
+                            level4<dlib::tag8<
+                            dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,dlib::tag9<
                             dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                            >>>>>>>>>>>>>>>>>>>>>>>>>;
+                            >>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = dlib::loss_multiclass_log_per_pixel<
                             dlib::con<class_count,1,1,1,1,
-                            dlib::concat_prev7<dlib::cont<class_count,7,7,2,2,
-                            dlib::concat_prev6<alevel4t<
-                            dlib::concat_prev5<alevel3t<
-                            dlib::concat_prev4<alevel2t<
-                            dlib::concat_prev3<alevel1t<
-                            alevel1<dlib::tag3<
-                            alevel2<dlib::tag4<
-                            alevel3<dlib::tag5<
-                            alevel4<dlib::max_pool<3,3,2,2,dlib::tag6<
-                            dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,dlib::tag7<
+                            dlib::concat_prev9<dlib::cont<class_count,7,7,2,2,
+                            dlib::concat_prev8<alevel4t<
+                            dlib::concat_prev7<alevel3t<
+                            dlib::concat_prev6<alevel2t<
+                            dlib::concat_prev5<alevel1t<
+                            alevel1<dlib::tag5<
+                            alevel2<dlib::tag6<
+                            alevel3<dlib::tag7<
+                            alevel4<dlib::tag8<
+                            dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,dlib::tag9<
                             dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                            >>>>>>>>>>>>>>>>>>>>>>>>>;
+                            >>>>>>>>>>>>>>>>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -185,19 +185,16 @@ using resize_and_concat = dlib::add_layer<
                           dlib::concat_<TAG1,TAG2>,
                           TAG2<dlib::resize_to_prev<TAG1,SUBNET>>>;
 
-template <typename SUBNET> using utag0 = dlib::add_tag_layer<2100+0,SUBNET>;
 template <typename SUBNET> using utag1 = dlib::add_tag_layer<2100+1,SUBNET>;
 template <typename SUBNET> using utag2 = dlib::add_tag_layer<2100+2,SUBNET>;
 template <typename SUBNET> using utag3 = dlib::add_tag_layer<2100+3,SUBNET>;
 template <typename SUBNET> using utag4 = dlib::add_tag_layer<2100+4,SUBNET>;
 
-template <typename SUBNET> using utag0_ = dlib::add_tag_layer<2110+0,SUBNET>;
 template <typename SUBNET> using utag1_ = dlib::add_tag_layer<2110+1,SUBNET>;
 template <typename SUBNET> using utag2_ = dlib::add_tag_layer<2110+2,SUBNET>;
 template <typename SUBNET> using utag3_ = dlib::add_tag_layer<2110+3,SUBNET>;
 template <typename SUBNET> using utag4_ = dlib::add_tag_layer<2110+4,SUBNET>;
 
-template <typename SUBNET> using concat_utag0 = resize_and_concat<utag0,utag0_,SUBNET>;
 template <typename SUBNET> using concat_utag1 = resize_and_concat<utag1,utag1_,SUBNET>;
 template <typename SUBNET> using concat_utag2 = resize_and_concat<utag2,utag2_,SUBNET>;
 template <typename SUBNET> using concat_utag3 = resize_and_concat<utag3,utag3_,SUBNET>;
@@ -212,7 +209,6 @@ static const char* semantic_segmentation_net_filename = "semantic_segmentation_v
 // training network type
 using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,1,1,1,1,
-                              dlib::relu<dlib::bn_con<dlib::cont<32,3,3,1,1,concat_utag0<
                               dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,
                               concat_utag1<level1t<
                               concat_utag2<level2t<
@@ -223,14 +219,12 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
                               level2<utag2<
                               level1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
-                              utag0<dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
+                              >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using anet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<class_count,1,1,1,1,
-                              dlib::relu<dlib::affine<dlib::cont<32,3,3,1,1,concat_utag0<
                               dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,
                               concat_utag1<alevel1t<
                               concat_utag2<alevel2t<
@@ -241,9 +235,8 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
                               alevel2<utag2<
                               alevel1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
-                              utag0<dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
+                              >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -225,30 +225,22 @@ using bnet_type = dlib::loss_multiclass_log_per_pixel<
 #endif
                               dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,concat_utag1<
                               level1t<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
-#endif
                               level2t<concat_utag3<level3t<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
-#endif
                               level4t<level4<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
-#endif
                               level3<utag3<level2<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
-#endif
                               level1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::bn_con<dlib::cont<16,3,3,1,1,
 #endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>
+                              >>>>>>>>>>>>>>>>>>>>>>>>>
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              >>>>>>>>>>>>
+                              >>>>>>>>
 #endif
                               ;
 
@@ -260,30 +252,22 @@ using anet_type = dlib::loss_multiclass_log_per_pixel<
 #endif
                               dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,concat_utag1<
                               alevel1t<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag2<
-#endif
                               alevel2t<concat_utag3<alevel3t<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               concat_utag4<
-#endif
                               alevel4t<alevel4<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag4<
-#endif
                               alevel3<utag3<alevel2<
-#if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag2<
-#endif
                               alevel1<dlib::max_pool<3,3,2,2,utag1<
                               dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
                               utag0<dlib::relu<dlib::affine<dlib::cont<16,3,3,1,1,
 #endif
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
-                              >>>>>>>>>>>>>>>>>>>>>
+                              >>>>>>>>>>>>>>>>>>>>>>>>>
 #if LIMIT_LAYER_COUNT_BECAUSE_OF_COMPILER_ISSUES == 0
-                              >>>>>>>>>>>>
+                              >>>>>>>>
 #endif
                               ;
 

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -342,8 +342,8 @@ int main(int argc, char** argv) try
     std::thread data_loader4([f](){ f(4); });
 
     // The main training loop.  Keep making mini-batches and giving them to the trainer.
-    // We will run until the learning rate has dropped by a factor of 1e-8.
-    while(trainer.get_learning_rate() >= 1e-8)
+    // We will run until the learning rate has dropped by a factor of 1e-4.
+    while(trainer.get_learning_rate() >= 1e-4)
     {
         samples.clear();
         labels.clear();

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
  
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 30;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 24;
 
     const double initial_learning_rate = 0.1;
     const double weight_decay = 0.0001;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
 
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 24;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 23;
     cout << "mini-batch size: " << minibatch_size << endl;
 
     const double initial_learning_rate = 0.1;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
 
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 20;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 23;
     cout << "mini-batch size: " << minibatch_size << endl;
 
     const double initial_learning_rate = 0.1;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
 
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 23;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 20;
     cout << "mini-batch size: " << minibatch_size << endl;
 
     const double initial_learning_rate = 0.1;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -259,12 +259,12 @@ double calculate_accuracy(anet_type& anet, const std::vector<image_info>& datase
 
 int main(int argc, char** argv) try
 {
-    if (argc != 2)
+    if (argc < 2 || argc > 3)
     {
         cout << "To run this program you need a copy of the PASCAL VOC2012 dataset." << endl;
         cout << endl;
         cout << "You call this program like this: " << endl;
-        cout << "./dnn_semantic_segmentation_train_ex /path/to/VOC2012" << endl;
+        cout << "./dnn_semantic_segmentation_train_ex /path/to/VOC2012 [minibatch-size]" << endl;
         return 1;
     }
 
@@ -277,7 +277,9 @@ int main(int argc, char** argv) try
         cout << "Didn't find the VOC2012 dataset. " << endl;
         return 1;
     }
-        
+ 
+    // a mini-batch smaller than the default can be used with GPUs having less memory
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 30;
 
     const double initial_learning_rate = 0.1;
     const double weight_decay = 0.0001;
@@ -345,9 +347,9 @@ int main(int argc, char** argv) try
         samples.clear();
         labels.clear();
 
-        // make a 30-image mini-batch
+        // make a mini-batch
         training_sample temp;
-        while(samples.size() < 30)
+        while(samples.size() < minibatch_size)
         {
             data.dequeue(temp);
 

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
  
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 50;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 60;
 
     const double initial_learning_rate = 0.1;
     const double weight_decay = 0.0001;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -374,7 +374,7 @@ int main(int argc, char** argv) try
 
     bnet.clean();
     cout << "saving network" << endl;
-    serialize("semantic_segmentation_voc2012net_v2.dnn") << bnet;
+    serialize(semantic_segmentation_net_filename) << bnet;
 
 
     // Make a copy of the network to use it for inference.

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
  
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 24;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 50;
 
     const double initial_learning_rate = 0.1;
     const double weight_decay = 0.0001;

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv) try
     }
 
     // a mini-batch smaller than the default can be used with GPUs having less memory
-    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 30;
+    const int minibatch_size = argc == 3 ? std::stoi(argv[2]) : 24;
     cout << "mini-batch size: " << minibatch_size << endl;
 
     const double initial_learning_rate = 0.1;


### PR DESCRIPTION
To address the [recent interest](https://github.com/davisking/dlib/issues/1236#issuecomment-447581865) in a U-net implementation, this PR adds a possibly-useful `resize_to_prev` layer, and upgrades the semantic-segmentation example.

Compared to the corresponding network without skip connections (see #943), the updated example should be able to draw more details:

![image](https://user-images.githubusercontent.com/2297572/50155550-05cb2600-02d5-11e9-8c8f-2c9f02dcd306.png)

However, overall it's not too much more accurate on the PASCAL VOC 2012 data -- this time around, the training should finish like this (note the lower loss but not much better accuracy, when compared to numbers reported in #943):

```
step#: 117901  learning rate: 0.001  average loss: 0.0239372    steps without apparent progress: 4941
step#: 118018  learning rate: 0.001  average loss: 0.0238844    steps without apparent progress: 4878
step#: 118135  learning rate: 0.001  average loss: 0.0235096    steps without apparent progress: 4840
step#: 118252  learning rate: 0.0001  average loss: 0.0232595    steps without apparent progress: 4178
step#: 118369  learning rate: 0.0001  average loss: 0.0243033    steps without apparent progress: 4282
step#: 118486  learning rate: 0.0001  average loss: 0.0214507    steps without apparent progress: 4412
step#: 118603  learning rate: 0.0001  average loss: 0.0246106    steps without apparent progress: 4516
step#: 118720  learning rate: 0.0001  average loss: 0.0239061    steps without apparent progress: 4646
step#: 118837  learning rate: 0.0001  average loss: 0.0219395    steps without apparent progress: 4750
step#: 118954  learning rate: 0.0001  average loss: 0.0220728    steps without apparent progress: 4880
Saved state to pascal_voc2012_trainer_state_file.dat_
step#: 119063  learning rate: 0.0001  average loss: 0.0224262    steps without apparent progress: 4903
Saved state to pascal_voc2012_trainer_state_file.dat
saving network
Testing the network...
train accuracy  :  0.991385
val accuracy    :  0.851742
```

However, on some other datasets the U-net approach can be very useful. (I guess in particular when there are lots of details to draw, but the classification task itself is not too difficult.)

~Note that I still want to find a network architecture that is clean, performs well, and compiles in finite time using MSVC++ (see the comment below). So I'd prefer not to have this merged just yet. But at the same time wanted to make it available already, in case e.g. @goldbattle wants to try it out.~
