### PR TITLE
add visitor to count net parameters

### DIFF
--- a/dlib/dnn/utilities.h
+++ b/dlib/dnn/utilities.h
@@ -273,6 +273,35 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    namespace impl
+    {
+        class visitor_count_parameters
+        {
+        public:
+            visitor_count_parameters(size_t& num_parameters_): num_parameters(num_parameters_) {}
+
+            void operator()(size_t, const tensor& t)
+            {
+                num_parameters += t.size();
+            }
+
+        private:
+            size_t& num_parameters;
+        };
+    }
+
+    template <typename net_type>
+    inline size_t count_parameters(
+        const net_type& net
+    )
+    {
+        size_t num_parameters = 0;
+        impl::visitor_count_parameters temp(num_parameters);
+        visit_layer_parameters(net, temp);
+        return num_parameters;
+    }
+
+// ----------------------------------------------------------------------------------------
 }
 
 #endif // DLIB_DNn_UTILITIES_H_ 

--- a/dlib/dnn/utilities_abstract.h
+++ b/dlib/dnn/utilities_abstract.h
@@ -120,6 +120,20 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <typename net_type>
+    inline size_t count_parameters(
+        const net_type& net
+    );
+    /*!
+        requires
+            - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
+              add_tag_layer.
+        ensures
+            - This function returns the number of parameters of net if it has been properly
+              initialized and 0 otherwise.
+    !*/
+
+// ----------------------------------------------------------------------------------------
 }
 
 #endif // DLIB_DNn_UTILITIES_ABSTRACT_H_ 


### PR DESCRIPTION
I've just added a simple visitor to count the parameters of a network.

Results for a ResNet 50:
- dlib:
``` c++
count_parameters(net);  // 22803176
```
- pytorch: 
``` python
sum(p.numel() for p in model.parameters() if p.requires_grad)  # 25557032
```
- keras
``` python
model.count_params()  # 25636712
```

There are some discrepancies, I think I'm doing it right, according to the `visit_layer_parameters` documentation and my ResNet 50 implementation.