### PR TITLE
Fix warnings while running the tests

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -691,14 +691,14 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const upsample_& , std::ostream& out)
+        friend void serialize(const upsample_& /*item*/, std::ostream& out)
         {
             serialize("upsample_", out);
             serialize(scale_y, out);
             serialize(scale_x, out);
         }
 
-        friend void deserialize(upsample_& , std::istream& in)
+        friend void deserialize(upsample_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -713,7 +713,7 @@ namespace dlib
                 throw serialization_error("Wrong scale found while deserializing dlib::upsample_");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const upsample_& )
+        friend std::ostream& operator<<(std::ostream& out, const upsample_& /*item*/)
         {
             out << "upsample\t ("
                 << "scale_y="<<scale_y
@@ -823,7 +823,7 @@ namespace dlib
                 throw serialization_error("Wrong size found while deserializing dlib::resize_to_");
         }
         
-        friend std::ostream& operator<<(std::ostream& out, const resize_to_& item)
+        friend std::ostream& operator<<(std::ostream& out, const resize_to_& /*item*/)
         {
             out << "resize_to ("
                 << "nr=" << NR_
@@ -832,7 +832,7 @@ namespace dlib
             return out;
         }
         
-        friend void to_xml(const resize_to_& item, std::ostream& out)
+        friend void to_xml(const resize_to_& /*item*/, std::ostream& out)
         {
             out << "<resize_to";
             out << " nr='" << NR_ << "'" ;
@@ -2153,7 +2153,7 @@ namespace dlib
             item.mode = (layer_mode)mode;
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const affine_& )
+        friend std::ostream& operator<<(std::ostream& out, const affine_& /*item*/)
         {
             out << "affine";
             return out;
@@ -2229,25 +2229,25 @@ namespace dlib
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }
         inline dpoint map_output_to_input (const dpoint& p) const { return p; }
 
-        friend void serialize(const add_prev_& , std::ostream& out)
+        friend void serialize(const add_prev_& /*item*/, std::ostream& out)
         {
             serialize("add_prev_", out);
         }
 
-        friend void deserialize(add_prev_& , std::istream& in)
+        friend void deserialize(add_prev_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
             if (version != "add_prev_")
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::add_prev_.");
         }
-        friend std::ostream& operator<<(std::ostream& out, const add_prev_& )
+        friend std::ostream& operator<<(std::ostream& out, const add_prev_& /*item*/)
         {
             out << "add_prev"<<id;
             return out;
         }
 
-        friend void to_xml(const add_prev_& item, std::ostream& out)
+        friend void to_xml(const add_prev_& /*item*/, std::ostream& out)
         {
             out << "<add_prev tag='"<<id<<"'/>\n";
         }
@@ -2329,12 +2329,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const mult_prev_& , std::ostream& out)
+        friend void serialize(const mult_prev_& /*item*/, std::ostream& out)
         {
             serialize("mult_prev_", out);
         }
 
-        friend void deserialize(mult_prev_& , std::istream& in)
+        friend void deserialize(mult_prev_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -2342,13 +2342,13 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::mult_prev_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const mult_prev_& item)
+        friend std::ostream& operator<<(std::ostream& out, const mult_prev_& /*item*/)
         {
             out << "mult_prev"<<id;
             return out;
         }
 
-        friend void to_xml(const mult_prev_& item, std::ostream& out)
+        friend void to_xml(const mult_prev_& /*item*/, std::ostream& out)
         {
             out << "<mult_prev tag='"<<id<<"'/>\n";
         }
@@ -2451,12 +2451,12 @@ namespace dlib
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }
         inline dpoint map_output_to_input (const dpoint& p) const { return p; }
 
-        friend void serialize(const resize_prev_to_tagged_& , std::ostream& out)
+        friend void serialize(const resize_prev_to_tagged_& /*item*/, std::ostream& out)
         {
             serialize("resize_prev_to_tagged_", out);
         }
 
-        friend void deserialize(resize_prev_to_tagged_& , std::istream& in)
+        friend void deserialize(resize_prev_to_tagged_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -2464,13 +2464,13 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::resize_prev_to_tagged_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const resize_prev_to_tagged_& )
+        friend std::ostream& operator<<(std::ostream& out, const resize_prev_to_tagged_& /*item*/)
         {
             out << "resize_prev_to_tagged"<<id;
             return out;
         }
 
-        friend void to_xml(const resize_prev_to_tagged_& , std::ostream& out)
+        friend void to_xml(const resize_prev_to_tagged_& /*item*/, std::ostream& out)
         {
             out << "<resize_prev_to_tagged tag='"<<id<<"'/>\n";
         }
@@ -2561,13 +2561,13 @@ namespace dlib
             deserialize(item.reshape_src, in);
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const scale_& item)
+        friend std::ostream& operator<<(std::ostream& out, const scale_& /*item*/)
         {
             out << "scale"<<id;
             return out;
         }
 
