### PR TITLE
 Add new loss layer for binary loss per pixel

### DIFF
--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1628,11 +1628,11 @@ namespace dlib
 
         __device__ float cuda_log1pexp(float x)
         {
-            if (x <= -37)
+            if (x <= -18)
                 return std::exp(x);
-            else if (-37 < x && x <= 18)
+            else if (-18 < x && x <= 9)
                 return std::log1p(std::exp(x));
-            else if (18 < x && x <= 33.3)
+            else if (9 < x && x <= 16)
                 return x + std::exp(-x);
             else
                 return x;

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1766,7 +1766,7 @@ namespace dlib
 
         void compute_loss_binary_log_per_pixel::
         do_work(
-            cuda_data_void_ptr loss_cuda_work_buffer,
+            cuda_data_ptr<float> loss_cuda_work_buffer,
             const float* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
@@ -1780,7 +1780,7 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_binary_log_per_pixel, max_jobs(gradient.size()),
-                static_cast<float*>(loss_cuda_work_buffer.data()), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
+                loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
 
             float floss;
             dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));
@@ -1789,7 +1789,7 @@ namespace dlib
 
         void compute_loss_multiclass_log_per_pixel::
         do_work(
-            cuda_data_void_ptr loss_cuda_work_buffer,
+            cuda_data_ptr<float> loss_cuda_work_buffer,
             const uint16_t* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
@@ -1804,7 +1804,7 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_multiclass_log_per_pixel, max_jobs(gradient.size()),
-                static_cast<float*>(loss_cuda_work_buffer.data()), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
+                loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
 
             float floss;
             dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1709,7 +1709,7 @@ namespace dlib
 
         void compute_loss_binary_log_per_pixel::
         do_work(
-            float* loss_cuda_work_buffer,
+            cuda_data_void_ptr loss_cuda_work_buffer,
             const float* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
@@ -1723,16 +1723,16 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_binary_log_per_pixel, max_jobs(gradient.size()),
-                loss_cuda_work_buffer, gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
+                static_cast<float*>(loss_cuda_work_buffer.data()), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
 
             float floss;
-            CHECK_CUDA(cudaMemcpy(&floss, loss_cuda_work_buffer, sizeof(float), cudaMemcpyDefault));
+            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));
             loss = scale*floss;
         }
 
         void compute_loss_multiclass_log_per_pixel::
         do_work(
-            float* loss_cuda_work_buffer,
+            cuda_data_void_ptr loss_cuda_work_buffer,
             const uint16_t* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
@@ -1747,10 +1747,10 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_multiclass_log_per_pixel, max_jobs(gradient.size()),
-                loss_cuda_work_buffer, gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
+                static_cast<float*>(loss_cuda_work_buffer.data()), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
 
             float floss;
-            CHECK_CUDA(cudaMemcpy(&floss, loss_cuda_work_buffer,  sizeof(float), cudaMemcpyDefault));
+            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));
             loss = scale*floss;
         }
 

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1626,6 +1626,48 @@ namespace dlib
 
     // ----------------------------------------------------------------------------------------
 
+        __device__ float cuda_log1pexp(float x)
+        {
+            if (x <= -37)
+                return std::exp(x);
+            else if (-37 < x && x <= 18)
+                return std::log1p(std::exp(x));
+            else if (18 < x && x <= 33.3)
+                return x + std::exp(-x);
+            else
+                return x;
+        }
+
+        __global__ void _cuda_compute_loss_binary_log_per_pixel(float* loss_out, float* g, const float* truth, const float* out_data, size_t n, const float scale)
+        {
+            float loss = 0;
+            for(auto i : grid_stride_range(0, n))
+            {
+                const float y = truth[i];
+
+                if (y > 0.f)
+                {
+                    const float temp = cuda_log1pexp(-out_data[i]);
+                    loss += y*temp;
+                    g[i] = y*scale*(g[i]-1);
+                }
+                else if (y < 0.f)
+                {
+                    const float temp = -(-out_data[i]-cuda_log1pexp(-out_data[i]));
+                    loss += -y*temp;
+                    g[i] = -y*scale*g[i];
+                }
+                else
+                {
+                    g[i] = 0.f;
+                }
+            }
+
+            warp_reduce_atomic_add(*loss_out, loss);
+        }
+
+    // ----------------------------------------------------------------------------------------
+
         __device__ float cuda_safe_log(float x, float epsilon = 1e-10)
         {
             // Prevent trying to calculate the logarithm of a very small number (let alone zero)
@@ -1663,6 +1705,30 @@ namespace dlib
             warp_reduce_atomic_add(*loss_out, loss);
         }
 
