### PR TITLE
Instance segmentation

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1397,12 +1397,34 @@ namespace dlib
 
             out << "detector_windows:(";
             auto& opts = item.options;
-            for (size_t i = 0; i < opts.detector_windows.size(); ++i)
+
             {
-                out << opts.detector_windows[i].width << "x" << opts.detector_windows[i].height;
-                if (i+1 < opts.detector_windows.size())
-                    out << ",";
+                // write detector windows grouped by label
+                // example output: detector_windows:(aeroplane:74x30,131x30,70x45,54x70,198x30;bicycle:70x57,32x70,70x32,51x70,128x30,30x121;car:70x36,70x60,99x30,52x70,30x83,30x114,30x200)
+                typedef std::deque<const dlib::mmod_options::detector_window_details*> detector_windows;
+                std::map<std::string, detector_windows> detector_windows_by_label;
+                for (const auto& detector_window : opts.detector_windows)
+                    detector_windows_by_label[detector_window.label].push_back(&detector_window);
+
+                size_t label_count = 0;
+                for (const auto& i : detector_windows_by_label)
+                {
+                    const auto& label = i.first;
+                    const auto& detector_windows = i.second;
+
+                    if (label_count++ > 0)
+                        out << ";";
+                    out << label << ":";
+
+                    for (size_t i = 0; i < detector_windows.size(); ++i)
+                    {
+                        out << detector_windows[i]->width << "x" << detector_windows[i]->height;
+                        if (i+1 < detector_windows.size())
+                            out << ",";
+                    }
+                }
             }
+
             out << ")";
             out << ", loss per FA:" << opts.loss_per_false_alarm;
             out << ", loss per miss:" << opts.loss_per_missed_target;

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -993,7 +993,7 @@ namespace dlib
         }
     }
 
-    std::ostream& operator<<(std::ostream& out, const std::vector<mmod_options::detector_window_details>& detector_windows)
+    inline std::ostream& operator<<(std::ostream& out, const std::vector<mmod_options::detector_window_details>& detector_windows)
     {
         // write detector windows grouped by label
         // example output: aeroplane:74x30,131x30,70x45,54x70,198x30;bicycle:70x57,32x70,70x32,51x70,128x30,30x121;car:70x36,70x60,99x30,52x70,30x83,30x114,30x200

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -697,10 +697,10 @@ namespace dlib
 
                     // Check if we should shrink the learning rate based on how the test
                     // error has been doing lately.
-                    if (learning_rate_shrink != 1 && steps_since_last_learning_rate_shrink > iter_without_progress_thresh)
+                    if (learning_rate_shrink != 1)
                     {
                         test_steps_without_progress = count_steps_without_decrease(test_previous_loss_values);
-                        if (test_steps_without_progress >= test_iter_without_progress_thresh)
+                        if (test_steps_without_progress >= test_iter_without_progress_thresh && steps_since_last_learning_rate_shrink >= test_iter_without_progress_thresh)
                         {
                             test_steps_without_progress = count_steps_without_decrease_robust(test_previous_loss_values);
                             if (test_steps_without_progress >= test_iter_without_progress_thresh)
@@ -809,13 +809,11 @@ namespace dlib
                 // have a "budget" that prevents us from calling
                 // count_steps_without_decrease() every iteration.  We do this because
                 // it can be expensive to compute when previous_loss_values is large.
-                if (gradient_check_budget > iter_without_progress_thresh
-                    && learning_rate_shrink != 1
-                    && steps_since_last_learning_rate_shrink > iter_without_progress_thresh)
+                if (gradient_check_budget > iter_without_progress_thresh && learning_rate_shrink != 1)
                 {
                     gradient_check_budget = 0;
                     steps_without_progress = count_steps_without_decrease(previous_loss_values);
-                    if (steps_without_progress >= iter_without_progress_thresh)
+                    if (steps_without_progress >= iter_without_progress_thresh && steps_since_last_learning_rate_shrink >= iter_without_progress_thresh)
                     {
                         // Double check that we aren't seeing decrease.  This second check
                         // discards the top 10% largest values and checks again.  We do

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1047,7 +1047,10 @@ namespace dlib
                     // might be better off giving up at this learning rate, and trying a
                     // lower one instead.
                     if (prob_loss_increasing_thresh >= prob_loss_increasing_thresh_max_value)
+                    {
+                        std::cout << "(and while at it, also shrinking the learning rate)" << std::endl;
                         learning_rate = learning_rate_shrink * learning_rate;
+                    }
                 }
                 else
                 {

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1036,10 +1036,13 @@ namespace dlib
                         std::cout << "(and while at it, also shrinking the learning rate)" << std::endl;
                         learning_rate = learning_rate_shrink * learning_rate;
                         steps_without_progress = 0;
-                        // Empty out some of the previous loss values so that steps_without_progress 
+                        test_steps_without_progress = 0;
+                        // Empty out some of the previous loss values so that steps_without_progress and test_steps_without_progress
                         // will decrease below iter_without_progress_thresh.  
-                        for (unsigned long cnt = 0; cnt < previous_loss_values_dump_amount + iter_without_progress_thresh / 10 && previous_loss_values.size() > 0; ++cnt)
+                        for (unsigned long cnt = 0; cnt < previous_loss_values_dump_amount+iter_without_progress_thresh/10 && previous_loss_values.size() > 0; ++cnt)
                             previous_loss_values.pop_front();
+                        for (unsigned long cnt = 0; cnt < test_previous_loss_values_dump_amount+test_iter_without_progress_thresh/10 && test_previous_loss_values.size() > 0; ++cnt)
+                            test_previous_loss_values.pop_front();
                     }
                 }
                 else

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1078,13 +1078,16 @@ namespace dlib
 
             // if the loss is very likely to be increasing then return true
             const double prob = g.probability_gradient_greater_than(0);
-            if (prob > prob_loss_increasing_thresh && prob_loss_increasing_thresh <= prob_loss_increasing_thresh_max_value)
+            if (prob > prob_loss_increasing_thresh)
             {
                 // Exponentially decay the threshold towards 1 so that if we keep finding
                 // the loss to be increasing over and over we will make the test
                 // progressively harder and harder until it fails, therefore ensuring we
                 // can't get stuck reloading from a previous state over and over. 
-                prob_loss_increasing_thresh = 0.1*prob_loss_increasing_thresh + 0.9*1;
+                prob_loss_increasing_thresh = std::min(
+                    0.1*prob_loss_increasing_thresh + 0.9*1,
+                    prob_loss_increasing_thresh_max_value
+                );
                 return true;
             }
             else

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1065,9 +1065,12 @@ namespace dlib
                     return true;
             }
 
-            // if we haven't seen much data yet then just say false.  Or, alternatively, if
-            // it's been too long since the last sync then don't reload either.
-            if (gradient_updates_since_last_sync < 30 || previous_loss_values.size() < 2*gradient_updates_since_last_sync)
+            // if we haven't seen much data yet then just say false.
+            if (gradient_updates_since_last_sync < 30)
+                return false;
+
+            // if it's been too long since the last sync then don't reload either.
+            if (previous_loss_values.size() + previous_loss_values_dump_amount < 2 * gradient_updates_since_last_sync)
                 return false;
 
             // Now look at the data since a little before the last disk sync.  We will

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -697,10 +697,10 @@ namespace dlib
 
                     // Check if we should shrink the learning rate based on how the test
                     // error has been doing lately.
-                    if (learning_rate_shrink != 1)
+                    if (learning_rate_shrink != 1 && steps_since_last_learning_rate_shrink > iter_without_progress_thresh)
                     {
                         test_steps_without_progress = count_steps_without_decrease(test_previous_loss_values);
-                        if (test_steps_without_progress >= test_iter_without_progress_thresh && steps_since_last_learning_rate_shrink >= test_iter_without_progress_thresh)
+                        if (test_steps_without_progress >= test_iter_without_progress_thresh)
                         {
                             test_steps_without_progress = count_steps_without_decrease_robust(test_previous_loss_values);
                             if (test_steps_without_progress >= test_iter_without_progress_thresh)
@@ -809,11 +809,13 @@ namespace dlib
                 // have a "budget" that prevents us from calling
                 // count_steps_without_decrease() every iteration.  We do this because
                 // it can be expensive to compute when previous_loss_values is large.
-                if (gradient_check_budget > iter_without_progress_thresh && learning_rate_shrink != 1)
+                if (gradient_check_budget > iter_without_progress_thresh
+                    && learning_rate_shrink != 1
+                    && steps_since_last_learning_rate_shrink > iter_without_progress_thresh)
                 {
                     gradient_check_budget = 0;
                     steps_without_progress = count_steps_without_decrease(previous_loss_values);
-                    if (steps_without_progress >= iter_without_progress_thresh && steps_since_last_learning_rate_shrink >= iter_without_progress_thresh)
+                    if (steps_without_progress >= iter_without_progress_thresh)
                     {
                         // Double check that we aren't seeing decrease.  This second check
                         // discards the top 10% largest values and checks again.  We do

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1099,15 +1099,18 @@ namespace dlib
                     return true;
             }
 
-            // if we haven't seen much data yet then just say false.  Or, alternatively, if
-            // it's been too long since the last sync then don't reload either.
-            if (gradient_updates_since_last_sync < 30 || previous_loss_values.size() < 2*gradient_updates_since_last_sync)
+            // if we haven't seen much data yet then just say false.
+            if (gradient_updates_since_last_sync < 30)
                 return false;
 
             // Now look at the data since a little before the last disk sync.  We will
             // check if the loss is getting better or worse.
             running_gradient g;
-            for (size_t i = previous_loss_values.size() - 2*gradient_updates_since_last_sync; i < previous_loss_values.size(); ++i)
+            const size_t first_index
+                = previous_loss_values.size() < 2 * gradient_updates_since_last_sync
+                ? 0
+                : previous_loss_values.size() - 2 * gradient_updates_since_last_sync;
+            for (size_t i = first_index; i < previous_loss_values.size(); ++i)
                 g.add(previous_loss_values[i]);
 
             // if the loss is very likely to be increasing then return true

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1068,18 +1068,15 @@ namespace dlib
                     return true;
             }
 
-            // if we haven't seen much data yet then just say false.
-            if (gradient_updates_since_last_sync < 30)
+            // if we haven't seen much data yet then just say false.  Or, alternatively, if
+            // it's been too long since the last sync then don't reload either.
+            if (gradient_updates_since_last_sync < 30 || previous_loss_values.size() < 2*gradient_updates_since_last_sync)
                 return false;
 
             // Now look at the data since a little before the last disk sync.  We will
             // check if the loss is getting better or worse.
             running_gradient g;
-            const size_t first_index
-                = previous_loss_values.size() < 2 * gradient_updates_since_last_sync
-                ? 0
-                : previous_loss_values.size() - 2 * gradient_updates_since_last_sync;
-            for (size_t i = first_index; i < previous_loss_values.size(); ++i)
+            for (size_t i = previous_loss_values.size() - 2*gradient_updates_since_last_sync; i < previous_loss_values.size(); ++i)
                 g.add(previous_loss_values[i]);
 
             // if the loss is very likely to be increasing then return true

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1226,9 +1226,15 @@ namespace dlib
             if (lr_schedule.size() == 0)
             {
                 if (test_previous_loss_values.size() == 0)
-                    std::cout << "steps without apparent progress: " << steps_without_progress;
+                    if (steps_since_last_learning_rate_shrink < iter_without_progress_thresh)
+                        std::cout << "steps since last learning rate shrink: " << steps_since_last_learning_rate_shrink;
+                    else
+                        std::cout << "steps without apparent progress: " << steps_without_progress;
                 else
-                    std::cout << "steps without apparent progress: train=" << steps_without_progress << ", test=" << test_steps_without_progress;
+                    if (steps_since_last_learning_rate_shrink < iter_without_progress_thresh && steps_since_last_learning_rate_shrink < test_iter_without_progress_thresh)
+                        std::cout << "steps since last learning rate shrink: " << steps_since_last_learning_rate_shrink;
+                    else
+                        std::cout << "steps without apparent progress: train=" << steps_without_progress << ", test=" << test_steps_without_progress;
             }
             else
             {

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -865,10 +865,18 @@ namespace dlib
                 float fout[4];
                 out.store(fout);
 
-                out_img[r][c]   = static_cast<T>(fout[0]);
-                out_img[r][c+1] = static_cast<T>(fout[1]);
-                out_img[r][c+2] = static_cast<T>(fout[2]);
-                out_img[r][c+3] = static_cast<T>(fout[3]);
+                const auto convert_to_output_type = [](float value)
+                {
+                    if (std::is_integral<T>::value)
+                        return static_cast<T>(value + 0.5);
+                    else
+                        return static_cast<T>(value);
+                };
+
+                out_img[r][c]   = convert_to_output_type(fout[0]);
+                out_img[r][c+1] = convert_to_output_type(fout[1]);
+                out_img[r][c+2] = convert_to_output_type(fout[2]);
+                out_img[r][c+3] = convert_to_output_type(fout[3]);
             }
             x = -x_scale + c*x_scale;
             for (; c < out_img.nc(); ++c)

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -867,11 +867,7 @@ namespace dlib
 
                 const auto convert_to_output_type = [](float value)
                 {
-                    if
-#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-                    constexpr
-#endif // __cplusplus >= 201703L
-                    (std::is_integral<T>::value)
+                    if (std::is_integral<T>::value)
                         return static_cast<T>(value + 0.5);
                     else
                         return static_cast<T>(value);

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -867,7 +867,11 @@ namespace dlib
 
                 const auto convert_to_output_type = [](float value)
                 {
-                    if (std::is_integral<T>::value)
+                    if
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+                    constexpr
+#endif // __cplusplus >= 201703L
+                    (std::is_integral<T>::value)
                         return static_cast<T>(value + 0.5);
                     else
                         return static_cast<T>(value);

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -126,7 +126,7 @@ namespace dlib
         unsigned char green;
         unsigned char blue;
 
-        inline bool operator == (const rgb_pixel& that) const
+        bool operator == (const rgb_pixel& that) const
         {
             return this->red   == that.red
                 && this->green == that.green
@@ -158,6 +158,13 @@ namespace dlib
         unsigned char blue;
         unsigned char green;
         unsigned char red;
+
+        bool operator == (const bgr_pixel& that) const
+        {
+            return this->blue  == that.blue
+                && this->green == that.green
+                && this->red   == that.red;
+        }
     };
 
 // ----------------------------------------------------------------------------------------
@@ -184,6 +191,14 @@ namespace dlib
         unsigned char green;
         unsigned char blue;
         unsigned char alpha;
+
+        bool operator == (const rgb_alpha_pixel& that) const
+        {
+            return this->red   == that.red
+                && this->green == that.green
+                && this->blue  == that.blue
+                && this->alpha == that.alpha;
+        }
     };
 
 // ----------------------------------------------------------------------------------------
@@ -207,6 +222,13 @@ namespace dlib
         unsigned char h;
         unsigned char s;
         unsigned char i;
+
+        bool operator == (const hsi_pixel& that) const
+        {
+            return this->h == that.h
+                && this->s == that.s
+                && this->i == that.i;
+        }
     };
     // ----------------------------------------------------------------------------------------
 
@@ -229,6 +251,13 @@ namespace dlib
         unsigned char l;
         unsigned char a;
         unsigned char b;
+
+        bool operator == (const lab_pixel& that) const
+        {
+            return this->l == that.l
+                && this->a == that.a
+                && this->b == that.b;
+        }
     };
 
 // ----------------------------------------------------------------------------------------

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -127,8 +127,11 @@ int main(int argc, char** argv) try
         // Show the input image on the left, and the predicted RGB labels on the right.
         win.set_image(join_rows(input_image, rgb_label_image));
 
-        cout << file.name() << " - hit enter to process the next image";
-        cin.get();
+        if (!instances.empty())
+        {
+            cout << file.name() << " - hit enter to process the next image";
+            cin.get();
+        }
     }
 }
 catch(std::exception& e)

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) try
                 static_cast<int>(chip_details.rect.width())
             );
 
