### PR TITLE
Fix vector normalizer doc

### DIFF
--- a/dlib/statistics/statistics_abstract.h
+++ b/dlib/statistics/statistics_abstract.h
@@ -1068,10 +1068,6 @@ namespace dlib
                 of column vectors.  In particular, normalized column vectors should 
                 have zero mean and a variance of one.  
 
-                Also, if desired, this object can use principal component 
-                analysis for the purposes of reducing the number of elements in a 
-                vector.  
-
             THREAD SAFETY
                 Note that this object contains a cached matrix object it uses 
                 to store intermediate results for normalization.  This avoids


### PR DESCRIPTION
I've just noticed that the `vector_normalizer` documentation mentions the PCA, which only applies to `vector_normalizer_pca`, so I deleted that part of the documentation.