+    // ----------------------------------------------------------------------------------------
+
+        void compute_loss_binary_log_per_pixel::
+        do_work(
+            float* loss_cuda_work_buffer,
+            const float* truth_buffer,
+            const tensor& subnetwork_output,
+            tensor& gradient,
+            double& loss
+        )
+        {
+            CHECK_CUDA(cudaMemset(loss_cuda_work_buffer, 0, sizeof(float)));
+            sigmoid(gradient, subnetwork_output);
+
+            // The loss we output is the average loss over the mini-batch, and also over each element of the matrix output.
+            const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
+
+            launch_kernel(_cuda_compute_loss_binary_log_per_pixel, max_jobs(gradient.size()),
+                loss_cuda_work_buffer, gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
+
+            float floss;
+            CHECK_CUDA(cudaMemcpy(&floss, loss_cuda_work_buffer, sizeof(float), cudaMemcpyDefault));
+            loss = scale*floss;
+        }
 
         void compute_loss_multiclass_log_per_pixel::
         do_work(
@@ -1679,7 +1745,6 @@ namespace dlib
 
             // The loss we output is the average loss over the mini-batch, and also over each element of the matrix output.
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
-
 
             launch_kernel(_cuda_compute_loss_multiclass_log_per_pixel, max_jobs(gradient.size()),
                 loss_cuda_work_buffer, gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1766,37 +1766,37 @@ namespace dlib
 
         void compute_loss_binary_log_per_pixel::
         do_work(
-            cuda_data_ptr<float> loss_cuda_work_buffer,
+            cuda_data_ptr<float> loss_work_buffer,
             const float* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
             double& loss
         )
         {
-            CHECK_CUDA(cudaMemset(loss_cuda_work_buffer, 0, sizeof(float)));
+            CHECK_CUDA(cudaMemset(loss_work_buffer, 0, sizeof(float)));
             sigmoid(gradient, subnetwork_output);
 
             // The loss we output is the average loss over the mini-batch, and also over each element of the matrix output.
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_binary_log_per_pixel, max_jobs(gradient.size()),
-                loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
+                loss_work_buffer.data(), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
 
             float floss;
-            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer);
+            dlib::cuda::memcpy(&floss, loss_work_buffer);
             loss = scale*floss;
         }
 
         void compute_loss_multiclass_log_per_pixel::
         do_work(
-            cuda_data_ptr<float> loss_cuda_work_buffer,
+            cuda_data_ptr<float> loss_work_buffer,
             const uint16_t* truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
             double& loss
         )
         {
-            CHECK_CUDA(cudaMemset(loss_cuda_work_buffer, 0, sizeof(float)));
+            CHECK_CUDA(cudaMemset(loss_work_buffer, 0, sizeof(float)));
             softmax(gradient, subnetwork_output);
             static const uint16_t label_to_ignore = std::numeric_limits<uint16_t>::max();
 
@@ -1804,10 +1804,10 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_multiclass_log_per_pixel, max_jobs(gradient.size()),
-                loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
+                loss_work_buffer.data(), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
 
             float floss;
-            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer);
+            dlib::cuda::memcpy(&floss, loss_work_buffer);
             loss = scale*floss;
         }
 

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1767,7 +1767,7 @@ namespace dlib
         void compute_loss_binary_log_per_pixel::
         do_work(
             cuda_data_ptr<float> loss_work_buffer,
-            const float* truth_buffer,
+            cuda_data_ptr<const float> truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
             double& loss
@@ -1780,7 +1780,7 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_binary_log_per_pixel, max_jobs(gradient.size()),
-                loss_work_buffer.data(), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
+                loss_work_buffer.data(), gradient.device(), truth_buffer.data(), subnetwork_output.device(), gradient.size(), scale);
 
             float floss;
             dlib::cuda::memcpy(&floss, loss_work_buffer);
@@ -1790,7 +1790,7 @@ namespace dlib
         void compute_loss_multiclass_log_per_pixel::
         do_work(
             cuda_data_ptr<float> loss_work_buffer,
-            const uint16_t* truth_buffer,
+            cuda_data_ptr<const uint16_t> truth_buffer,
             const tensor& subnetwork_output,
             tensor& gradient,
             double& loss
@@ -1804,7 +1804,7 @@ namespace dlib
             const double scale = 1.0 / (subnetwork_output.num_samples() * subnetwork_output.nr() * subnetwork_output.nc());
 
             launch_kernel(_cuda_compute_loss_multiclass_log_per_pixel, max_jobs(gradient.size()),
-                loss_work_buffer.data(), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
+                loss_work_buffer.data(), gradient.device(), truth_buffer.data(), gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
 
             float floss;
             dlib::cuda::memcpy(&floss, loss_work_buffer);

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1783,7 +1783,7 @@ namespace dlib
                 loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, subnetwork_output.device(), gradient.size(), scale);
 
             float floss;
-            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));
+            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer);
             loss = scale*floss;
         }
 
