### PR TITLE
fix some pedantic warnings

### DIFF
--- a/dlib/global_optimization/global_function_search.cpp
+++ b/dlib/global_optimization/global_function_search.cpp
@@ -896,7 +896,6 @@ namespace dlib
         size_t num
     )
     {
-        DLIB_CASSERT(0 <= num);
         num_random_samples = num;
     }
 

--- a/dlib/matrix/matrix_math_functions.h
+++ b/dlib/matrix/matrix_math_functions.h
@@ -18,25 +18,25 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    DLIB_DEFINE_FUNCTION_M(op_sqrt, sqrt, std::sqrt ,7);
-    DLIB_DEFINE_FUNCTION_M(op_log, log, std::log ,7);
-    DLIB_DEFINE_FUNCTION_M(op_log10, log10, std::log10 ,7);
-    DLIB_DEFINE_FUNCTION_M(op_exp, exp, std::exp ,7);
+    DLIB_DEFINE_FUNCTION_M(op_sqrt, sqrt, std::sqrt, 7)
+    DLIB_DEFINE_FUNCTION_M(op_log, log, std::log, 7)
+    DLIB_DEFINE_FUNCTION_M(op_log10, log10, std::log10, 7)
+    DLIB_DEFINE_FUNCTION_M(op_exp, exp, std::exp, 7)
 
-    DLIB_DEFINE_FUNCTION_M(op_conj, conj, std::conj ,2);
+    DLIB_DEFINE_FUNCTION_M(op_conj, conj, std::conj, 2)
 
-    DLIB_DEFINE_FUNCTION_M(op_ceil, ceil, std::ceil ,7);
-    DLIB_DEFINE_FUNCTION_M(op_floor, floor, std::floor ,7);
+    DLIB_DEFINE_FUNCTION_M(op_ceil, ceil, std::ceil, 7)
+    DLIB_DEFINE_FUNCTION_M(op_floor, floor, std::floor, 7)
 
-    DLIB_DEFINE_FUNCTION_M(op_sin, sin, std::sin ,7);
-    DLIB_DEFINE_FUNCTION_M(op_cos, cos, std::cos ,7);
-    DLIB_DEFINE_FUNCTION_M(op_tan, tan, std::tan ,7);
-    DLIB_DEFINE_FUNCTION_M(op_sinh, sinh, std::sinh ,7);
-    DLIB_DEFINE_FUNCTION_M(op_cosh, cosh, std::cosh ,7);
-    DLIB_DEFINE_FUNCTION_M(op_tanh, tanh, std::tanh ,7);
-    DLIB_DEFINE_FUNCTION_M(op_asin, asin, std::asin ,7);
-    DLIB_DEFINE_FUNCTION_M(op_acos, acos, std::acos ,7);
-    DLIB_DEFINE_FUNCTION_M(op_atan, atan, std::atan ,7);
+    DLIB_DEFINE_FUNCTION_M(op_sin, sin, std::sin, 7)
+    DLIB_DEFINE_FUNCTION_M(op_cos, cos, std::cos, 7)
+    DLIB_DEFINE_FUNCTION_M(op_tan, tan, std::tan, 7)
+    DLIB_DEFINE_FUNCTION_M(op_sinh, sinh, std::sinh, 7)
+    DLIB_DEFINE_FUNCTION_M(op_cosh, cosh, std::cosh, 7)
+    DLIB_DEFINE_FUNCTION_M(op_tanh, tanh, std::tanh, 7)
+    DLIB_DEFINE_FUNCTION_M(op_asin, asin, std::asin, 7)
+    DLIB_DEFINE_FUNCTION_M(op_acos, acos, std::acos, 7)
+    DLIB_DEFINE_FUNCTION_M(op_atan, atan, std::atan, 7)
 
 // ----------------------------------------------------------------------------------------
 
@@ -157,16 +157,16 @@ namespace dlib
 
     }
 
