### PR TITLE
 Fix setting a point's y coordinate changes x instead (Python bindings)

### DIFF
--- a/tools/python/src/vector.cpp
+++ b/tools/python/src/vector.cpp
@@ -432,7 +432,7 @@ void bind_vector(py::module& m)
             .def(double() * py::self)
             .def("normalize", &type::normalize, "Returns a unit normalized copy of this vector.")
             .def_property("x", &point_x, [](point& p, long x){p.x()=x;}, "The x-coordinate of the point.")
-            .def_property("y", &point_y, [](point& p, long y){p.x()=y;}, "The y-coordinate of the point.")
+            .def_property("y", &point_y, [](point& p, long y){p.y()=y;}, "The y-coordinate of the point.")
             .def(py::pickle(&getstate<type>, &setstate<type>));
     }
     {

--- a/tools/python/test/test_point.py
+++ b/tools/python/test/test_point.py
@@ -16,6 +16,14 @@ def test_point():
     assert deser.x == p.x
     assert deser.y == p.y
 
+def test_point_assignment():
+    p = point(27, 42)
+    p.x = 16
+    assert p.x == 16
+    assert p.y == 42
+    p.y = 31
+    assert p.x == 16
+    assert p.y == 31
 
 def test_point_init_kwargs():
     p = point(y=27, x=42)


### PR DESCRIPTION
* Add test to reproduce issue #1794 
* Fix python bindings