### PR TITLE
Clear truth_idxs between samples

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1139,7 +1139,8 @@ namespace dlib
                     det_thresh_speed_adjust = std::max(det_thresh_speed_adjust,dets[max_num_initial_dets].detection_confidence + options.loss_per_false_alarm);
                 }
 
-                std::vector<size_t> truth_idxs;  truth_idxs.reserve(truth->size());
+                std::vector<size_t> truth_idxs;
+                truth_idxs.reserve(truth->size());
 
                 // The loss will measure the number of incorrect detections.  A detection is
                 // incorrect if it doesn't hit a truth rectangle or if it is a duplicate detection
@@ -1155,6 +1156,7 @@ namespace dlib
                         {
                             // Ignore boxes that can't be detected by the CNN.
                             loss -= options.loss_per_missed_target;
+                            truth_idxs.push_back(0);
                             continue;
                         }
                         const size_t idx = (k*output_tensor.nr() + p.y())*output_tensor.nc() + p.x();

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1125,7 +1125,6 @@ namespace dlib
 
             const float* out_data = output_tensor.host();
 
-            std::vector<size_t> truth_idxs;  truth_idxs.reserve(truth->size());
             std::vector<intermediate_detection> dets;
             for (long i = 0; i < output_tensor.num_samples(); ++i)
             {
@@ -1140,6 +1139,7 @@ namespace dlib
                     det_thresh_speed_adjust = std::max(det_thresh_speed_adjust,dets[max_num_initial_dets].detection_confidence + options.loss_per_false_alarm);
                 }
 
+                std::vector<size_t> truth_idxs;  truth_idxs.reserve(truth->size());
 
                 // The loss will measure the number of incorrect detections.  A detection is
                 // incorrect if it doesn't hit a truth rectangle or if it is a duplicate detection
@@ -1240,7 +1240,6 @@ namespace dlib
 
                 hit_truth_table.assign(hit_truth_table.size(), false);
                 final_dets.clear();
-                truth_idxs.clear();
 
                 // Now figure out which detections jointly maximize the loss and detection score sum.  We
                 // need to take into account the fact that allowing a true detection in the output, while 

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1240,7 +1240,7 @@ namespace dlib
 
                 hit_truth_table.assign(hit_truth_table.size(), false);
                 final_dets.clear();
-
+                truth_idxs.clear();
 
                 // Now figure out which detections jointly maximize the loss and detection score sum.  We
                 // need to take into account the fact that allowing a true detection in the output, while 


### PR DESCRIPTION
To address the possible issue mentioned [here](https://github.com/davisking/dlib/commit/29db3ee566d68b3a197e24394c3beb64513ca98e#r34900715), clear the `truth_idxs` vector between samples.