### PR TITLE
Fixed constness for lapack function declarations

### DIFF
--- a/dlib/matrix/lapack/gees.h
+++ b/dlib/matrix/lapack/gees.h
@@ -21,15 +21,15 @@ namespace dlib
 
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dgees) (char *jobvs, char *sort, L_fp select, integer *n, 
-                                             double *a, integer *lda, integer *sdim, double *wr, 
-                                             double *wi, double *vs, integer *ldvs, double *work, 
-                                             integer *lwork, logical *bwork, integer *info);
+                void DLIB_FORTRAN_ID(dgees) (const char *jobvs, const char *sort, const L_fp select, const integer *n, 
+                                             double *a, const integer *lda, integer *sdim, double *wr, 
+                                             double *wi, double *vs, const integer *ldvs, double *work, 
+                                             const integer *lwork, logical *bwork, integer *info);
 
-                void DLIB_FORTRAN_ID(sgees) (char *jobvs, char *sort, L_fp select, integer *n, 
-                                             float *a, integer *lda, integer *sdim, float *wr, 
-                                             float *wi, float *vs, integer *ldvs, float *work, 
-                                             integer *lwork, logical *bwork, integer *info);
+                void DLIB_FORTRAN_ID(sgees) (const char *jobvs, const char *sort, const L_fp select, const integer *n, 
+                                             float *a, const integer *lda, integer *sdim, float *wr, 
+                                             float *wi, float *vs, const integer *ldvs, float *work, 
+                                             const integer *lwork, logical *bwork, integer *info);
 
             }
 

--- a/dlib/matrix/lapack/geev.h
+++ b/dlib/matrix/lapack/geev.h
@@ -14,15 +14,15 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dgeev) (char *jobvl, char *jobvr, integer *n, double * a, 
-                                             integer *lda, double *wr, double *wi, double *vl, 
-                                             integer *ldvl, double *vr, integer *ldvr, double *work, 
-                                             integer *lwork, integer *info);
+                void DLIB_FORTRAN_ID(dgeev) (const char *jobvl, const char *jobvr, const integer *n, double * a, 
+                                             const integer *lda, double *wr, double *wi, double *vl, 
+                                             const integer *ldvl, double *vr, const integer *ldvr, double *work, 
+                                             const integer *lwork, integer *info);
 
-                void DLIB_FORTRAN_ID(sgeev) (char *jobvl, char *jobvr, integer *n, float * a, 
-                                             integer *lda, float *wr, float *wi, float *vl, 
-                                             integer *ldvl, float *vr, integer *ldvr, float *work, 
-                                             integer *lwork, integer *info);
+                void DLIB_FORTRAN_ID(sgeev) (const char *jobvl, const char *jobvr, const integer *n, float * a, 
+                                             const integer *lda, float *wr, float *wi, float *vl, 
+                                             const integer *ldvl, float *vr, const integer *ldvr, float *work, 
+                                             const integer *lwork, integer *info);
 
             }
 

--- a/dlib/matrix/lapack/geqrf.h
+++ b/dlib/matrix/lapack/geqrf.h
@@ -14,12 +14,12 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dgeqrf) (integer *m, integer *n, double *a, integer *
-                                              lda, double *tau, double *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(dgeqrf) (const integer *m, const integer *n, double *a, const integer*
+                                              lda, double *tau, double *work, const integer *lwork, 
                                               integer *info);
 
-                void DLIB_FORTRAN_ID(sgeqrf) (integer *m, integer *n, float *a, integer *
-                                              lda, float *tau, float *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(sgeqrf) (const integer *m, const integer *n, float *a, const integer*
+                                              lda, float *tau, float *work, const integer *lwork, 
                                               integer *info);
             }
 

--- a/dlib/matrix/lapack/getrf.h
+++ b/dlib/matrix/lapack/getrf.h
@@ -14,11 +14,11 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dgetrf) (integer* m, integer *n, double *a, 
-                                             integer* lda, integer *ipiv, integer *info);
+                void DLIB_FORTRAN_ID(dgetrf) (const integer *m, const integer *n, double *a, 
+                                              const integer *lda, integer *ipiv, integer *info);
 
-                void DLIB_FORTRAN_ID(sgetrf) (integer* m, integer *n, float *a, 
-                                             integer* lda, integer *ipiv, integer *info);
+                void DLIB_FORTRAN_ID(sgetrf) (const integer *m, const integer *n, float *a, 
+                                              const integer *lda, integer *ipiv, integer *info);
 
             }
 

