### PR TITLE
Ensures DLIB_FALLTHROUGH macro is only set for GCC>=7

### DIFF
--- a/dlib/general_hash/murmur_hash3.h
+++ b/dlib/general_hash/murmur_hash3.h
@@ -24,7 +24,7 @@ namespace dlib
     // Microsoft Visual Studio
 
 
-#if (defined(__GNUC__) || defined(__clang__))
+#if ((defined(__GNUC__) && __GNUC__ >= 7) || defined(__clang__))
 #define DLIB_FALLTHROUGH [[fallthrough]]
 #else
 #define DLIB_FALLTHROUGH 


### PR DESCRIPTION
because the [[fallthrough]] warning protection is not valid before and ti keeps flooding the console with the following warning:
general_hash/murmur_hash3.h:28:26: warning: attributes at the beginning of statement are ignored [-Wattributes]
 #define DLIB_FALLTHROUGH [[fallthrough]]
                          ^
C:/Utilisateurs/A134883/Workspace/Perso/dlib/dlib/general_hash/murmur_hash3.h:224:21: note: in expansion of macro 'DLIB_FALLTHROUGH'
                     DLIB_FALLTHROUGH; // fall through