### PR TITLE
imglab: chinese ("automatic") clustering, keyboard shortcuts for zooming

### DIFF
--- a/dlib/gui_widgets/widgets.cpp
+++ b/dlib/gui_widgets/widgets.cpp
@@ -7065,25 +7065,9 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     void image_display::
-    on_wheel_up (
-        unsigned long state
+    zoom_in (
     )
     {
-        // disable mouse wheel if the user is drawing a rectangle
-        if (drawing_rect)
-            return;
-
-        // if CONTROL is not being held down
-        if ((state & base_window::CONTROL) == 0)
-        {
-            scrollable_region::on_wheel_up(state);
-            return;
-        }
-
-        if (rect.contains(lastx,lasty) == false || hidden || !enabled)
-            return;
-
-
         if (zoom_in_scale < 100 && zoom_out_scale == 1)
         {
             const point mouse_loc(lastx, lasty);
@@ -7119,7 +7103,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     void image_display::
-    on_wheel_down (
+    on_wheel_up (
         unsigned long state
     )
     {
@@ -7130,14 +7114,22 @@ namespace dlib
         // if CONTROL is not being held down
         if ((state & base_window::CONTROL) == 0)
         {
-            scrollable_region::on_wheel_down(state);
+            scrollable_region::on_wheel_up(state);
             return;
         }
 
         if (rect.contains(lastx,lasty) == false || hidden || !enabled)
             return;
 
+        zoom_in();
+    }
 
+// ----------------------------------------------------------------------------------------
+
+    void image_display::
+    zoom_out (
+    )
+    {
         if (zoom_in_scale != 1)
         {
             const point mouse_loc(lastx, lasty);
@@ -7168,6 +7160,30 @@ namespace dlib
             const point delta = total_rect().tl_corner() - (mouse_loc - pix_loc/zoom_out_scale);
             scroll_to_rect(translate_rect(display_rect(), delta)); 
         }
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    void image_display::
+    on_wheel_down (
+        unsigned long state
+    )
+    {
+        // disable mouse wheel if the user is drawing a rectangle
+        if (drawing_rect)
+            return;
+
+        // if CONTROL is not being held down
+        if ((state & base_window::CONTROL) == 0)
+        {
+            scrollable_region::on_wheel_down(state);
+            return;
+        }
+
+        if (rect.contains(lastx,lasty) == false || hidden || !enabled)
+            return;
+
+        zoom_out();
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/gui_widgets/widgets.h
+++ b/dlib/gui_widgets/widgets.h
@@ -3493,6 +3493,12 @@ namespace dlib
         bool overlay_editing_is_enabled (
         ) const { auto_mutex M(m); return overlay_editing_enabled; }
 
+        void zoom_in (
+        );
+
+        void zoom_out (
+        );
+
     private:
 
         void draw (

--- a/tools/imglab/src/main.cpp
+++ b/tools/imglab/src/main.cpp
@@ -588,7 +588,7 @@ int main(int argc, char** argv)
                                         "The parts are instead simply mirrored to the flipped dataset.", 1);
         parser.add_option("rotate", "Read an XML image dataset and output a copy that is rotated counter clockwise by <arg> degrees. "
                                   "The output is saved to an XML file prefixed with rotated_<arg>.",1);
-        parser.add_option("cluster", "Cluster all the objects in an XML file into <arg> different clusters and save "
+        parser.add_option("cluster", "Cluster all the objects in an XML file into <arg> different clusters (pass 0 to find automatically) and save "
                                      "the results as cluster_###.xml and cluster_###.jpg files.",1);
         parser.add_option("ignore", "Mark boxes labeled as <arg> as ignored.  The resulting XML file is output as a separate file and the original is not modified.",1);
         parser.add_option("rmlabel","Remove all boxes labeled <arg> and save the results to a new XML file.",1);
@@ -704,7 +704,7 @@ int main(int argc, char** argv)
         parser.check_incompatible_options("box-images", "ignore");
         const char* convert_args[] = {"pascal-xml","pascal-v1","idl"};
         parser.check_option_arg_range("convert", convert_args);
-        parser.check_option_arg_range("cluster", 2, 999);
+        parser.check_option_arg_range("cluster", 0, 999);
         parser.check_option_arg_range("rotate", -360, 360);
         parser.check_option_arg_range("size", 10*10, 1000*1000);
         parser.check_option_arg_range("min-object-size", 1, 10000*10000);

--- a/tools/imglab/src/metadata_editor.cpp
+++ b/tools/imglab/src/metadata_editor.cpp
@@ -343,6 +343,16 @@ on_keydown (
             last_keyboard_jump_pos_update = 0;
         }
 
+        if (key == '=')
+        {
+            display.zoom_in();
+        }
+
+        if (key == '-')
+        {
+            display.zoom_out();
+        }
+
         if (key == 'd' && (state&base_window::KBD_MOD_ALT))
         {
             remove_selected_images();


### PR DESCRIPTION
Using chinese whispers for "automatic" clustering usually works and is nice for lazy people, and scrolling to zoom is a bit annoying at least for me.

In case the diff isn't clear, I just moved the zoom handling code out from the on_wheel_{up,down} into separate functions and call those as appropriate instead.