-    DLIB_DEFINE_FUNCTION_M(op_sigmoid, sigmoid, impl::sigmoid, 7);
-    DLIB_DEFINE_FUNCTION_MS(op_round_zeros, round_zeros, impl::round_zeros_eps, 7);
-    DLIB_DEFINE_FUNCTION_M(op_round_zeros2, round_zeros, impl::round_zeros, 7);
-    DLIB_DEFINE_FUNCTION_M(op_cubed, cubed, impl::cubed, 7);
-    DLIB_DEFINE_FUNCTION_M(op_squared, squared, impl::squared, 6);
-    DLIB_DEFINE_FUNCTION_M(op_sign, sign, impl::sign, 6);
-    DLIB_DEFINE_FUNCTION_MS(op_pow1, pow, impl::pow1, 7);
-    DLIB_DEFINE_FUNCTION_SM(op_pow2, pow, impl::pow2, 7);
-    DLIB_DEFINE_FUNCTION_M(op_reciprocal, reciprocal, impl::reciprocal, 6);
-    DLIB_DEFINE_FUNCTION_M(op_reciprocal_max, reciprocal_max, impl::reciprocal_max, 6);
+    DLIB_DEFINE_FUNCTION_M(op_sigmoid, sigmoid, impl::sigmoid, 7)
+    DLIB_DEFINE_FUNCTION_MS(op_round_zeros, round_zeros, impl::round_zeros_eps, 7)
+    DLIB_DEFINE_FUNCTION_M(op_round_zeros2, round_zeros, impl::round_zeros, 7)
+    DLIB_DEFINE_FUNCTION_M(op_cubed, cubed, impl::cubed, 7)
+    DLIB_DEFINE_FUNCTION_M(op_squared, squared, impl::squared, 6)
+    DLIB_DEFINE_FUNCTION_M(op_sign, sign, impl::sign, 6)
+    DLIB_DEFINE_FUNCTION_MS(op_pow1, pow, impl::pow1, 7)
+    DLIB_DEFINE_FUNCTION_SM(op_pow2, pow, impl::pow2, 7)
+    DLIB_DEFINE_FUNCTION_M(op_reciprocal, reciprocal, impl::reciprocal, 6)
+    DLIB_DEFINE_FUNCTION_M(op_reciprocal_max, reciprocal_max, impl::reciprocal_max, 6)
 
 // ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Just a pull request to silence some -Wpedantic warnings when compiling with g++ 8.3.0.

I was also wondering if it would be OK to remove that `DLIB_CASSERT`, since `num` is declared as a `size_t`.
```
[37/59] Building CXX object dlib/CMakeFi...ptimization/global_function_search.cpp.o
In file included from ../dlib/global_optimization/../matrix/../algs.h:111,
                 from ../dlib/global_optimization/../matrix/matrix_exp.h:6,
                 from ../dlib/global_optimization/../matrix/matrix.h:6,
                 from ../dlib/global_optimization/../matrix.h:6,
                 from ../dlib/global_optimization/global_function_search.h:8,
                 from ../dlib/global_optimization/global_function_search.cpp:2:
../dlib/global_optimization/global_function_search.cpp: In member function ‘void dlib::global_function_search::set_monte_carlo_upper_bound_sample_num(size_t)’:
../dlib/global_optimization/global_function_search.cpp:899:24: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
         DLIB_CASSERT(0 <= num);
                      ~~^~~~~~
../dlib/global_optimization/../matrix/../assert.h:157:47: note: in definition of macro ‘DLIB_WORKAROUND_VISUAL_STUDIO_BUGS’
 #define DLIB_WORKAROUND_VISUAL_STUDIO_BUGS(x) x
                                               ^
../dlib/global_optimization/../matrix/../assert.h:160:48: note: in expansion of macro ‘DLIBM_CASSERT’
 #define DLIBM_CASSERT_1_ARGS(exp)              DLIBM_CASSERT(exp,"")
                                                ^~~~~~~~~~~~~
../dlib/global_optimization/../matrix/../assert.h:157:47: note: in expansion of macro ‘DLIBM_CASSERT_1_ARGS’
 #define DLIB_WORKAROUND_VISUAL_STUDIO_BUGS(x) x
                                               ^
../dlib/global_optimization/global_function_search.cpp:899:9: note: in expansion of macro ‘DLIB_CASSERT’
         DLIB_CASSERT(0 <= num);
         ^~~~~~~~~~~~
[59/59] Linking CXX static library dlib/libdlib.a
```