-            dlib::resize_image(mask, resized_mask, interpolate_nearest_neighbor());
+            dlib::resize_image(mask, resized_mask);
 
             for (int r = 0; r < resized_mask.nr(); ++r)
                 for (int c = 0; c < resized_mask.nc(); ++c)

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -82,9 +82,8 @@ int main(int argc, char** argv) try
 
         for (const auto& instance : instances)
         {
-            // TODO: expand the rect by 20% or so (by the same value that was used in training)
-
-            const chip_details chip_details(instance.rect, chip_dims(seg_dim, seg_dim));
+            const auto cropping_rect = get_cropping_rect(instance.rect);
+            const chip_details chip_details(cropping_rect, chip_dims(seg_dim, seg_dim));
             extract_image_chip(input_image, chip_details, input_chip, interpolate_bilinear());
 
             const auto mask = seg_net(input_chip);

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -139,7 +139,9 @@ int main(int argc, char** argv) try
             dlib::resize_image(mask, resized_mask);
 
             for (int r = 0; r < resized_mask.nr(); ++r)
+            {
                 for (int c = 0; c < resized_mask.nc(); ++c)
+                {
                     if (resized_mask(r, c))
                     {
                         const auto y = chip_details.rect.top() + r;
@@ -147,6 +149,8 @@ int main(int argc, char** argv) try
                         if (y >= 0 && y < rgb_label_image.nr() && x >= 0 && x < rgb_label_image.nc())
                             rgb_label_image(y, x) = random_color;
                     }
+                }
+            }
 
             const Voc2012class& voc2012_class = find_voc2012_class(
                 [&instance](const Voc2012class& candidate) {

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -34,76 +34,6 @@ using namespace dlib;
  
 // ----------------------------------------------------------------------------------------
 
-// The PASCAL VOC2012 dataset contains 20 ground-truth classes + background.  Each class
-// is represented using an RGB color value.  We associate each class also to an index in the
-// range [0, 20], used internally by the network.  To generate nice RGB representations of
-// inference results, we need to be able to convert the index values to the corresponding
-// RGB values.
-
-// Given an index in the range [0, 20], find the corresponding PASCAL VOC2012 class
-// (e.g., 'dog').
-const Voc2012class& find_voc2012_class(const uint16_t& index_label)
-{
-    return find_voc2012_class(
-        [&index_label](const Voc2012class& voc2012class)
-        {
-            return index_label == voc2012class.index;
-        }
-    );
-}
-
-// Convert an index in the range [0, 20] to a corresponding RGB class label.
-inline rgb_pixel index_label_to_rgb_label(uint16_t index_label)
-{
-    return find_voc2012_class(index_label).rgb_label;
-}
-
-// Convert an image containing indexes in the range [0, 20] to a corresponding
-// image containing RGB class labels.
-void index_label_image_to_rgb_label_image(
-    const matrix<uint16_t>& index_label_image,
-    matrix<rgb_pixel>& rgb_label_image
-)
-{
-    const long nr = index_label_image.nr();
-    const long nc = index_label_image.nc();
-
-    rgb_label_image.set_size(nr, nc);
-
-    for (long r = 0; r < nr; ++r)
-    {
-        for (long c = 0; c < nc; ++c)
-        {
-            rgb_label_image(r, c) = index_label_to_rgb_label(index_label_image(r, c));
-        }
-    }
-}
-
-// Find the most prominent class label from amongst the per-pixel predictions.
-std::string get_most_prominent_non_background_classlabel(const matrix<uint16_t>& index_label_image)
-{
-    const long nr = index_label_image.nr();
-    const long nc = index_label_image.nc();
-
-    std::vector<unsigned int> counters(class_count);
-
-    for (long r = 0; r < nr; ++r)
-    {
-        for (long c = 0; c < nc; ++c)
-        {
-            const uint16_t label = index_label_image(r, c);
-            ++counters[label];
-        }
-    }
-
-    const auto max_element = std::max_element(counters.begin() + 1, counters.end());
-    const uint16_t most_prominent_index_label = max_element - counters.begin();
-
-    return find_voc2012_class(most_prominent_index_label).classlabel;
-}
-
-// ----------------------------------------------------------------------------------------
-
 int main(int argc, char** argv) try
 {
     if (argc != 2)
@@ -118,20 +48,21 @@ int main(int argc, char** argv) try
         return 1;
     }
 
-    // Read the file containing the trained network from the working directory.
-    anet_type net;
-    deserialize(instance_segmentation_net_filename) >> net;
+    // Read the file containing the trained networks from the working directory.
+    det_anet_type det_net;
+    seg_anet_type seg_net;
+    deserialize(instance_segmentation_net_filename) >> det_net >> seg_net;
 
     // Show inference results in a window.
     image_window win;
 
     matrix<rgb_pixel> input_image;
-    matrix<uint16_t> index_label_image;
-    matrix<rgb_pixel> rgb_label_image;
 
     // Find supported image files.
     const std::vector<file> files = dlib::get_files_in_directory_tree(argv[1],
         dlib::match_endings(".jpeg .jpg .png"));
+
+    dlib::rand rnd;
 
     cout << "Found " << files.size() << " images, processing..." << endl;
 
@@ -140,28 +71,51 @@ int main(int argc, char** argv) try
         // Load the input image.
         load_image(input_image, file.full_name());
 
-        // Create predictions for each pixel. At this point, the type of each prediction
-        // is an index (a value between 0 and 20). Note that the net may return an image
-        // that is not exactly the same size as the input.
-        const matrix<uint16_t> temp = net(input_image);
+        // Find instances in the input image
+        const auto instances = det_net(input_image);
 
-        // Crop the returned image to be exactly the same size as the input.
-        const chip_details chip_details(
-            centered_rect(temp.nc() / 2, temp.nr() / 2, input_image.nc(), input_image.nr()),
-            chip_dims(input_image.nr(), input_image.nc())
-        );
-        extract_image_chip(temp, chip_details, index_label_image, interpolate_nearest_neighbor());
+        matrix<rgb_pixel> rgb_label_image;
+        matrix<rgb_pixel> input_chip;
 
-        // Convert the indexes to RGB values.
-        index_label_image_to_rgb_label_image(index_label_image, rgb_label_image);
+        rgb_label_image = rgb_pixel(0, 0, 0);
+
+        for (const auto& instance : instances)
+        {
+            const chip_details chip_details(instance.rect, chip_dims(seg_dim, seg_dim));
+            extract_image_chip(input_image, chip_details, input_chip, interpolate_bilinear());
+
+            const auto mask = seg_net(input_chip);
+
+            rgb_pixel random_color(
+                rnd.get_random_8bit_number(),
+                rnd.get_random_8bit_number(),
+                rnd.get_random_8bit_number()
+            );
+
+            dlib::matrix<uint16_t> resized_mask(
+                static_cast<int>(chip_details.rect.height()),
+                static_cast<int>(chip_details.rect.width())
+            );
+
+            dlib::resize_image(mask, resized_mask);
+
+            for (int r = 0; r < resized_mask.nr(); ++r)
+                for (int c = 0; c < resized_mask.nc(); ++c)
+                    if (resized_mask(r, c))
+                    {
+                        const auto y = chip_details.rect.top() + r;
+                        const auto x = chip_details.rect.left() + c;
+                        if (y >= 0 && y < rgb_label_image.nr() && x >= 0 && x < rgb_label_image.nc())
+                            rgb_label_image(y, x) = random_color;
+                    }
+
+            dlib::draw_rectangle(rgb_label_image, instance.rect, dlib::rgb_pixel(255, 255, 255), 1);
+        }
 
         // Show the input image on the left, and the predicted RGB labels on the right.
         win.set_image(join_rows(input_image, rgb_label_image));
 
-        // Find the most prominent class label from amongst the per-pixel predictions.
-        const std::string classlabel = get_most_prominent_non_background_classlabel(index_label_image);
-
-        cout << file.name() << " : " << classlabel << " - hit enter to process the next image";
+        cout << file.name() << " - hit enter to process the next image";
         cin.get();
     }
 }

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -90,8 +90,21 @@ int main(int argc, char** argv) try
         rgb_label_image.set_size(input_image.nr(), input_image.nc());
         rgb_label_image = rgb_pixel(0, 0, 0);
 
+        bool found_something = false;
+
         for (const auto& instance : instances)
         {
+            if (!found_something)
+            {
+                cout << "Found ";
+                found_something = true;
+            }
+            else
+            {
+                cout << ", ";
+            }
+            cout << instance.label;
+
             const auto cropping_rect = get_cropping_rect(instance.rect);
             const chip_details chip_details(cropping_rect, chip_dims(seg_dim, seg_dim));
             extract_image_chip(input_image, chip_details, input_chip, interpolate_bilinear());
@@ -129,7 +142,7 @@ int main(int argc, char** argv) try
 
         if (!instances.empty())
         {
-            cout << file.name() << " - hit enter to process the next image";
+            cout << " in " << file.name() << " - hit enter to process the next image";
             cin.get();
         }
     }

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -81,6 +81,8 @@ int main(int argc, char** argv) try
 
         for (const auto& instance : instances)
         {
+            // TODO: expand the rect by 20% or so (by the same value that was used in training)
+
             const chip_details chip_details(instance.rect, chip_dims(seg_dim, seg_dim));
             extract_image_chip(input_image, chip_details, input_chip, interpolate_bilinear());
 

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -71,8 +71,18 @@ int main(int argc, char** argv) try
         // Load the input image.
         load_image(input_image, file.full_name());
 
+        // Draw largest objects last
+        const auto sort_instances = [](const std::vector<mmod_rect>& input) {
+            auto output = input;
+            const auto compare_area = [](const mmod_rect& lhs, const mmod_rect& rhs) {
+                return lhs.rect.area() < rhs.rect.area();
+            };
+            std::sort(output.rbegin(), output.rend(), compare_area);
+            return output;
+        };
+
         // Find instances in the input image
-        const auto instances = det_net(input_image);
+        const auto instances = sort_instances(det_net(input_image));
 
         matrix<rgb_pixel> rgb_label_image;
         matrix<rgb_pixel> input_chip;

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv) try
             const auto compare_area = [](const mmod_rect& lhs, const mmod_rect& rhs) {
                 return lhs.rect.area() < rhs.rect.area();
             };
-            std::sort(output.rbegin(), output.rend(), compare_area);
+            std::sort(output.begin(), output.end(), compare_area);
             return output;
         };
 

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -77,6 +77,7 @@ int main(int argc, char** argv) try
         matrix<rgb_pixel> rgb_label_image;
         matrix<rgb_pixel> input_chip;
 
