### PR TITLE
Reliably detect AVX2 at runtime on Linux

### DIFF
--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -129,7 +129,7 @@
     { 
         std::array<unsigned int,4> info;
         // Load EAX, EBX, ECX, EDX into info
-        __cpuid(function_id, info[0], info[1], info[2], info[3]);
+        __cpuid_count(function_id, 0, info[0], info[1], info[2], info[3]);
         return info;
     }
 


### PR DESCRIPTION
ECX must be set to 0 to read this flag, the easiest way to achieve this
is to use __cpuid_count with 0 as the second argument.

---
I have been repeatedly getting the message "Dlib was compiled to use AVX2 instructions, but these aren't available on your machine." despite using a Ryzen processor with AVX2.

This change stops the message appearing for me. I haven't found a primary source for it but several mentions e.g.
https://bugs.chromium.org/p/chromium/issues/detail?id=630077#c9
