### PR TITLE
Make sure CUDA_VERSION is defined

### DIFF
--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include "cuda_utils.h"
 #include <cstring>
-
+#include <cuda.h>
 
 namespace dlib
 {
@@ -81,7 +81,9 @@ namespace dlib
 
     void synchronize_stream(cudaStream_t stream)
     {
-#if CUDA_VERSION >= 9020 && CUDA_VERSION <= 10000
+#if !defined CUDA_VERSION
+#error CUDA_VERSION not defined
+#elif CUDA_VERSION >= 9020 && CUDA_VERSION <= 10000
         // This should be pretty much the same as cudaStreamSynchronize, which for some
         // reason makes training freeze in some cases.
         // (see https://github.com/davisking/dlib/issues/1513)


### PR DESCRIPTION
I noticed I was still hitting #1513, although this time on GTX 1080 Ti (CUDA 10, Windows 10, MSVC 2017).

Then I realized that #1514 wasn't helping, in particular after #1596, because `CUDA_VERSION` wasn't even `#define`d here!

I actually thought that the preprocessor would give an error in this case, but [apparently that is not the case](https://stackoverflow.com/questions/17160755/is-there-a-way-to-both-check-a-macro-is-defined-and-it-equals-a-certain-value-at). Learn something new every day!