+        rgb_label_image.set_size(input_image.nr(), input_image.nc());
         rgb_label_image = rgb_pixel(0, 0, 0);
 
         for (const auto& instance : instances)

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv) try
 
             const auto mask = seg_net(input_chip);
 
-            rgb_pixel random_color(
+            const rgb_pixel random_color(
                 rnd.get_random_8bit_number(),
                 rnd.get_random_8bit_number(),
                 rnd.get_random_8bit_number()
@@ -136,7 +136,7 @@ int main(int argc, char** argv) try
                 static_cast<int>(chip_details.rect.width())
             );
 
-            dlib::resize_image(mask, resized_mask);
+            dlib::resize_image(mask, resized_mask, interpolate_nearest_neighbor());
 
             for (int r = 0; r < resized_mask.nr(); ++r)
                 for (int c = 0; c < resized_mask.nc(); ++c)

--- a/examples/dnn_instance_segmentation_ex.cpp
+++ b/examples/dnn_instance_segmentation_ex.cpp
@@ -24,6 +24,7 @@
 */
 
 #include "dnn_instance_segmentation_ex.h"
+#include "pascal_voc_2012.h"
 
 #include <iostream>
 #include <dlib/data_io.h>
@@ -134,7 +135,13 @@ int main(int argc, char** argv) try
                             rgb_label_image(y, x) = random_color;
                     }
 
-            dlib::draw_rectangle(rgb_label_image, instance.rect, dlib::rgb_pixel(255, 255, 255), 1);
+            const Voc2012class& voc2012_class = find_voc2012_class(
+                [&instance](const Voc2012class& candidate) {
+                    return candidate.classlabel == instance.label;
+                }
+            );
+
+            dlib::draw_rectangle(rgb_label_image, instance.rect, voc2012_class.rgb_label, 1);
         }
 
         // Show the input image on the left, and the predicted RGB labels on the right.

--- a/examples/dnn_instance_segmentation_ex.h
+++ b/examples/dnn_instance_segmentation_ex.h
@@ -66,17 +66,17 @@ dlib::rectangle get_cropping_rect(const dlib::rectangle& rectangle)
 template <long num_filters, typename SUBNET> using con5d = dlib::con<num_filters,5,5,2,2,SUBNET>;
 template <long num_filters, typename SUBNET> using con5  = dlib::con<num_filters,5,5,1,1,SUBNET>;
 