@@ -1807,7 +1807,7 @@ namespace dlib
                 loss_cuda_work_buffer.data(), gradient.device(), truth_buffer, gradient.size(), gradient.nr()*gradient.nc(), gradient.nr()*gradient.nc()*gradient.k(), gradient.k(), label_to_ignore, scale);
 
             float floss;
-            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer, sizeof(float));
+            dlib::cuda::memcpy(&floss, loss_cuda_work_buffer);
             loss = scale*floss;
         }
 

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -447,7 +447,8 @@ namespace dlib
                 double& loss
             ) const
             {
-                const size_t bytes_per_plane = subnetwork_output.nr()*subnetwork_output.nc()*sizeof(float);
+                const auto image_size = subnetwork_output.nr()*subnetwork_output.nc();
+                const size_t bytes_per_plane = image_size*sizeof(float);
                 // Allocate a cuda buffer to store all the truth images and also one float
                 // for the scalar loss output.
                 buf = device_global_buffer(subnetwork_output.num_samples()*bytes_per_plane + sizeof(float));
@@ -464,14 +465,16 @@ namespace dlib
                     memcpy(buf + i*bytes_per_plane, &t(0,0), bytes_per_plane);
                 }
 
-                do_work(loss_buf, static_cast<float*>(buf.data()), subnetwork_output, gradient, loss);
+                auto truth_buf = static_pointer_cast<const float>(buf, subnetwork_output.num_samples()*image_size);
+
+                do_work(loss_buf, truth_buf, subnetwork_output, gradient, loss);
             }
 
         private:
 
             static void do_work(
                 cuda_data_ptr<float> loss_work_buffer,
-                const float* truth_buffer,
+                cuda_data_ptr<const float> truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,
                 double& loss
@@ -503,7 +506,8 @@ namespace dlib
                 double& loss
             ) const
             {
-                const size_t bytes_per_plane = subnetwork_output.nr()*subnetwork_output.nc()*sizeof(uint16_t);
+                const auto image_size = subnetwork_output.nr()*subnetwork_output.nc();
+                const size_t bytes_per_plane = image_size*sizeof(uint16_t);
                 // Allocate a cuda buffer to store all the truth images and also one float
                 // for the scalar loss output.
                 buf = device_global_buffer(subnetwork_output.num_samples()*bytes_per_plane + sizeof(float));
@@ -520,14 +524,16 @@ namespace dlib
                     memcpy(buf + i*bytes_per_plane, &t(0,0), bytes_per_plane);
                 }
 
