### PR TITLE
Change CUDA version check for cudaSync from 10000 to 10010

### DIFF
--- a/dlib/cuda/gpu_data.cpp
+++ b/dlib/cuda/gpu_data.cpp
@@ -83,7 +83,7 @@ namespace dlib
     {
 #if !defined CUDA_VERSION
 #error CUDA_VERSION not defined
-#elif CUDA_VERSION >= 9020 && CUDA_VERSION <= 10000
+#elif CUDA_VERSION >= 9020 && CUDA_VERSION <= 10010
         // This should be pretty much the same as cudaStreamSynchronize, which for some
         // reason makes training freeze in some cases.
         // (see https://github.com/davisking/dlib/issues/1513)


### PR DESCRIPTION
When upgrading to CUDA 10.1, I've started to have the same problem fixed in #1514.  
This is because the CUDA_VERSION wasn't change in gpu_data.cpp file.  
This pull request simply upgrades version check from 10000 to 10010 (CUDA_VERSION in CUDA 10.1).  