-template <typename SUBNET> using bdownsampler = dlib::relu<dlib::bn_con<con5d<64,dlib::relu<dlib::bn_con<con5d<64,dlib::relu<dlib::bn_con<con5d<16,SUBNET>>>>>>>>>;
-template <typename SUBNET> using adownsampler = dlib::relu<dlib::affine<con5d<64,dlib::relu<dlib::affine<con5d<64,dlib::relu<dlib::affine<con5d<16,SUBNET>>>>>>>>>;
+template <typename SUBNET> using bdownsampler = dlib::relu<dlib::bn_con<con5d<128,dlib::relu<dlib::bn_con<con5d<128,dlib::relu<dlib::bn_con<con5d<32,SUBNET>>>>>>>>>;
+template <typename SUBNET> using adownsampler = dlib::relu<dlib::affine<con5d<128,dlib::relu<dlib::affine<con5d<128,dlib::relu<dlib::affine<con5d<32,SUBNET>>>>>>>>>;
 
-template <typename SUBNET> using brcon5 = dlib::relu<dlib::bn_con<con5<128,SUBNET>>>;
-template <typename SUBNET> using arcon5 = dlib::relu<dlib::affine<con5<128,SUBNET>>>;
+template <typename SUBNET> using brcon5 = dlib::relu<dlib::bn_con<con5<256,SUBNET>>>;
+template <typename SUBNET> using arcon5 = dlib::relu<dlib::affine<con5<256,SUBNET>>>;
 
 using det_bnet_type = dlib::loss_mmod<dlib::con<1,9,9,1,1,brcon5<brcon5<brcon5<bdownsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
 using det_anet_type = dlib::loss_mmod<dlib::con<1,9,9,1,1,arcon5<arcon5<arcon5<adownsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
 
 // The segmentation network.
-// For the time being, this is very much copy-paste from dnn_semantic_segmentation.h.
+// For the time being, this is very much copy-paste from dnn_semantic_segmentation.h, although the network is made narrower (smaller feature maps).
 
 template <int N, template <typename> class BN, int stride, typename SUBNET>
 using block = BN<dlib::con<N,3,3,1,1,dlib::relu<BN<dlib::con<N,3,3,stride,stride,SUBNET>>>>>;
@@ -102,34 +102,34 @@ template <int N, typename SUBNET> using ares_up   = dlib::relu<residual_up<block
 
 // ----------------------------------------------------------------------------------------
 
-template <typename SUBNET> using res64 = res<64,SUBNET>;
-template <typename SUBNET> using res128 = res<128,SUBNET>;
-template <typename SUBNET> using res256 = res<256,SUBNET>;
-template <typename SUBNET> using res512 = res<512,SUBNET>;
-template <typename SUBNET> using ares64 = ares<64,SUBNET>;
-template <typename SUBNET> using ares128 = ares<128,SUBNET>;
-template <typename SUBNET> using ares256 = ares<256,SUBNET>;
-template <typename SUBNET> using ares512 = ares<512,SUBNET>;
+template <typename SUBNET> using res16 = res<16,SUBNET>;
+template <typename SUBNET> using res24 = res<24,SUBNET>;
+template <typename SUBNET> using res32 = res<32,SUBNET>;
+template <typename SUBNET> using res48 = res<48,SUBNET>;
+template <typename SUBNET> using ares16 = ares<16,SUBNET>;
+template <typename SUBNET> using ares24 = ares<24,SUBNET>;
+template <typename SUBNET> using ares32 = ares<32,SUBNET>;
+template <typename SUBNET> using ares48 = ares<48,SUBNET>;
 
-template <typename SUBNET> using level1 = dlib::repeat<2,res64,res<64,SUBNET>>;
-template <typename SUBNET> using level2 = dlib::repeat<2,res128,res_down<128,SUBNET>>;
-template <typename SUBNET> using level3 = dlib::repeat<2,res256,res_down<256,SUBNET>>;
-template <typename SUBNET> using level4 = dlib::repeat<2,res512,res_down<512,SUBNET>>;
+template <typename SUBNET> using level1 = dlib::repeat<2,res16,res<16,SUBNET>>;
+template <typename SUBNET> using level2 = dlib::repeat<2,res24,res_down<24,SUBNET>>;
+template <typename SUBNET> using level3 = dlib::repeat<2,res32,res_down<32,SUBNET>>;
+template <typename SUBNET> using level4 = dlib::repeat<2,res48,res_down<48,SUBNET>>;
 
-template <typename SUBNET> using alevel1 = dlib::repeat<2,ares64,ares<64,SUBNET>>;
-template <typename SUBNET> using alevel2 = dlib::repeat<2,ares128,ares_down<128,SUBNET>>;
-template <typename SUBNET> using alevel3 = dlib::repeat<2,ares256,ares_down<256,SUBNET>>;
-template <typename SUBNET> using alevel4 = dlib::repeat<2,ares512,ares_down<512,SUBNET>>;
+template <typename SUBNET> using alevel1 = dlib::repeat<2,ares16,ares<16,SUBNET>>;
+template <typename SUBNET> using alevel2 = dlib::repeat<2,ares24,ares_down<24,SUBNET>>;
+template <typename SUBNET> using alevel3 = dlib::repeat<2,ares32,ares_down<32,SUBNET>>;
+template <typename SUBNET> using alevel4 = dlib::repeat<2,ares48,ares_down<48,SUBNET>>;
 
-template <typename SUBNET> using level1t = dlib::repeat<2,res64,res_up<64,SUBNET>>;
-template <typename SUBNET> using level2t = dlib::repeat<2,res128,res_up<128,SUBNET>>;
-template <typename SUBNET> using level3t = dlib::repeat<2,res256,res_up<256,SUBNET>>;
-template <typename SUBNET> using level4t = dlib::repeat<2,res512,res_up<512,SUBNET>>;
+template <typename SUBNET> using level1t = dlib::repeat<2,res16,res_up<16,SUBNET>>;
+template <typename SUBNET> using level2t = dlib::repeat<2,res24,res_up<24,SUBNET>>;
+template <typename SUBNET> using level3t = dlib::repeat<2,res32,res_up<32,SUBNET>>;
+template <typename SUBNET> using level4t = dlib::repeat<2,res48,res_up<48,SUBNET>>;
 
-template <typename SUBNET> using alevel1t = dlib::repeat<2,ares64,ares_up<64,SUBNET>>;
-template <typename SUBNET> using alevel2t = dlib::repeat<2,ares128,ares_up<128,SUBNET>>;
-template <typename SUBNET> using alevel3t = dlib::repeat<2,ares256,ares_up<256,SUBNET>>;
-template <typename SUBNET> using alevel4t = dlib::repeat<2,ares512,ares_up<512,SUBNET>>;
+template <typename SUBNET> using alevel1t = dlib::repeat<2,ares16,ares_up<16,SUBNET>>;
+template <typename SUBNET> using alevel2t = dlib::repeat<2,ares24,ares_up<24,SUBNET>>;
+template <typename SUBNET> using alevel3t = dlib::repeat<2,ares32,ares_up<32,SUBNET>>;
+template <typename SUBNET> using alevel4t = dlib::repeat<2,ares48,ares_up<48,SUBNET>>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -166,7 +166,7 @@ static const char* instance_segmentation_net_filename = "instance_segmentation_v
 // training network type
 using seg_bnet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<2,1,1,1,1,
-                              dlib::relu<dlib::bn_con<dlib::cont<64,7,7,2,2,
+                              dlib::relu<dlib::bn_con<dlib::cont<16,7,7,2,2,
                               concat_utag1<level1t<
                               concat_utag2<level2t<
                               concat_utag3<level3t<
@@ -175,14 +175,14 @@ using seg_bnet_type = dlib::loss_multiclass_log_per_pixel<
                               level3<utag3<
                               level2<utag2<
                               level1<dlib::max_pool<3,3,2,2,utag1<
-                              dlib::relu<dlib::bn_con<dlib::con<64,7,7,2,2,
+                              dlib::relu<dlib::bn_con<dlib::con<16,7,7,2,2,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
                               >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
 using seg_anet_type = dlib::loss_multiclass_log_per_pixel<
                               dlib::cont<2,1,1,1,1,
-                              dlib::relu<dlib::affine<dlib::cont<64,7,7,2,2,
+                              dlib::relu<dlib::affine<dlib::cont<16,7,7,2,2,
                               concat_utag1<alevel1t<
                               concat_utag2<alevel2t<
                               concat_utag3<alevel3t<
@@ -191,7 +191,7 @@ using seg_anet_type = dlib::loss_multiclass_log_per_pixel<
                               alevel3<utag3<
                               alevel2<utag2<
                               alevel1<dlib::max_pool<3,3,2,2,utag1<
-                              dlib::relu<dlib::affine<dlib::con<64,7,7,2,2,
+                              dlib::relu<dlib::affine<dlib::con<16,7,7,2,2,
                               dlib::input<dlib::matrix<dlib::rgb_pixel>>
                               >>>>>>>>>>>>>>>>>>>>>>>>>;
 

--- a/examples/dnn_instance_segmentation_ex.h
+++ b/examples/dnn_instance_segmentation_ex.h
@@ -42,6 +42,22 @@ namespace {
     constexpr int seg_dim = 227;
 }
 
+dlib::rectangle get_cropping_rect(const dlib::rectangle& rectangle)
+{
+    DLIB_ASSERT(!rectangle.is_empty());
+
+    const auto center_point = dlib::center(rectangle);
+    const auto max_dim = std::max(rectangle.width(), rectangle.height());
+    const auto d = static_cast<long>(std::round(max_dim / 2.0 * 1.5)); // add +50%
+
+    return dlib::rectangle(
+        center_point.x() - d,
+        center_point.y() - d,
+        center_point.x() + d,
+        center_point.y() + d
+    );
+}
+
 // ----------------------------------------------------------------------------------------
 
 // The object detection network.

