### PR TITLE
link against openblasp

### DIFF
--- a/dlib/cmake_utils/find_blas.cmake
+++ b/dlib/cmake_utils/find_blas.cmake
@@ -192,7 +192,7 @@ if (UNIX OR MINGW)
    INCLUDE (CheckFunctionExists)
 
    if (NOT blas_found)
-      find_library(cblas_lib openblas PATHS ${extra_paths})
+      find_library(cblas_lib NAMES openblasp openblas PATHS ${extra_paths})
       if (cblas_lib)
          set(blas_libraries ${cblas_lib})
          set(blas_found 1)


### PR DESCRIPTION
openblasp is a parallel implementation of openblas with pthreads found on Centos/Fedora. See #2023