### PR TITLE
Prevention of compiler warning

### DIFF
--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -1722,7 +1722,7 @@ namespace dlib
             throw dlib::serialization_error("Error while serializing a Google Protocol Buffer object, message too large.");
 
         // write temp to the output stream
-        uint32 size = temp.size();
+        uint32 size = static_cast<uint32>(temp.size());
         bo.host_to_little(size);
         out.write((char*)&size, sizeof(size));
         out.write(temp.c_str(), temp.size());


### PR DESCRIPTION
An exception will be thrown if the actual size is larger than the limit of uint32 but the assignment does not contain an explicit cast. The missing cast may trigger an incorrect compiler warning (e.g. Clang).