--- a/examples/dnn_instance_segmentation_ex.h
+++ b/examples/dnn_instance_segmentation_ex.h
@@ -66,11 +66,11 @@ dlib::rectangle get_cropping_rect(const dlib::rectangle& rectangle)
 template <long num_filters, typename SUBNET> using con5d = dlib::con<num_filters,5,5,2,2,SUBNET>;
 template <long num_filters, typename SUBNET> using con5  = dlib::con<num_filters,5,5,1,1,SUBNET>;
 
-template <typename SUBNET> using bdownsampler = dlib::relu<dlib::bn_con<con5d<32,dlib::relu<dlib::bn_con<con5d<32,dlib::relu<dlib::bn_con<con5d<16,SUBNET>>>>>>>>>;
-template <typename SUBNET> using adownsampler = dlib::relu<dlib::affine<con5d<32,dlib::relu<dlib::affine<con5d<32,dlib::relu<dlib::affine<con5d<16,SUBNET>>>>>>>>>;
+template <typename SUBNET> using bdownsampler = dlib::relu<dlib::bn_con<con5d<64,dlib::relu<dlib::bn_con<con5d<64,dlib::relu<dlib::bn_con<con5d<16,SUBNET>>>>>>>>>;
+template <typename SUBNET> using adownsampler = dlib::relu<dlib::affine<con5d<64,dlib::relu<dlib::affine<con5d<64,dlib::relu<dlib::affine<con5d<16,SUBNET>>>>>>>>>;
 
