### PR TITLE
Ignore truth rects that overlap too much (have same index in feature coordinates)

### DIFF
--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -3288,9 +3288,6 @@ namespace
         const input_image_type input_image = generate_input_image();
         const std::vector<mmod_rect> labels = generate_labels();
 
-        // For simplicity, using no image pyramid. But the problem can be
-        // reproduced with an image pyramid as well:
-        // mmod_options options({ original_labels }, 5, 5);
         mmod_options options(use_image_pyramid::no, { labels });
 
         // Define a simple network.

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -3306,9 +3306,10 @@ namespace
         const auto dets = net(input_image);
         DLIB_TEST(dets.size() > 0);
 
-        // Indeed most of the truth objects should be found.
-        const auto approximate_expected_det_count = (nr - 2 * margin) * (nc - 2 * margin) / 4.0;
-        DLIB_TEST(fabs(dets.size() / approximate_expected_det_count - 1.0) < 0.1);
+        // Indeed many truth objects should be found.
+        const auto approximate_desired_det_count = (nr - 2 * margin) * (nc - 2 * margin) / 2.0;
+        DLIB_TEST(dets.size() > approximate_desired_det_count * 0.45);
+        DLIB_TEST(dets.size() < approximate_desired_det_count * 1.05);
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
resolves #1894 
