### PR TITLE
Fix warning in dnn_trainer initialization list

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -107,7 +107,7 @@ namespace dlib
             const solver_type& solver_,
             const std::vector<int>& cuda_extra_devices,
             std::shared_ptr<threads> thread_pools_ = std::shared_ptr<threads>()
-        ) : job_pipe(0), net(net_), thread_pools(thread_pools_)
+        ) : job_pipe(0), thread_pools(thread_pools_), net(net_)
         {
             devices.push_back(std::make_shared<device_data>(dlib::cuda::get_device(), net, solver_));
 


### PR DESCRIPTION
The thread pool was initialized after the network, so it lead to a
reorder warning in GCC 9.3.0