-        friend void to_xml(const scale_& item, std::ostream& out)
+        friend void to_xml(const scale_& /*item*/, std::ostream& out)
         {
             out << "<scale tag='"<<id<<"'/>\n";
         }
@@ -2641,12 +2641,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const relu_& , std::ostream& out)
+        friend void serialize(const relu_& /*item*/, std::ostream& out)
         {
             serialize("relu_", out);
         }
 
-        friend void deserialize(relu_& , std::istream& in)
+        friend void deserialize(relu_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -2654,7 +2654,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::relu_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const relu_& )
+        friend std::ostream& operator<<(std::ostream& out, const relu_& /*item*/)
         {
             out << "relu";
             return out;
@@ -2874,12 +2874,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const sig_& , std::ostream& out)
+        friend void serialize(const sig_& /*item*/, std::ostream& out)
         {
             serialize("sig_", out);
         }
 
-        friend void deserialize(sig_& , std::istream& in)
+        friend void deserialize(sig_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -2887,7 +2887,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::sig_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const sig_& )
+        friend std::ostream& operator<<(std::ostream& out, const sig_& /*item*/)
         {
             out << "sig";
             return out;
@@ -2947,12 +2947,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const mish_& , std::ostream& out)
+        friend void serialize(const mish_& /*item*/, std::ostream& out)
         {
             serialize("mish_", out);
         }
 
-        friend void deserialize(mish_& , std::istream& in)
+        friend void deserialize(mish_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -2960,7 +2960,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::mish_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const mish_& )
+        friend std::ostream& operator<<(std::ostream& out, const mish_& /*item*/)
         {
             out << "mish";
             return out;
@@ -3015,12 +3015,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const htan_& , std::ostream& out)
+        friend void serialize(const htan_& /*item*/, std::ostream& out)
         {
             serialize("htan_", out);
         }
 
-        friend void deserialize(htan_& , std::istream& in)
+        friend void deserialize(htan_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -3028,7 +3028,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::htan_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const htan_& )
+        friend std::ostream& operator<<(std::ostream& out, const htan_& /*item*/)
         {
             out << "htan";
             return out;
@@ -3080,12 +3080,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const softmax_& , std::ostream& out)
+        friend void serialize(const softmax_& /*item*/, std::ostream& out)
         {
             serialize("softmax_", out);
         }
 
-        friend void deserialize(softmax_& , std::istream& in)
+        friend void deserialize(softmax_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -3093,7 +3093,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::softmax_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const softmax_& )
+        friend std::ostream& operator<<(std::ostream& out, const softmax_& /*item*/)
         {
             out << "softmax";
             return out;
@@ -3143,12 +3143,12 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const softmax_all_& , std::ostream& out)
+        friend void serialize(const softmax_all_& /*item*/, std::ostream& out)
         {
             serialize("softmax_all_", out);
         }
 
-        friend void deserialize(softmax_all_& , std::istream& in)
+        friend void deserialize(softmax_all_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -3156,7 +3156,7 @@ namespace dlib
                 throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::softmax_all_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const softmax_all_& )
+        friend std::ostream& operator<<(std::ostream& out, const softmax_all_& /*item*/)
         {
             out << "softmax_all";
             return out;
@@ -3278,14 +3278,14 @@ namespace dlib
         const tensor& get_layer_params() const { return params; }
         tensor& get_layer_params() { return params; }
 
-        friend void serialize(const concat_& , std::ostream& out)
+        friend void serialize(const concat_& /*item*/, std::ostream& out)
         {
             serialize("concat_", out);
             size_t count = tag_count();
             serialize(count, out);
         }
 
-        friend void deserialize(concat_& , std::istream& in)
+        friend void deserialize(concat_& /*item*/, std::istream& in)
         {
             std::string version;
             deserialize(version, in);
@@ -3299,7 +3299,7 @@ namespace dlib
                                                   " found while deserializing dlib::concat_.");
         }
 
-        friend std::ostream& operator<<(std::ostream& out, const concat_& )
+        friend std::ostream& operator<<(std::ostream& out, const concat_& /*item*/)
         {
             out << "concat\t (";
             list_tags(out);
@@ -3307,7 +3307,7 @@ namespace dlib
             return out;
         }
 