-template <typename SUBNET> using brcon5 = dlib::relu<dlib::bn_con<con5<55,SUBNET>>>;
-template <typename SUBNET> using arcon5 = dlib::relu<dlib::affine<con5<55,SUBNET>>>;
+template <typename SUBNET> using brcon5 = dlib::relu<dlib::bn_con<con5<128,SUBNET>>>;
+template <typename SUBNET> using arcon5 = dlib::relu<dlib::affine<con5<128,SUBNET>>>;
 
 using det_bnet_type = dlib::loss_mmod<dlib::con<1,9,9,1,1,brcon5<brcon5<brcon5<bdownsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
 using det_anet_type = dlib::loss_mmod<dlib::con<1,9,9,1,1,arcon5<arcon5<arcon5<adownsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -190,6 +190,9 @@ det_bnet_type train_detection_network(
     const double momentum = 0.9;
 
     mmod_options options(mmod_rects, 70, 30);
+    
+    options.overlaps_ignore = test_box_overlap(0.5, 0.95);
+
     det_bnet_type det_net(options);
 
     det_net.subnet().layer_details().set_num_filters(options.detector_windows.size());

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -304,7 +304,12 @@ matrix<uint16_t> keep_only_main_instance(const matrix<rgb_pixel>& rgb_label_imag
         for (long c = 0; c < nc; ++c)
         {
             const auto& index = rgb_label_image(r, c);
-            result(r, c) = (index == main_instance) ? 1 : 0;
+            if (index == main_instance)
+                result(r, c) = 1;
+            else if (index == dlib::rgb_pixel(224, 224, 192))
+                result(r, c) = dlib::loss_multiclass_log_per_pixel_::label_to_ignore;
+            else
+                result(r, c) = 0;
         }
     }
 

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -634,18 +634,24 @@ int main(int argc, char** argv) try
 
     cout << "images in dataset filtered by class: " << listing.size() << endl;
 
-    // First train a detection network (loss_mmod), and then a mask segmentation network (loss_log_per_pixel)
+    // First train an object detector network (loss_mmod).
     cout << endl << "Training detector network:" << endl;
     const auto det_net = train_detection_network    (listing, truth_instances, det_minibatch_size);
 
+    // Then train mask predictors (segmentation).
     std::map<std::string, seg_bnet_type> seg_nets_by_class;
+
+    // This flag controls if a separate mask predictor is trained for each class.
+    // Note that it would also be possible to train a separate mask predictor for
+    // class groups, each containing somehow similar classes -- for example, one
+    // mask predictor for cars and buses, another for cats and dogs, and so on.
     constexpr bool separate_seg_net_for_each_class = true;
 
     if (separate_seg_net_for_each_class)
     {
         for (const auto& classlabel : desired_classlabels)
         {
-            // Consider only the truth instances belonging to this class
+            // Consider only the truth instances belonging to this class.
             auto listing_for_classlabel = listing;
             auto truth_instances_for_classlabel = truth_instances;
             filter_listing(listing_for_classlabel, truth_instances_for_classlabel, { classlabel });

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -373,9 +373,8 @@ seg_bnet_type train_segmentation_network(
 
                 // Pick a random training instance.
                 const auto& mmod_rect = image_rects[rnd.get_random_32bit_number() % image_rects.size()];
-                const chip_details chip_details(mmod_rect.rect, chip_dims(seg_dim, seg_dim));
-
-                // TODO: expand the rect by 20% or so (by a hard-coded value that will be available for inference as well)
+                const auto cropping_rect = get_cropping_rect(mmod_rect.rect);
+                const chip_details chip_details(cropping_rect, chip_dims(seg_dim, seg_dim));
 
                 // Crop the input image.
                 extract_image_chip(input_image, chip_details, temp.input_image, interpolate_bilinear());

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -292,12 +292,13 @@ rgb_pixel decide_main_instance(const matrix<rgb_pixel>& rgb_label_image)
 
 matrix<uint16_t> keep_only_main_instance(const matrix<rgb_pixel>& rgb_label_image)
 {
-    matrix<uint16_t> result;
+    const auto nr = rgb_label_image.nr();
+    const auto nc = rgb_label_image.nc();
+
+    matrix<uint16_t> result(nr, nc);
 
     const auto main_instance = decide_main_instance(rgb_label_image);
 
-    const auto nr = rgb_label_image.nr();
-    const auto nc = rgb_label_image.nc();
     for (long r = 0; r < nr; ++r)
     {
         for (long c = 0; c < nc; ++c)

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -701,9 +701,9 @@ int main(int argc, char** argv) try
 
     if (desired_classlabels.empty())
     {
-        desired_classlabels.push_back("aeroplane");
         desired_classlabels.push_back("bicycle");
         desired_classlabels.push_back("car");
+        desired_classlabels.push_back("cat");
     }
 
     cout << "desired classlabels:";

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -190,9 +190,6 @@ det_bnet_type train_detection_network(
     const double momentum = 0.9;
 
     mmod_options options(mmod_rects, 70, 30);
-    
-    options.overlaps_ignore = test_box_overlap(0.5, 0.95);
-
     det_bnet_type det_net(options);
 
     det_net.subnet().layer_details().set_num_filters(options.detector_windows.size());

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -150,7 +150,7 @@ std::vector<truth_instance> rgb_label_images_to_truth_instances(
 
 struct truth_image
 {
-    image_info image_info;
+    image_info info;
     std::vector<truth_instance> truth_instances;
 };
 
@@ -240,7 +240,7 @@ det_bnet_type train_detection_network(
             const auto& truth_image = truth_images[random_index];
 
             // Load the input image.
-            load_image(input_image, truth_image.image_info.image_filename);
+            load_image(input_image, truth_image.info.image_filename);
 
             // Get a random crop of the input.
             const auto mmod_rects = extract_mmod_rects(truth_image.truth_instances);
@@ -396,13 +396,13 @@ seg_bnet_type train_segmentation_network(
 
             if (!image_truths.empty())
             {
-                const image_info& image_info = truth_image.image_info;
+                const image_info& info = truth_image.info;
 
                 // Load the input image.
-                load_image(input_image, image_info.image_filename);
+                load_image(input_image, info.image_filename);
 
                 // Load the ground-truth (RGB) instance labels.
-                load_image(rgb_label_image, image_info.instance_label_filename);
+                load_image(rgb_label_image, info.instance_label_filename);
 
                 // Pick a random training instance.
                 const auto& truth_instance = image_truths[rnd.get_random_32bit_number() % image_truths.size()];
@@ -540,13 +540,13 @@ int ignore_overlapped_boxes(
     return num_ignored;
 }
 
-std::vector<truth_instance> load_truth_instances(const image_info& image_info)
+std::vector<truth_instance> load_truth_instances(const image_info& info)
 {
     matrix<rgb_pixel> instance_label_image;
     matrix<rgb_pixel> class_label_image;
 
-    load_image(instance_label_image, image_info.instance_label_filename);
-    load_image(class_label_image, image_info.class_label_filename);
+    load_image(instance_label_image, info.instance_label_filename);
+    load_image(class_label_image, info.class_label_filename);
 
     return rgb_label_images_to_truth_instances(instance_label_image, class_label_image);
 };
@@ -606,7 +606,7 @@ std::vector<truth_image> filter_based_on_classlabel(
                 represents_desired_class
             );
 
-            result.push_back(truth_image{ input.image_info, temp });
+            result.push_back(truth_image{ input.info, temp });
         }
     }
 

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -366,7 +366,7 @@ seg_bnet_type train_segmentation_network(
     seg_trainer.be_verbose();
     seg_trainer.set_learning_rate(initial_learning_rate);
     seg_trainer.set_synchronization_file(synchronization_file_name, std::chrono::minutes(10));
-    seg_trainer.set_iterations_without_progress_threshold(5000);
+    seg_trainer.set_iterations_without_progress_threshold(2000);
     set_all_bn_running_stats_window_sizes(seg_net, 1000);
 
     // Output training parameters.
@@ -689,7 +689,7 @@ int main(int argc, char** argv) try
     }
 
     // mini-batches smaller than the default can be used with GPUs having less memory
-    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 60;
+    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 35;
     const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 100;
     cout << "det mini-batch size: " << det_minibatch_size << endl;
     cout << "seg mini-batch size: " << seg_minibatch_size << endl;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -176,7 +176,7 @@ std::vector<std::vector<mmod_rect>> extract_mmod_rect_vectors(
 {
     std::vector<std::vector<mmod_rect>> mmod_rects(truth_images.size());
 
-    const auto extract_mmod_rects_from_truth_image = [](const auto& truth_image)
+    const auto extract_mmod_rects_from_truth_image = [](const truth_image& truth_image)
     {
         return extract_mmod_rects(truth_image.truth_instances);
     };
@@ -658,7 +658,7 @@ std::vector<truth_image> filter_images_with_no_truth(const std::vector<truth_ima
 
     for (const auto& truth_image : truth_images)
     {
-        const auto ignored = [](const auto& truth) { return truth.mmod_rect.ignore; };
+        const auto ignored = [](const truth_instance& truth) { return truth.mmod_rect.ignore; };
         const auto& truth_instances = truth_image.truth_instances;
         if (!std::all_of(truth_instances.begin(), truth_instances.end(), ignored))
             result.push_back(truth_image);

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -155,6 +155,8 @@ std::vector<dlib::mmod_rect> rgb_label_image_to_mmod_rects(
                 // Encountered a new instance
                 instance_indexes[rgb_label] = mmod_rects.size();
                 mmod_rects.emplace_back(dlib::rectangle(c, r, c, r));
+
+                // TODO: read the instance's class from the other png!
             }
             else
             {
@@ -460,7 +462,7 @@ std::vector<std::vector<dlib::mmod_rect>> load_all_mmod_rects(const std::vector<
 
 int main(int argc, char** argv) try
 {
-    if (argc < 2 || argc > 3)
+    if (argc < 2 || argc > 4)
     {
         cout << "To run this program you need a copy of the PASCAL VOC2012 dataset." << endl;
         cout << endl;
@@ -480,7 +482,7 @@ int main(int argc, char** argv) try
     }
 
     // mini-batches smaller than the default can be used with GPUs having less memory
-    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 87;
+    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 75;
     const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 25;
     cout << "det mini-batch size: " << det_minibatch_size << endl;
     cout << "seg mini-batch size: " << seg_minibatch_size << endl;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -372,6 +372,8 @@ seg_bnet_type train_segmentation_network(
                 const auto& mmod_rect = image_rects[rnd.get_random_32bit_number() % image_rects.size()];
                 const chip_details chip_details(mmod_rect.rect, chip_dims(seg_dim, seg_dim));
 
+                // TODO: expand the rect by 20% or so (by a hard-coded value that will be available for inference as well)
+
                 // Crop the input image.
                 extract_image_chip(input_image, chip_details, temp.input_image, interpolate_bilinear());
 

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -107,8 +107,7 @@ std::vector<truth_instance> rgb_label_images_to_truth_instances(
                 continue;
 
             const auto rgb_class_label = class_label_image(r, c);
-            const auto class_label_index = rgb_label_to_index_label(rgb_class_label);
-            const Voc2012class& voc2012_class = classes[class_label_index];
+            const Voc2012class& voc2012_class = find_voc2012_class(rgb_class_label);
 
             const auto i = result_map.find(rgb_instance_label);
             if (i == result_map.end())

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -552,8 +552,16 @@ void filter_listing(
         );
 
         if (has_desired_class) {
+            std::vector<truth_instance> temp;
+            std::copy_if(
+                truth_instances[i].begin(),
+                truth_instances[i].end(),
+                std::back_inserter(temp),
+                represents_desired_class
+            );
+
             filtered_listing.push_back(listing[i]);
-            filtered_truth_instances.push_back(truth_instances[i]);
+            filtered_truth_instances.push_back(temp);
         }
     }
 
@@ -583,7 +591,7 @@ int main(int argc, char** argv) try
     }
 
     // mini-batches smaller than the default can be used with GPUs having less memory
-    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 60;
+    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 75;
     const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 25;
     cout << "det mini-batch size: " << det_minibatch_size << endl;
     cout << "seg mini-batch size: " << seg_minibatch_size << endl;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -470,9 +470,17 @@ int ignore_overlapped_boxes(
 std::vector<mmod_rect> load_mmod_rects(const image_info& image_info)
 {
     matrix<rgb_pixel> rgb_label_image;
+
     load_image(rgb_label_image, image_info.label_filename);
+
     auto mmod_rects = rgb_label_image_to_mmod_rects(rgb_label_image);
+
     ignore_overlapped_boxes(mmod_rects, test_box_overlap(0.50, 0.95));
+
+    for (auto& rect : mmod_rects)
+        if (rect.rect.width() < 35 && rect.rect.height() < 35)
+            rect.ignore = true;
+
     return mmod_rects;
 };
 

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -663,7 +663,7 @@ int main(int argc, char** argv) try
 
     // mini-batches smaller than the default can be used with GPUs having less memory
     const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 60;
-    const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 20;
+    const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 100;
     cout << "det mini-batch size: " << det_minibatch_size << endl;
     cout << "seg mini-batch size: " << seg_minibatch_size << endl;
 

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -550,7 +550,7 @@ int main(int argc, char** argv) try
     }
 
     // mini-batches smaller than the default can be used with GPUs having less memory
-    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 75;
+    const unsigned int det_minibatch_size = argc >= 3 ? std::stoi(argv[2]) : 40;
     const unsigned int seg_minibatch_size = argc >= 4 ? std::stoi(argv[3]) : 25;
     cout << "det mini-batch size: " << det_minibatch_size << endl;
     cout << "seg mini-batch size: " << seg_minibatch_size << endl;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -116,7 +116,6 @@ std::vector<truth_instance> rgb_label_images_to_truth_instances(
                 // Encountered a new instance
                 result_map[rgb_instance_label] = rectangle(c, r, c, r);
                 result_map[rgb_instance_label].label = voc2012_class.classlabel;
-                // TODO: read the instance's class from the other png!
             }
             else
             {

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -501,7 +501,7 @@ std::vector<truth_instance> load_truth_instances(const image_info& image_info)
 
     auto truth_instances = rgb_label_images_to_truth_instances(instance_label_image, class_label_image);
 
-    ignore_overlapped_boxes(truth_instances, test_box_overlap(0.50, 0.95));
+    ignore_overlapped_boxes(truth_instances, test_box_overlap(0.90, 0.95));
 
     for (auto& truth : truth_instances)
     {

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -190,6 +190,8 @@ det_bnet_type train_detection_network(
     mmod_options options(mmod_rects, 70, 30);
     det_bnet_type det_net(options);
 
+    det_net.subnet().layer_details().set_num_filters(options.detector_windows.size());
+
     dlib::pipe<det_training_sample> data(200);
     auto f = [&data, &listing, &mmod_rects](time_t seed)
     {

--- a/examples/dnn_semantic_segmentation_ex.h
+++ b/examples/dnn_semantic_segmentation_ex.h
@@ -34,76 +34,7 @@
 #define DLIB_DNn_SEMANTIC_SEGMENTATION_EX_H_
 
 #include <dlib/dnn.h>
-
-// ----------------------------------------------------------------------------------------
-
-// The PASCAL VOC2012 dataset contains 20 ground-truth classes + background.  Each class
-// is represented using an RGB color value.  We associate each class also to an index in the
-// range [0, 20], used internally by the network.
-
-struct Voc2012class {
-    Voc2012class(uint16_t index, const dlib::rgb_pixel& rgb_label, const std::string& classlabel)
-        : index(index), rgb_label(rgb_label), classlabel(classlabel)
-    {}
-
-    // The index of the class. In the PASCAL VOC 2012 dataset, indexes from 0 to 20 are valid.
-    const uint16_t index = 0;
-
-    // The corresponding RGB representation of the class.
-    const dlib::rgb_pixel rgb_label;
-
-    // The label of the class in plain text.
-    const std::string classlabel;
-};
-
-namespace {
-    constexpr int class_count = 21; // background + 20 classes
-
-    const std::vector<Voc2012class> classes = {
-        Voc2012class(0, dlib::rgb_pixel(0, 0, 0), ""), // background
-
-        // The cream-colored `void' label is used in border regions and to mask difficult objects
-        // (see http://host.robots.ox.ac.uk/pascal/VOC/voc2012/htmldoc/devkit_doc.html)
-        Voc2012class(dlib::loss_multiclass_log_per_pixel_::label_to_ignore,
-            dlib::rgb_pixel(224, 224, 192), "border"),
-
-        Voc2012class(1,  dlib::rgb_pixel(128,   0,   0), "aeroplane"),
-        Voc2012class(2,  dlib::rgb_pixel(  0, 128,   0), "bicycle"),
-        Voc2012class(3,  dlib::rgb_pixel(128, 128,   0), "bird"),
-        Voc2012class(4,  dlib::rgb_pixel(  0,   0, 128), "boat"),
-        Voc2012class(5,  dlib::rgb_pixel(128,   0, 128), "bottle"),
-        Voc2012class(6,  dlib::rgb_pixel(  0, 128, 128), "bus"),
-        Voc2012class(7,  dlib::rgb_pixel(128, 128, 128), "car"),
-        Voc2012class(8,  dlib::rgb_pixel( 64,   0,   0), "cat"),
-        Voc2012class(9,  dlib::rgb_pixel(192,   0,   0), "chair"),
-        Voc2012class(10, dlib::rgb_pixel( 64, 128,   0), "cow"),
-        Voc2012class(11, dlib::rgb_pixel(192, 128,   0), "diningtable"),
-        Voc2012class(12, dlib::rgb_pixel( 64,   0, 128), "dog"),
-        Voc2012class(13, dlib::rgb_pixel(192,   0, 128), "horse"),
-        Voc2012class(14, dlib::rgb_pixel( 64, 128, 128), "motorbike"),
-        Voc2012class(15, dlib::rgb_pixel(192, 128, 128), "person"),
-        Voc2012class(16, dlib::rgb_pixel(  0,  64,   0), "pottedplant"),
-        Voc2012class(17, dlib::rgb_pixel(128,  64,   0), "sheep"),
-        Voc2012class(18, dlib::rgb_pixel(  0, 192,   0), "sofa"),
-        Voc2012class(19, dlib::rgb_pixel(128, 192,   0), "train"),
-        Voc2012class(20, dlib::rgb_pixel(  0,  64, 128), "tvmonitor"),
-    };
-}
-
-template <typename Predicate>
-const Voc2012class& find_voc2012_class(Predicate predicate)
-{
-    const auto i = std::find_if(classes.begin(), classes.end(), predicate);
-
-    if (i != classes.end())
-    {
-        return *i;
-    }
-    else
-    {
-        throw std::runtime_error("Unable to find a matching VOC2012 class");
-    }
-}
+#include "pascal_voc_2012.h"
 
 // ----------------------------------------------------------------------------------------
 

--- a/examples/dnn_semantic_segmentation_train_ex.cpp
+++ b/examples/dnn_semantic_segmentation_train_ex.cpp
@@ -91,107 +91,6 @@ void randomly_crop_image (
 
 // ----------------------------------------------------------------------------------------
 
-// The names of the input image and the associated RGB label image in the PASCAL VOC 2012
-// data set.
-struct image_info
-{
-    string image_filename;
-    string label_filename;
-};
-
-// Read the list of image files belonging to either the "train", "trainval", or "val" set
-// of the PASCAL VOC2012 data.
-std::vector<image_info> get_pascal_voc2012_listing(
-    const std::string& voc2012_folder,
-    const std::string& file = "train" // "train", "trainval", or "val"
-)
-{
-    std::ifstream in(voc2012_folder + "/ImageSets/Segmentation/" + file + ".txt");
-
-    std::vector<image_info> results;
-
-    while (in)
-    {
-        std::string basename;
-        in >> basename;
-
-        if (!basename.empty())
-        {
-            image_info image_info;
-            image_info.image_filename = voc2012_folder + "/JPEGImages/" + basename + ".jpg";
-            image_info.label_filename = voc2012_folder + "/SegmentationClass/" + basename + ".png";
-            results.push_back(image_info);
-        }
-    }
-
-    return results;
-}
-
-// Read the list of image files belong to the "train" set of the PASCAL VOC2012 data.
-std::vector<image_info> get_pascal_voc2012_train_listing(
-    const std::string& voc2012_folder
-)
-{
-    return get_pascal_voc2012_listing(voc2012_folder, "train");
-}
-
-// Read the list of image files belong to the "val" set of the PASCAL VOC2012 data.
-std::vector<image_info> get_pascal_voc2012_val_listing(
-    const std::string& voc2012_folder
-)
-{
-    return get_pascal_voc2012_listing(voc2012_folder, "val");
-}
-
-// ----------------------------------------------------------------------------------------
-
-// The PASCAL VOC2012 dataset contains 20 ground-truth classes + background.  Each class
-// is represented using an RGB color value.  We associate each class also to an index in the
-// range [0, 20], used internally by the network.  To convert the ground-truth data to
-// something that the network can efficiently digest, we need to be able to map the RGB
-// values to the corresponding indexes.
-
-// Given an RGB representation, find the corresponding PASCAL VOC2012 class
-// (e.g., 'dog').
-const Voc2012class& find_voc2012_class(const dlib::rgb_pixel& rgb_label)
-{
-    return find_voc2012_class(
-        [&rgb_label](const Voc2012class& voc2012class)
-        {
-            return rgb_label == voc2012class.rgb_label;
-        }
-    );
-}
-
-// Convert an RGB class label to an index in the range [0, 20].
-inline uint16_t rgb_label_to_index_label(const dlib::rgb_pixel& rgb_label)
-{
-    return find_voc2012_class(rgb_label).index;
-}
-
-// Convert an image containing RGB class labels to a corresponding
-// image containing indexes in the range [0, 20].
-void rgb_label_image_to_index_label_image(
-    const dlib::matrix<dlib::rgb_pixel>& rgb_label_image,
-    dlib::matrix<uint16_t>& index_label_image
-)
-{
-    const long nr = rgb_label_image.nr();
-    const long nc = rgb_label_image.nc();
-
-    index_label_image.set_size(nr, nc);
-
-    for (long r = 0; r < nr; ++r)
-    {
-        for (long c = 0; c < nc; ++c)
-        {
-            index_label_image(r, c) = rgb_label_to_index_label(rgb_label_image(r, c));
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------------------
-
 // Calculate the per-pixel accuracy on a dataset whose file names are supplied as a parameter.
 double calculate_accuracy(anet_type& anet, const std::vector<image_info>& dataset)
 {
@@ -209,7 +108,7 @@ double calculate_accuracy(anet_type& anet, const std::vector<image_info>& datase
         load_image(input_image, image_info.image_filename);
 
         // Load the ground-truth (RGB) labels.
-        load_image(rgb_label_image, image_info.label_filename);
+        load_image(rgb_label_image, image_info.class_label_filename);
 
         // Create predictions for each pixel. At this point, the type of each prediction
         // is an index (a value between 0 and 20). Note that the net may return an image
@@ -324,7 +223,7 @@ int main(int argc, char** argv) try
             load_image(input_image, image_info.image_filename);
 
             // Load the ground-truth (RGB) labels.
-            load_image(rgb_label_image, image_info.label_filename);
+            load_image(rgb_label_image, image_info.class_label_filename);
 
             // Convert the RGB values to indexes.
             rgb_label_image_to_index_label_image(rgb_label_image, index_label_image);

--- a/examples/pascal_voc_2012.h
+++ b/examples/pascal_voc_2012.h
@@ -109,11 +109,11 @@ std::vector<image_info> get_pascal_voc2012_listing(
 
         if (!basename.empty())
         {
-            image_info image_info;
-            image_info.image_filename          = voc2012_folder + "/JPEGImages/"         + basename + ".jpg";
-            image_info.class_label_filename    = voc2012_folder + "/SegmentationClass/"  + basename + ".png";
-            image_info.instance_label_filename = voc2012_folder + "/SegmentationObject/" + basename + ".png";
-            results.push_back(image_info);
+            image_info info;
+            info.image_filename          = voc2012_folder + "/JPEGImages/"         + basename + ".jpg";
+            info.class_label_filename    = voc2012_folder + "/SegmentationClass/"  + basename + ".png";
+            info.instance_label_filename = voc2012_folder + "/SegmentationObject/" + basename + ".png";
+            results.push_back(info);
         }
     }
 

--- a/examples/pascal_voc_2012.h
+++ b/examples/pascal_voc_2012.h
@@ -142,9 +142,9 @@ const Voc2012class& find_voc2012_class(const dlib::rgb_pixel& rgb_label)
 {
     return find_voc2012_class(
         [&rgb_label](const Voc2012class& voc2012class)
-    {
-        return rgb_label == voc2012class.rgb_label;
-    }
+        {
+            return rgb_label == voc2012class.rgb_label;
+        }
     );
 }
 

--- a/examples/pascal_voc_2012.h
+++ b/examples/pascal_voc_2012.h
@@ -1,0 +1,180 @@
+// The contents of this file are in the public domain. See LICENSE_FOR_EXAMPLE_PROGRAMS.txt
+/*
+    Helper definitions for working with the PASCAL VOC2012 dataset.
+*/
+
+#ifndef PASCAL_VOC_2012_H_
+#define PASCAL_VOC_2012_H_
+
+#include <dlib/pixel.h>
+
+// ----------------------------------------------------------------------------------------
+
+// The PASCAL VOC2012 dataset contains 20 ground-truth classes + background.  Each class
+// is represented using an RGB color value.  We associate each class also to an index in the
+// range [0, 20], used internally by the network. To convert the ground-truth data to
+// something that the network can efficiently digest, we need to be able to map the RGB
+// values to the corresponding indexes.
+
+struct Voc2012class {
+    Voc2012class(uint16_t index, const dlib::rgb_pixel& rgb_label, const std::string& classlabel)
+        : index(index), rgb_label(rgb_label), classlabel(classlabel)
+    {}
+
+    // The index of the class. In the PASCAL VOC 2012 dataset, indexes from 0 to 20 are valid.
+    const uint16_t index = 0;
+
+    // The corresponding RGB representation of the class.
+    const dlib::rgb_pixel rgb_label;
+
+    // The label of the class in plain text.
+    const std::string classlabel;
+};
+
+namespace {
+    constexpr int class_count = 21; // background + 20 classes
+
+    const std::vector<Voc2012class> classes = {
+        Voc2012class(0, dlib::rgb_pixel(0, 0, 0), ""), // background
+
+        // The cream-colored `void' label is used in border regions and to mask difficult objects
+        // (see http://host.robots.ox.ac.uk/pascal/VOC/voc2012/htmldoc/devkit_doc.html)
+        Voc2012class(dlib::loss_multiclass_log_per_pixel_::label_to_ignore,
+            dlib::rgb_pixel(224, 224, 192), "border"),
+
+        Voc2012class(1,  dlib::rgb_pixel(128,   0,   0), "aeroplane"),
+        Voc2012class(2,  dlib::rgb_pixel(  0, 128,   0), "bicycle"),
+        Voc2012class(3,  dlib::rgb_pixel(128, 128,   0), "bird"),
+        Voc2012class(4,  dlib::rgb_pixel(  0,   0, 128), "boat"),
+        Voc2012class(5,  dlib::rgb_pixel(128,   0, 128), "bottle"),
+        Voc2012class(6,  dlib::rgb_pixel(  0, 128, 128), "bus"),
+        Voc2012class(7,  dlib::rgb_pixel(128, 128, 128), "car"),
+        Voc2012class(8,  dlib::rgb_pixel( 64,   0,   0), "cat"),
+        Voc2012class(9,  dlib::rgb_pixel(192,   0,   0), "chair"),
+        Voc2012class(10, dlib::rgb_pixel( 64, 128,   0), "cow"),
+        Voc2012class(11, dlib::rgb_pixel(192, 128,   0), "diningtable"),
+        Voc2012class(12, dlib::rgb_pixel( 64,   0, 128), "dog"),
+        Voc2012class(13, dlib::rgb_pixel(192,   0, 128), "horse"),
+        Voc2012class(14, dlib::rgb_pixel( 64, 128, 128), "motorbike"),
+        Voc2012class(15, dlib::rgb_pixel(192, 128, 128), "person"),
+        Voc2012class(16, dlib::rgb_pixel(  0,  64,   0), "pottedplant"),
+        Voc2012class(17, dlib::rgb_pixel(128,  64,   0), "sheep"),
+        Voc2012class(18, dlib::rgb_pixel(  0, 192,   0), "sofa"),
+        Voc2012class(19, dlib::rgb_pixel(128, 192,   0), "train"),
+        Voc2012class(20, dlib::rgb_pixel(  0,  64, 128), "tvmonitor"),
+    };
+}
+
+template <typename Predicate>
+const Voc2012class& find_voc2012_class(Predicate predicate)
+{
+    const auto i = std::find_if(classes.begin(), classes.end(), predicate);
+
+    if (i != classes.end())
+    {
+        return *i;
+    }
+    else
+    {
+        throw std::runtime_error("Unable to find a matching VOC2012 class");
+    }
+}
+
+// ----------------------------------------------------------------------------------------
+
+// The names of the input image and the associated RGB label image in the PASCAL VOC 2012
+// data set.
+struct image_info
+{
+    std::string image_filename;
+    std::string class_label_filename;
+    std::string instance_label_filename;
+};
+
+// Read the list of image files belonging to either the "train", "trainval", or "val" set
+// of the PASCAL VOC2012 data.
+std::vector<image_info> get_pascal_voc2012_listing(
+    const std::string& voc2012_folder,
+    const std::string& file = "train" // "train", "trainval", or "val"
+)
+{
+    std::ifstream in(voc2012_folder + "/ImageSets/Segmentation/" + file + ".txt");
+
+    std::vector<image_info> results;
+
+    while (in)
+    {
+        std::string basename;
+        in >> basename;
+
+        if (!basename.empty())
+        {
+            image_info image_info;
+            image_info.image_filename          = voc2012_folder + "/JPEGImages/"         + basename + ".jpg";
+            image_info.class_label_filename    = voc2012_folder + "/SegmentationClass/"  + basename + ".png";
+            image_info.instance_label_filename = voc2012_folder + "/SegmentationObject/" + basename + ".png";
+            results.push_back(image_info);
+        }
+    }
+
+    return results;
+}
+
+// Read the list of image files belong to the "train" set of the PASCAL VOC2012 data.
+std::vector<image_info> get_pascal_voc2012_train_listing(
+    const std::string& voc2012_folder
+)
+{
+    return get_pascal_voc2012_listing(voc2012_folder, "train");
+}
+
+// Read the list of image files belong to the "val" set of the PASCAL VOC2012 data.
+std::vector<image_info> get_pascal_voc2012_val_listing(
+    const std::string& voc2012_folder
+)
+{
+    return get_pascal_voc2012_listing(voc2012_folder, "val");
+}
+
+// Given an RGB representation, find the corresponding PASCAL VOC2012 class
+// (e.g., 'dog').
+const Voc2012class& find_voc2012_class(const dlib::rgb_pixel& rgb_label)
+{
+    return find_voc2012_class(
+        [&rgb_label](const Voc2012class& voc2012class)
+    {
+        return rgb_label == voc2012class.rgb_label;
+    }
+    );
+}
+
+// ----------------------------------------------------------------------------------------
+
+// Convert an RGB class label to an index in the range [0, 20].
+inline uint16_t rgb_label_to_index_label(const dlib::rgb_pixel& rgb_label)
+{
+    return find_voc2012_class(rgb_label).index;
+}
+
+// Convert an image containing RGB class labels to a corresponding
+// image containing indexes in the range [0, 20].
+void rgb_label_image_to_index_label_image(
+    const dlib::matrix<dlib::rgb_pixel>& rgb_label_image,
+    dlib::matrix<uint16_t>& index_label_image
+)
+{
+    const long nr = rgb_label_image.nr();
+    const long nc = rgb_label_image.nc();
+
+    index_label_image.set_size(nr, nc);
+
+    for (long r = 0; r < nr; ++r)
+    {
+        for (long c = 0; c < nc; ++c)
+        {
+            index_label_image(r, c) = rgb_label_to_index_label(rgb_label_image(r, c));
+        }
+    }
+}
+
+#endif // PASCAL_VOC_2012_H_


### PR DESCRIPTION
(resolves #1646)

This PR adds an _instance segmentation_ example.

In the sample images below, colors of rectangles depend on class, whereas segmentation colors are random (to show where one instance changes to another).

Some examples from the training set (PASCAL VOC 2012, but with bicycles, cars and cats only):

![image](https://user-images.githubusercontent.com/2297572/68544758-46d99680-03cf-11ea-81e9-6d8a3a295218.png)
![image](https://user-images.githubusercontent.com/2297572/68544761-49d48700-03cf-11ea-8fe1-e5b0b7ec7a7a.png)
![image](https://user-images.githubusercontent.com/2297572/68544765-4ccf7780-03cf-11ea-88c7-82f3e640424f.png)
![image](https://user-images.githubusercontent.com/2297572/68544767-522cc200-03cf-11ea-85c2-28ee0c510b49.png)
![image](https://user-images.githubusercontent.com/2297572/68544768-548f1c00-03cf-11ea-9ea4-238e640ce2f6.png)
![image](https://user-images.githubusercontent.com/2297572/68544770-55c04900-03cf-11ea-937f-8ffea1fbad98.png)
![image](https://user-images.githubusercontent.com/2297572/68544773-5822a300-03cf-11ea-90b6-9dabe1611702.png)
![image](https://user-images.githubusercontent.com/2297572/68544779-5ce75700-03cf-11ea-9c54-ebadfbf439cb.png)
![image](https://user-images.githubusercontent.com/2297572/68544780-5eb11a80-03cf-11ea-9f87-e7a58290fe57.png)

Some examples not seen during training:

![image](https://user-images.githubusercontent.com/2297572/68545015-b81a4900-03d1-11ea-99f4-66be764a385a.png)
![image](https://user-images.githubusercontent.com/2297572/68545017-ba7ca300-03d1-11ea-8a4a-d86bba0f186b.png)
![image](https://user-images.githubusercontent.com/2297572/68545018-bcdefd00-03d1-11ea-99d1-95510da48dfa.png)
![image](https://user-images.githubusercontent.com/2297572/68545019-bf415700-03d1-11ea-9d00-b6897916df4f.png)
![image](https://user-images.githubusercontent.com/2297572/68545020-c2d4de00-03d1-11ea-99dd-a911c4cbef0d.png)
![image](https://user-images.githubusercontent.com/2297572/68545022-c5373800-03d1-11ea-946a-1f7316bef18f.png)
![image](https://user-images.githubusercontent.com/2297572/68545027-c9635580-03d1-11ea-81e7-cfcd786bb4ec.png)
![image](https://user-images.githubusercontent.com/2297572/68545029-cc5e4600-03d1-11ea-91e0-f327fa35969f.png)
![image](https://user-images.githubusercontent.com/2297572/68545031-cff1cd00-03d1-11ea-8087-853ce84935c2.png)

(Yes, these is certainly overfitting, for example in the cat detector. But avoiding that is not really the point of this PR.)

The proposed implementation is (I guess) pretty much the simplest possible approach: first run standard MMOD object detector, then predict the correct segmentation mask for each found object. So object detection and segmentation are decoupled (separate networks).

An alternative approach would be a single loss layer, predicting both objects and instance masks at the same time. This is how [Mask R-CNN](https://arxiv.org/pdf/1703.06870), for example, works.
(Actually started implementing that direction also. But here it wasn't entirely straightforward (to me at least) to figure out how the MMOD side of it could run an image pyramid, without forcing the segmentation head to do that as well. But this may nevertheless be a reasonable direction for future work; the PR at hand should be seen only as a baseline example, upon which we can later improve.)

While the decoupled approach is sort-of unexciting, there are also benefits to it:
* When a common (downscaling) path is not used, distributing training to two different machines is trivial (the machines need not even be networked).
* You don't really need to find a balance between detection loss and segmentation loss, like you do in Mask R-CNN. I suppose that's mostly a trial-and-error exercise in practice (haven't really tried though). At any rate, find it nice that in the proposed approach we don't need to set another parameter whose scale perhaps is not very easily understood.

---

Note that in addition to the instance segmentation example, this PR also contains a proposed change to the trainer code itself. In particular, this trainer code change tries to fix a problem where dumping some of the previous loss values (when shrinking the learning rate) appears to cause the trainer not to load from its synchronization file, even though training loss may have increased a whole lot since the latest disk sync:

![image](https://user-images.githubusercontent.com/2297572/68545038-d84a0800-03d1-11ea-9fb2-989bb00678ee.png)

(This problem should be rather easy to reproduce by training instance segmentation networks _without_ the proposed trainer changes.)