-                do_work(loss_buf, static_cast<uint16_t*>(buf.data()), subnetwork_output, gradient, loss);
+                auto truth_buf = static_pointer_cast<const uint16_t>(buf, subnetwork_output.num_samples()*image_size);
+
+                do_work(loss_buf, truth_buf, subnetwork_output, gradient, loss);
             }
 
         private:
 
             static void do_work(
                 cuda_data_ptr<float> loss_work_buffer,
-                const uint16_t* truth_buffer,
+                cuda_data_ptr<const uint16_t> truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,
                 double& loss

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -412,6 +412,62 @@ namespace dlib
 
     // ----------------------------------------------------------------------------------------
 
+        class compute_loss_binary_log_per_pixel
+        {
+            /*!
+                The point of this class is to compute the loss computed by
+                loss_binary_log_per_pixel, but to do so with CUDA.
+            !*/
+        public:
+
+            compute_loss_binary_log_per_pixel(
+            )
+            {
+            }
+
+            template <
+                typename const_label_iterator
+                >
+            void operator() (
+                const_label_iterator truth,
+                const tensor& subnetwork_output,
+                tensor& gradient,
+                double& loss
+            ) const
+            {
+                const size_t bytes_per_plane = subnetwork_output.nr()*subnetwork_output.nc()*sizeof(float);
+                // Allocate a cuda buffer to store all the truth images and also one float
+                // for the scalar loss output.
+                buf = device_global_buffer(subnetwork_output.num_samples()*bytes_per_plane + sizeof(float));
+
+                cuda_data_void_ptr loss_buf = buf;
+                buf = buf+sizeof(float);
+
+                // copy the truth data into a cuda buffer.
+                for (long i = 0; i < subnetwork_output.num_samples(); ++i, ++truth)
+                {
+                    const matrix<float>& t = *truth;
+                    DLIB_ASSERT(t.nr() == subnetwork_output.nr());
+                    DLIB_ASSERT(t.nc() == subnetwork_output.nc());
+                    memcpy(buf + i*bytes_per_plane, &t(0,0), bytes_per_plane);
+                }
+
+                do_work(static_cast<float*>(loss_buf.data()), static_cast<float*>(buf.data()), subnetwork_output, gradient, loss);
+            }
+
+        private:
+
+            static void do_work(
+                float* loss_cuda_work_buffer,
+                const float* truth_buffer,
+                const tensor& subnetwork_output,
+                tensor& gradient,
+                double& loss
+            );
+            
+            mutable cuda_data_void_ptr buf;
+        };
+
         class compute_loss_multiclass_log_per_pixel
         {
             /*!

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -452,7 +452,7 @@ namespace dlib
                 // for the scalar loss output.
                 buf = device_global_buffer(subnetwork_output.num_samples()*bytes_per_plane + sizeof(float));
 
-                cuda_data_void_ptr loss_buf = buf;
+                cuda_data_ptr<float> loss_buf = static_pointer_cast<float>(buf, 1);
                 buf = buf+sizeof(float);
 
                 // copy the truth data into a cuda buffer.
@@ -470,7 +470,7 @@ namespace dlib
         private:
 
             static void do_work(
-                cuda_data_void_ptr loss_cuda_work_buffer,
+                cuda_data_ptr<float> loss_cuda_work_buffer,
                 const float* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,
@@ -508,7 +508,7 @@ namespace dlib
                 // for the scalar loss output.
                 buf = device_global_buffer(subnetwork_output.num_samples()*bytes_per_plane + sizeof(float));
 
-                cuda_data_void_ptr loss_buf = buf;
+                cuda_data_ptr<float> loss_buf = static_pointer_cast<float>(buf, 1);
                 buf = buf+sizeof(float);
 
                 // copy the truth data into a cuda buffer.
@@ -526,7 +526,7 @@ namespace dlib
         private:
 
             static void do_work(
-                cuda_data_void_ptr loss_cuda_work_buffer,
+                cuda_data_ptr<float> loss_cuda_work_buffer,
                 const uint16_t* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -470,7 +470,7 @@ namespace dlib
         private:
 
             static void do_work(
-                cuda_data_ptr<float> loss_cuda_work_buffer,
+                cuda_data_ptr<float> loss_work_buffer,
                 const float* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,
@@ -526,7 +526,7 @@ namespace dlib
         private:
 
             static void do_work(
-                cuda_data_ptr<float> loss_cuda_work_buffer,
+                cuda_data_ptr<float> loss_work_buffer,
                 const uint16_t* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -416,7 +416,7 @@ namespace dlib
         {
             /*!
                 The point of this class is to compute the loss computed by
-                loss_binary_log_per_pixel, but to do so with CUDA.
+                loss_binary_log_per_pixel_, but to do so with CUDA.
             !*/
         public:
 
@@ -452,13 +452,13 @@ namespace dlib
                     memcpy(buf + i*bytes_per_plane, &t(0,0), bytes_per_plane);
                 }
 
-                do_work(static_cast<float*>(loss_buf.data()), static_cast<float*>(buf.data()), subnetwork_output, gradient, loss);
+                do_work(loss_buf, static_cast<float*>(buf.data()), subnetwork_output, gradient, loss);
             }
 
         private:
 
             static void do_work(
-                float* loss_cuda_work_buffer,
+                cuda_data_void_ptr loss_cuda_work_buffer,
                 const float* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,
@@ -472,7 +472,7 @@ namespace dlib
         {
             /*!
                 The point of this class is to compute the loss computed by
-                loss_multiclass_log_per_pixel, but to do so with CUDA.
+                loss_multiclass_log_per_pixel_, but to do so with CUDA.
             !*/
         public:
 
@@ -508,13 +508,13 @@ namespace dlib
                     memcpy(buf + i*bytes_per_plane, &t(0,0), bytes_per_plane);
                 }
 
-                do_work(static_cast<float*>(loss_buf.data()), static_cast<uint16_t*>(buf.data()), subnetwork_output, gradient, loss);
+                do_work(loss_buf, static_cast<uint16_t*>(buf.data()), subnetwork_output, gradient, loss);
             }
 
         private:
 
             static void do_work(
-                float* loss_cuda_work_buffer,
+                cuda_data_void_ptr loss_cuda_work_buffer,
                 const uint16_t* truth_buffer,
                 const tensor& subnetwork_output,
                 tensor& gradient,

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -1285,6 +1285,68 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    class loss_binary_log_per_pixel_
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This object implements the loss layer interface defined above by
+                EXAMPLE_LOSS_LAYER_.  In particular, it implements the log loss, which is
+                appropriate for binary classification problems.  It is basically just like
+                loss_binary_log_ except that it lets you define matrix outputs instead
+                of scalar outputs.  It should be useful, for example, in segmentation
+                where we want to classify each pixel of an image, and also get at least
+                some sort of confidence estimate for each pixel.
+        !*/
+    public:
+
+        typedef matrix<float> training_label_type;
+        typedef matrix<float> output_label_type;
+
+        template <
+            typename SUB_TYPE,
+            typename label_iterator
+            >
+        void to_label (
+            const tensor& input_tensor,
+            const SUB_TYPE& sub,
+            label_iterator iter
+        ) const;
+        /*!
+            This function has the same interface as EXAMPLE_LOSS_LAYER_::to_label() except
+            it has the additional calling requirements that:
+                - sub.get_output().num_samples() == input_tensor.num_samples()
+                - sub.sample_expansion_factor() == 1
+            and the output label is the raw score for each classified object.  If the score
+            is > 0 then the classifier is predicting the +1 class, otherwise it is
+            predicting the -1 class.
+        !*/
+
+        template <
+            typename const_label_iterator,
+            typename SUBNET
+            >
+        double compute_loss_value_and_gradient (
+            const tensor& input_tensor,
+            const_label_iterator truth,
+            SUBNET& sub
+        ) const;
+        /*!
+            This function has the same interface as EXAMPLE_LOSS_LAYER_::compute_loss_value_and_gradient()
+            except it has the additional calling requirements that:
+                - sub.get_output().num_samples() == input_tensor.num_samples()
+                - sub.sample_expansion_factor() == 1
+                - all pixel values pointed to by truth correspond to the desired target values.
+                  Nominally they should be +1 or -1, each indicating the desired class label,
+                  or 0 to indicate that the corresponding pixel is to be ignored.
+        !*/
+
+    };
+
+    template <typename SUBNET>
+    using loss_binary_log_per_pixel = add_loss_layer<loss_binary_log_per_pixel_, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
     class loss_multiclass_log_per_pixel_
     {
         /*!

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2653,7 +2653,7 @@ namespace
 
         dnn_trainer<net_type> trainer(net, sgd(0, 0.9));
         trainer.set_learning_rate(1);
-        trainer.set_max_num_epochs(200);
+        trainer.set_max_num_epochs(400);
         trainer.train(x, y);
 
         // The learning task is easy, so the net should have no problem

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2653,7 +2653,7 @@ namespace
 
         dnn_trainer<net_type> trainer(net, sgd(0, 0.9));
         trainer.set_learning_rate(1);
-        trainer.set_max_num_epochs(400);
+        trainer.set_max_num_epochs(800);
         trainer.train(x, y);
 
         // The learning task is easy, so the net should have no problem

--- a/examples/dnn_instance_segmentation_ex.h
+++ b/examples/dnn_instance_segmentation_ex.h
@@ -23,7 +23,7 @@
        ./dnn_instance_segmentation_ex /path/to/VOC2012-or-other-images
 
     An alternative to steps 2-4 above is to download a pre-trained network
-    from here: http://dlib.net/files/instance_segmentation_voc2012net.dnn
+    from here: http://dlib.net/files/instance_segmentation_voc2012net_v2.dnn
 
     It would be a good idea to become familiar with dlib's DNN tooling before reading this
     example.  So you should read dnn_introduction_ex.cpp and dnn_introduction2_ex.cpp
@@ -159,13 +159,13 @@ template <typename SUBNET> using concat_utag4 = resize_and_concat<utag4,utag4_,S
 
 // ----------------------------------------------------------------------------------------
 
-static const char* instance_segmentation_net_filename = "instance_segmentation_voc2012net.dnn";
+static const char* instance_segmentation_net_filename = "instance_segmentation_voc2012net_v2.dnn";
 
 // ----------------------------------------------------------------------------------------
 
 // training network type
-using seg_bnet_type = dlib::loss_multiclass_log_per_pixel<
-                              dlib::cont<2,1,1,1,1,
+using seg_bnet_type = dlib::loss_binary_log_per_pixel<
+                              dlib::cont<1,1,1,1,1,
                               dlib::relu<dlib::bn_con<dlib::cont<16,7,7,2,2,
                               concat_utag1<level1t<
                               concat_utag2<level2t<
@@ -180,8 +180,8 @@ using seg_bnet_type = dlib::loss_multiclass_log_per_pixel<
                               >>>>>>>>>>>>>>>>>>>>>>>>>;
 
 // testing network type (replaced batch normalization with fixed affine transforms)
-using seg_anet_type = dlib::loss_multiclass_log_per_pixel<
-                              dlib::cont<2,1,1,1,1,
+using seg_anet_type = dlib::loss_binary_log_per_pixel<
+                              dlib::cont<1,1,1,1,1,
                               dlib::relu<dlib::affine<dlib::cont<16,7,7,2,2,
                               concat_utag1<alevel1t<
                               concat_utag2<alevel2t<


### PR DESCRIPTION
- Add new loss layer for binary loss per pixel (say, for completeness)
- In the instance-segmentation example, resolve possibly overlapping instances using the per-pixel output intensity (and not result rect size as previously); while at it, also make the instance output look "soft":
![image](https://user-images.githubusercontent.com/2297572/72452415-2f030200-37c6-11ea-9c93-2d88d2fe1e9c.png)
