### PR TITLE
Integer conversions generating compiler warnings

### DIFF
--- a/dlib/http_client/http_client.cpp
+++ b/dlib/http_client/http_client.cpp
@@ -67,7 +67,7 @@ namespace dlib
 //! \return modified string ``s'' with spaces trimmed from left
     inline std::string& triml(std::string& s)
     {
-        int pos(0);
+        std::string::size_type pos(0);
         for ( ; s[pos] == ' ' || s[pos] == '\t' || s[pos] == '\r' || s[pos] == '\n' ; ++pos );
         s.erase(0, pos);
         return s;
@@ -78,7 +78,7 @@ namespace dlib
 //! \return modified string ``s'' with spaces trimmed from right
     inline std::string& trimr(std::string& s)
     {
-        int pos(s.size());
+        std::string::size_type pos(s.size());
         for ( ; pos && (s[pos-1] == ' ' || s[pos-1] == '\t' || s[pos-1] == '\r' || s[pos-1] == '\n') ; --pos );
         s.erase(pos, s.size()-pos);
         return s;

--- a/dlib/linker/linker_kernel_1.cpp
+++ b/dlib/linker/linker_kernel_1.cpp
@@ -159,7 +159,7 @@ namespace dlib
 
         // forward data from a to b
         char buf[200];
-        int status;
+        long status;
         bool error = false; // becomes true if one of the connections returns an error
         while (true)
         {
@@ -287,7 +287,7 @@ namespace dlib
 
         // forward data from b to a
         char buf[200];
-        int status;
+        long status;
         bool error = false;
         while (true)
         {

--- a/dlib/md5/md5_kernel_1.cpp
+++ b/dlib/md5/md5_kernel_1.cpp
@@ -454,7 +454,7 @@ namespace dlib
 
 
 
-        unsigned long len = 0;
+        std::streamsize len = 0;
 
         // an array of 16 words
         uint32 x[16];
@@ -467,7 +467,7 @@ namespace dlib
         std::streambuf& inputbuf = *input.rdbuf();
         while(!at_end)
         {
-            int num = inputbuf.sgetn(reinterpret_cast<char*>(temp),64);
+            std::streamsize num = inputbuf.sgetn(reinterpret_cast<char*>(temp),64);
             len += num;
 
             // if we hit the end of the stream then pad and add length


### PR DESCRIPTION
With respect to issue #2017 I submit a few adjustments that mainly change the type of local variables to prevent potentially wrong integer conversions.