--- a/dlib/matrix/lapack/ormqr.h
+++ b/dlib/matrix/lapack/ormqr.h
@@ -14,14 +14,14 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dormqr) (char *side, char *trans, integer *m, integer *n, 
-                                              integer *k, const double *a, integer *lda, const double *tau, 
-                                              double * c_, integer *ldc, double *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(dormqr) (const char *side, const char *trans, const integer *m, const integer *n, 
+                                              const integer *k, const double *a, const integer *lda, const double *tau, 
+                                              double * c_, const integer *ldc, double *work, const integer *lwork, 
                                               integer *info);
 
-                void DLIB_FORTRAN_ID(sormqr) (char *side, char *trans, integer *m, integer *n, 
-                                              integer *k, const float *a, integer *lda, const float *tau, 
-                                              float * c_, integer *ldc, float *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(sormqr) (const char *side, const char *trans, const integer *m, const integer *n, 
+                                              const integer *k, const float *a, const integer *lda, const float *tau, 
+                                              float * c_, const integer *ldc, float *work, const integer *lwork, 
                                               integer *info);
 
             }

--- a/dlib/matrix/lapack/pbtrf.h
+++ b/dlib/matrix/lapack/pbtrf.h
@@ -13,11 +13,11 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dpbtrf) (const char* uplo, const integer* n, const integer* kd,
-                                              double* ab, const integer* ldab, integer* info);
+                void DLIB_FORTRAN_ID(dpbtrf) (const char *uplo, const integer *n, const integer *kd,
+                                              double *ab, const integer *ldab, integer *info);
 
-                void DLIB_FORTRAN_ID(spbtrf) (const char* uplo, const integer* n, const integer* kd,
-                                              float* ab, const integer* ldab, integer* info);
+                void DLIB_FORTRAN_ID(spbtrf) (const char *uplo, const integer *n, const integer *kd,
+                                              float *ab, const integer *ldab, integer *info);
 
             }
 

--- a/dlib/matrix/lapack/potrf.h
+++ b/dlib/matrix/lapack/potrf.h
@@ -14,11 +14,11 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dpotrf) (char *uplo, integer *n, double *a, 
-                                              integer* lda, integer *info);
+                void DLIB_FORTRAN_ID(dpotrf) (const char *uplo, const integer *n, double *a, 
+                                              const integer *lda, integer *info);
 
-                void DLIB_FORTRAN_ID(spotrf) (char *uplo, integer *n, float *a, 
-                                              integer* lda, integer *info);
+                void DLIB_FORTRAN_ID(spotrf) (const char *uplo, const integer *n, float *a, 
+                                              const integer *lda, integer *info);
 
             }
 

--- a/dlib/matrix/lapack/syev.h
+++ b/dlib/matrix/lapack/syev.h
@@ -14,12 +14,12 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dsyev) (char *jobz, char *uplo, integer *n, double *a,
-                                             integer *lda, double *w, double *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(dsyev) (const char *jobz, const char *uplo, const integer *n, double *a,
+                                             const integer *lda, double *w, double *work, const integer *lwork, 
                                              integer *info);
 
-                void DLIB_FORTRAN_ID(ssyev) (char *jobz, char *uplo, integer *n, float *a,
-                                             integer *lda, float *w, float *work, integer *lwork, 
+                void DLIB_FORTRAN_ID(ssyev) (const char *jobz, const char *uplo, const integer *n, float *a,
+                                             const integer *lda, float *w, float *work, const integer *lwork, 
                                              integer *info);
 
             }

--- a/dlib/matrix/lapack/syevr.h
+++ b/dlib/matrix/lapack/syevr.h
@@ -14,17 +14,17 @@ namespace dlib
         {
             extern "C"
             {
-                void DLIB_FORTRAN_ID(dsyevr) (char *jobz, char *range, char *uplo, integer *n, 
-                                              double *a, integer *lda, double *vl, double *vu, integer * il, 
-                                              integer *iu, double *abstol, integer *m, double *w, 
-                                              double *z_, integer *ldz, integer *isuppz, double *work, 
-                                              integer *lwork, integer *iwork, integer *liwork, integer *info);
+                void DLIB_FORTRAN_ID(dsyevr) (const char *jobz, const char *range, const char *uplo, const integer *n, 
+                                              double *a, const integer *lda, const double *vl, const double *vu, const integer *il, 
+                                              const integer *iu, const double *abstol, integer *m, double *w, 
+                                              double *z_, const integer *ldz, integer *isuppz, double *work, 
+                                              const integer *lwork, integer *iwork, const integer *liwork, integer *info);
 
-                void DLIB_FORTRAN_ID(ssyevr) (char *jobz, char *range, char *uplo, integer *n, 
-                                              float *a, integer *lda, float *vl, float *vu, integer * il, 
-                                              integer *iu, float *abstol, integer *m, float *w, 
+                void DLIB_FORTRAN_ID(ssyevr) (const char *jobz, const char *range, const char *uplo, const integer *n, 
+                                              float *a, const integer *lda, const float *vl, const float *vu, const integer *il, 
+                                              const integer *iu, const float *abstol, integer *m, float *w, 
                                               float *z_, integer *ldz, integer *isuppz, float *work, 
-                                              integer *lwork, integer *iwork, integer *liwork, integer *info);
+                                              const integer *lwork, integer *iwork, const integer *liwork, integer *info);
             }
 
             inline int syevr (char jobz, char range, char uplo, integer n, 


### PR DESCRIPTION
This brings const correctness for lapack function parameters, according to the documentation provided by netlib.

~~I was not sure about code formatting and west const/east const, because I found some mixed styles. For the latter, I decided to keep all the changes with east const. Anyway, if you want me to format the code in a different way, it is not a problem.~~ I changed the format style using the _west const_ following the suggestion of @davisking.

P.s.: ironically, I sent a similar patch to armadillo because some lapack functions in dlib were const correct and it created some conflicts armadillo declarations. Now that the patch is in trunk and there is a release candidate, I noticed that exact same problem for dlib.