-        friend void to_xml(const concat_& , std::ostream& out)
+        friend void to_xml(const concat_& /*item*/, std::ostream& out)
         {
             out << "<concat tags='";
             list_tags(out);

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -170,7 +170,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
    add_definitions("-W -Wall")
    # I don't care about unused testing functions though.  I like to keep them
    # around.  Don't warn about it.
-   add_definitions("-Wno-unused-function")
+   add_definitions("-Wno-unused-function -fdiagnostics-color=always -Wno-deprecated-copy -Wextra -pedantic")
 endif()
 
 

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -170,7 +170,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
    add_definitions("-W -Wall")
    # I don't care about unused testing functions though.  I like to keep them
    # around.  Don't warn about it.
-   add_definitions("-Wno-unused-function -fdiagnostics-color=always -Wno-deprecated-copy -Wextra -pedantic")
+   add_definitions("-Wno-unused-function")
 endif()
 
 

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2935,8 +2935,8 @@ namespace
 
         // Feed forward the training samples.
         resizable_tensor temp_tensor;
-        net.subnet().to_tensor(&x[0], &x[0] + num_samples, temp_tensor);
-        net.subnet().forward(temp_tensor);
+        net.to_tensor(&x[0], &x[0] + num_samples, temp_tensor);
+        net.forward(temp_tensor);
         const dimpl::subnet_wrapper<filter_type> wsub(net.subnet());
         const tensor& output_tensor = wsub.get_output();
         const float* const out_data = output_tensor.host();

--- a/dlib/test/is_same_object.cpp
+++ b/dlib/test/is_same_object.cpp
@@ -13,11 +13,11 @@ namespace
     using namespace std;
     dlib::logger dlog("test.is_same_object");
 
-    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_booya_template, void, template booya<int>, (std::string)const);
-    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_booya2_template, void, template booya2<int>, (int)const);
-    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_int, void, funct, (int));
-    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_double, void, funct, (double));
-    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_f, float, funct_f, (int));
+    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_booya_template, void, template booya<int>, (std::string)const)
+    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_booya2_template, void, template booya2<int>, (int)const)
+    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_int, void, funct, (int))
+    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_double, void, funct, (double))
+    DLIB_MAKE_HAS_MEMBER_FUNCTION_TEST(has_funct_f, float, funct_f, (int))
 
     class htest
     {

--- a/dlib/threads/async.h
+++ b/dlib/threads/async.h
@@ -86,7 +86,7 @@ namespace dlib
                 prom->set_exception(std::current_exception());
             }
         });
-        return std::move(ret);
+        return ret;
     }
 
 // ----------------------------------------------------------------------------------------

--- a/examples/dnn_dcgan_train_ex.cpp
+++ b/examples/dnn_dcgan_train_ex.cpp
@@ -112,7 +112,7 @@ matrix<unsigned char> generate_image(generator_type& net, const noise_t& noise)
 std::vector<matrix<unsigned char>> get_generated_images(const tensor& out)
 {
     std::vector<matrix<unsigned char>> images;
-    for (size_t n = 0; n < out.num_samples(); ++n)
+    for (long n = 0; n < out.num_samples(); ++n)
     {
         matrix<float> output = image_plane(out, n);
         matrix<unsigned char> image;

--- a/examples/dnn_instance_segmentation_train_ex.cpp
+++ b/examples/dnn_instance_segmentation_train_ex.cpp
@@ -168,7 +168,7 @@ std::vector<mmod_rect> extract_mmod_rects(
     );
 
     return mmod_rects;
-};
+}
 
 std::vector<std::vector<mmod_rect>> extract_mmod_rect_vectors(
     const std::vector<truth_image>& truth_images
@@ -549,7 +549,7 @@ std::vector<truth_instance> load_truth_instances(const image_info& info)
     load_image(class_label_image, info.class_label_filename);
 
     return rgb_label_images_to_truth_instances(instance_label_image, class_label_image);
-};
+}
 
 std::vector<std::vector<truth_instance>> load_all_truth_instances(const std::vector<image_info>& listing)
 {

--- a/examples/dnn_introduction3_ex.cpp
+++ b/examples/dnn_introduction3_ex.cpp
@@ -132,7 +132,7 @@ int main() try
     std::vector<matrix<rgb_pixel>> minibatch(1, image);
     resizable_tensor input;
     net.to_tensor(minibatch.begin(), minibatch.end(), input);
-    net.subnet().forward(input);
+    net.forward(input);
     cout << net << endl;
     cout << "input size=(" <<
        "num:" << input.num_samples() << ", " <<


### PR DESCRIPTION
As I've been running the tests several times these last days, I noticed there were some warnings when building with GCC 9.3.0 and these flags:
``` cmake
if (CMAKE_COMPILER_IS_GNUCXX)
   add_definitions("-W -Wall")
   # I don't care about unused testing functions though.  I like to keep them
   # around.  Don't warn about it.
   add_definitions("-Wno-unused-function -fdiagnostics-color=always -Wno-deprecated-copy -Wextra -pedantic")
endif()
```
I might try the deprecated-copy warnings another time :)

Also, while I was at it, I made the `layers.h` a bit more uniform when there are unused parameters in methods like `serialize`.