### PR TITLE
don't cast away constness

### DIFF
--- a/dlib/image_processing/generic_image.h
+++ b/dlib/image_processing/generic_image.h
@@ -186,7 +186,7 @@ namespace dlib
         image_view(
             image_type& img
         ) : 
-            _data((char*)image_data(img)), 
+            _data(reinterpret_cast<char*>(image_data(img))), 
             _width_step(width_step(img)),
             _nr(num_rows(img)),
             _nc(num_columns(img)),
@@ -332,7 +332,7 @@ namespace dlib
         const_image_view(
             const image_type& img
         ) : 
-            _data((char*)image_data(img)), 
+            _data(reinterpret_cast<const char*>(image_data(img))), 
             _width_step(width_step(img)),
             _nr(num_rows(img)),
             _nc(num_columns(img))


### PR DESCRIPTION
there was no actual harm here: the unconsting was consted up by the member (but it needn't have been had the member been pointer to non-const). 

generally speaking, `reinterpret_cast` is better than C-style casting because it cannot cast away constness.