### PR TITLE
Corrected interpolate_bilinear for lab_pixel.

### DIFF
--- a/dlib/image_processing/generic_image.h
+++ b/dlib/image_processing/generic_image.h
@@ -134,6 +134,16 @@ namespace dlib
     struct is_rgb_image { const static bool value = pixel_traits<typename image_traits<image_type>::pixel_type>::rgb; };
 
     template <typename image_type>
+    struct is_color_space_cartesian_image { const static bool value = 
+        pixel_traits<typename image_traits<image_type>::pixel_type>::rgb || 
+        pixel_traits<typename image_traits<image_type>::pixel_type>::lab || 
+        pixel_traits<typename image_traits<image_type>::pixel_type>::grayscale; };
+    /*
+        Tells if all color components of image pixels are in cartesian coordinates, compared to e.g. polar coordinates.
+        Polar coordinates that may require more complicated blending.
+    */
+
+    template <typename image_type>
     struct is_grayscale_image { const static bool value = pixel_traits<typename image_traits<image_type>::pixel_type>::grayscale; };
 
 

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -237,14 +237,14 @@ namespace dlib
         ) const
         {
             // Interpolation currently supports only fully cartesian (non-polar) spaces.
-            COMPILE_TIME_ASSERT(is_color_space_cartesian_image<image_view_type>::value == true);
+            static_assert(is_color_space_cartesian_image<image_view_type>::value == true, "Non-cartesian color space used in interpolation");
 
             using traits = pixel_traits<typename image_view_type::pixel_type>;
 
-            const long left = static_cast<long>(std::floor(p.x()));
-            const long top = static_cast<long>(std::floor(p.y()));
-            const long right = left + 1;
-            const long bottom = top + 1;
+            const long left   = static_cast<long>(std::floor(p.x()));
+            const long top    = static_cast<long>(std::floor(p.y()));
+            const long right  = left+1;
+            const long bottom = top+1;
 
             // if the interpolation goes outside img 
             if (!(left >= 0 && top >= 0 && right < img.nc() && bottom < img.nr()))
@@ -253,10 +253,10 @@ namespace dlib
             const double lr_frac = p.x() - left;
             const double tb_frac = p.y() - top;
 
-            auto const tl = pixel_to_vector<typename traits::basic_pixel_type>(img[top][left]);
-            auto const tr = pixel_to_vector<typename traits::basic_pixel_type>(img[top][right]);
-            auto const bl = pixel_to_vector<typename traits::basic_pixel_type>(img[bottom][left]);
-            auto const br = pixel_to_vector<typename traits::basic_pixel_type>(img[bottom][right]);
+            auto const tl = pixel_to_vector<double>(img[top][left]);
+            auto const tr = pixel_to_vector<double>(img[top][right]);
+            auto const bl = pixel_to_vector<double>(img[bottom][left]);
+            auto const br = pixel_to_vector<double>(img[bottom][right]);
             typename ::std::remove_const<decltype(tl)>::type pvout;
             for (long i = 0; i < traits::num; ++i)
                 pvout(i) = (1 - tb_frac) * ((1 - lr_frac) * tl(i) + lr_frac * tr(i)) +

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -236,6 +236,8 @@ namespace dlib
             pixel_type& result
         ) const
         {
+            // Assign pixel gives special meaning to alpha channel that would break interpolation
+            static_assert(pixel_traits<typename image_view_type::pixel_type>::has_alpha == false, "Images with alpha channel not supported");
             // Interpolation currently supports only fully cartesian (non-polar) spaces.
             static_assert(is_color_space_cartesian_image<image_view_type>::value == true, "Non-cartesian color space used in interpolation");
 
@@ -257,11 +259,13 @@ namespace dlib
             auto const tr = pixel_to_vector<double>(img[top][right]);
             auto const bl = pixel_to_vector<double>(img[bottom][left]);
             auto const br = pixel_to_vector<double>(img[bottom][right]);
-            typename ::std::remove_const<decltype(tl)>::type pvout;
+            matrix<double, traits::num, 1> pvout;
             for (long i = 0; i < traits::num; ++i)
                 pvout(i) = (1 - tb_frac) * ((1 - lr_frac) * tl(i) + lr_frac * tr(i)) +
                 tb_frac * ((1 - lr_frac) * bl(i) + lr_frac * br(i));
-            vector_to_pixel(result, pvout);
+            typename image_view_type::pixel_type temp;
+            vector_to_pixel(temp, pvout);
+            assign_pixel(result, temp);
             return true;
         }
 
@@ -275,94 +279,43 @@ namespace dlib
     public:
 
         template <typename T, typename image_view_type, typename pixel_type>
-        typename disable_if<is_rgb_image<image_view_type>,bool>::type operator() (
+        bool operator() (
             const image_view_type& img,
             const dlib::vector<T,2>& p,
             pixel_type& result
         ) const
         {
-            COMPILE_TIME_ASSERT(pixel_traits<typename image_view_type::pixel_type>::has_alpha == false);
+            // Assign pixel gives special meaning to alpha channel that would break interpolation
+            static_assert(pixel_traits<typename image_view_type::pixel_type>::has_alpha == false, "Images with alpha channel not supported");
+            // Interpolation currently supports only fully cartesian (non-polar) spaces.
+            static_assert(is_color_space_cartesian_image<image_view_type>::value == true, "Non-cartesian color space used in interpolation");
+
+            using traits = pixel_traits<typename image_view_type::pixel_type>;
 
             const point pp(p);
 
             // if the interpolation goes outside img 
-            if (!get_rect(img).contains(grow_rect(pp,1))) 
+            if (!get_rect(img).contains(grow_rect(pp, 1)))
                 return false;
 
             const long r = pp.y();
             const long c = pp.x();
 
-            const double temp = interpolate(p-pp, 
-                                    img[r-1][c-1],
-                                    img[r-1][c  ],
-                                    img[r-1][c+1],
-                                    img[r  ][c-1],
-                                    img[r  ][c  ],
-                                    img[r  ][c+1],
-                                    img[r+1][c-1],
-                                    img[r+1][c  ],
-                                    img[r+1][c+1]);
-
+            matrix<double, traits::num, 1> pvout;
+            for (long i = 0; i < traits::num; ++i)
+                pvout(i) = interpolate(p - pp,
+                    pixel_to_vector<double>(img[r-1][c-1])(i),
+                    pixel_to_vector<double>(img[r-1][c  ])(i),
+                    pixel_to_vector<double>(img[r-1][c+1])(i),
+                    pixel_to_vector<double>(img[r  ][c-1])(i),
+                    pixel_to_vector<double>(img[r  ][c  ])(i),
+                    pixel_to_vector<double>(img[r  ][c+1])(i),
+                    pixel_to_vector<double>(img[r+1][c-1])(i),
+                    pixel_to_vector<double>(img[r+1][c  ])(i),
+                    pixel_to_vector<double>(img[r+1][c+1])(i));
+            typename image_view_type::pixel_type temp;
+            vector_to_pixel(temp, pvout);
             assign_pixel(result, temp);
-            return true;
-        }
-
-        template <typename T, typename image_view_type, typename pixel_type>
-        typename enable_if<is_rgb_image<image_view_type>,bool>::type operator() (
-            const image_view_type& img,
-            const dlib::vector<T,2>& p,
-            pixel_type& result
-        ) const
-        {
-            COMPILE_TIME_ASSERT(pixel_traits<typename image_view_type::pixel_type>::has_alpha == false);
-
-            const point pp(p);
-
-            // if the interpolation goes outside img 
-            if (!get_rect(img).contains(grow_rect(pp,1))) 
-                return false;
-
-            const long r = pp.y();
-            const long c = pp.x();
-
-            const double red = interpolate(p-pp, 
-                            img[r-1][c-1].red,
-                            img[r-1][c  ].red,
-                            img[r-1][c+1].red,
-                            img[r  ][c-1].red,
-                            img[r  ][c  ].red,
-                            img[r  ][c+1].red,
-                            img[r+1][c-1].red,
-                            img[r+1][c  ].red,
-                            img[r+1][c+1].red);
-            const double green = interpolate(p-pp, 
-                            img[r-1][c-1].green,
-                            img[r-1][c  ].green,
-                            img[r-1][c+1].green,
-                            img[r  ][c-1].green,
-                            img[r  ][c  ].green,
-                            img[r  ][c+1].green,
-                            img[r+1][c-1].green,
-                            img[r+1][c  ].green,
-                            img[r+1][c+1].green);
-            const double blue = interpolate(p-pp, 
-                            img[r-1][c-1].blue,
-                            img[r-1][c  ].blue,
-                            img[r-1][c+1].blue,
-                            img[r  ][c-1].blue,
-                            img[r  ][c  ].blue,
-                            img[r  ][c+1].blue,
-                            img[r+1][c-1].blue,
-                            img[r+1][c  ].blue,
-                            img[r+1][c+1].blue);
-
-
-            rgb_pixel temp;
-            assign_pixel(temp.red, red);
-            assign_pixel(temp.green, green);
-            assign_pixel(temp.blue, blue);
-            assign_pixel(result, temp);
-
             return true;
         }
 

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -232,7 +232,7 @@ namespace dlib
         template <typename T, typename image_view_type, typename pixel_type>
         bool operator() (
             const image_view_type& img,
-            const dlib::vector<T, 2>& p,
+            const dlib::vector<T,2>& p,
             pixel_type& result
         ) const
         {
@@ -295,7 +295,7 @@ namespace dlib
             const point pp(p);
 
             // if the interpolation goes outside img 
-            if (!get_rect(img).contains(grow_rect(pp, 1)))
+            if (!get_rect(img).contains(grow_rect(pp,1)))
                 return false;
 
             const long r = pp.y();
@@ -303,7 +303,7 @@ namespace dlib
 
             matrix<double, traits::num, 1> pvout;
             for (long i = 0; i < traits::num; ++i)
-                pvout(i) = interpolate(p - pp,
+                pvout(i) = interpolate(p-pp,
                     pixel_to_vector<double>(img[r-1][c-1])(i),
                     pixel_to_vector<double>(img[r-1][c  ])(i),
                     pixel_to_vector<double>(img[r-1][c+1])(i),

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -78,14 +78,13 @@ namespace dlib
                 - image_view_type == an image_view or const_image_view object 
                 - pixel_traits<typename image_view_type::pixel_type>::has_alpha == false
                 - pixel_traits<pixel_type> is defined
+                - pixel_type uses cartesian coordinates color space
             ensures
                 - if (there is an interpolatable image location at point p in img) then
                     - #result == the interpolated pixel value from img at point p.
                     - assign_pixel() will be used to write to #result, therefore any
                       necessary color space conversion will be performed.
                     - returns true
-                    - if img contains RGB pixels then the interpolation will be in color.
-                      Otherwise, the interpolation will be performed in a grayscale mode.
                 - else
                     - returns false
         !*/
@@ -119,14 +118,13 @@ namespace dlib
                 - image_view_type == an image_view or const_image_view object. 
                 - pixel_traits<typename image_view_type::pixel_type>::has_alpha == false
                 - pixel_traits<pixel_type> is defined
+                - pixel_type uses cartesian coordinates color space
             ensures
                 - if (there is an interpolatable image location at point p in img) then
                     - #result == the interpolated pixel value from img at point p
                     - assign_pixel() will be used to write to #result, therefore any
                       necessary color space conversion will be performed.
                     - returns true
-                    - if img contains RGB pixels then the interpolation will be in color.
-                      Otherwise, the interpolation will be performed in a grayscale mode.
                 - else
                     - returns false
         !*/

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -132,7 +132,52 @@ namespace dlib
                 && this->green == that.green
                 && this->blue  == that.blue;
         }
+
     };
+
+    template<size_t Index>
+    inline unsigned char get_component(rgb_pixel const &p);
+
+    template<>
+    inline unsigned char get_component<0>(rgb_pixel const &p)
+    {
+        return p.red;
+    }
+
+    template<>
+    inline unsigned char get_component<1>(rgb_pixel const &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char get_component<2>(rgb_pixel const &p)
+    {
+        return p.blue;
+    }
+
+    template<size_t Index>
+    inline unsigned char &get_component(rgb_pixel &p);
+
+    template<>
+    inline unsigned char &get_component<0>(rgb_pixel &p)
+    {
+        return p.red;
+    }
+
+    template<>
+    inline unsigned char &get_component<1>(rgb_pixel &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char &get_component<2>(rgb_pixel &p)
+    {
+        return p.blue;
+    }
+
+
 
 // ----------------------------------------------------------------------------------------
 
@@ -165,7 +210,50 @@ namespace dlib
                 && this->green == that.green
                 && this->red   == that.red;
         }
+
     };
+
+    template<size_t Index>
+    inline unsigned char get_component(bgr_pixel const &p);
+
+    template<>
+    inline unsigned char get_component<0>(bgr_pixel const &p)
+    {
+        return p.blue;
+    }
+
+    template<>
+    inline unsigned char get_component<1>(bgr_pixel const &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char get_component<2>(bgr_pixel const &p)
+    {
+        return p.red;
+    }
+
+    template<size_t Index>
+    inline unsigned char &get_component(bgr_pixel &p);
+
+    template<>
+    inline unsigned char &get_component<0>(bgr_pixel &p)
+    {
+        return p.blue;
+    }
+
+    template<>
+    inline unsigned char &get_component<1>(bgr_pixel &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char &get_component<2>(bgr_pixel &p)
+    {
+        return p.red;
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -199,7 +287,62 @@ namespace dlib
                 && this->blue  == that.blue
                 && this->alpha == that.alpha;
         }
+
     };
+
+    template<size_t Index>
+    inline unsigned char get_component(rgb_alpha_pixel const &p);
+
+    template<>
+    inline unsigned char get_component<0>(rgb_alpha_pixel const &p)
+    {
+        return p.red;
+    }
+
+    template<>
+    inline unsigned char get_component<1>(rgb_alpha_pixel const &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char get_component<2>(rgb_alpha_pixel const &p)
+    {
+        return p.blue;
+    }
+
+    template<>
+    inline unsigned char get_component<3>(rgb_alpha_pixel const &p)
+    {
+        return p.alpha;
+    }
+
+    template<size_t Index>
+    inline unsigned char &get_component(rgb_alpha_pixel &p);
+
+    template<>
+    inline unsigned char &get_component<0>(rgb_alpha_pixel &p)
+    {
+        return p.red;
+    }
+
+    template<>
+    inline unsigned char &get_component<1>(rgb_alpha_pixel &p)
+    {
+        return p.green;
+    }
+
+    template<>
+    inline unsigned char &get_component<2>(rgb_alpha_pixel &p)
+    {
+        return p.blue;
+    }
+
+    template<>
+    inline unsigned char &get_component<3>(rgb_alpha_pixel &p)
+    {
+        return p.alpha;
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -229,7 +372,51 @@ namespace dlib
                 && this->s == that.s
                 && this->i == that.i;
         }
+
     };
+
+    template<size_t Index>
+    inline unsigned char get_component(hsi_pixel const &p);
+
+    template<>
+    inline unsigned char get_component<0>(hsi_pixel const &p)
+    {
+        return p.h;
+    }
+
+    template<>
+    inline unsigned char get_component<1>(hsi_pixel const &p)
+    {
+        return p.s;
+    }
+
+    template<>
+    inline unsigned char get_component<2>(hsi_pixel const &p)
+    {
+        return p.i;
+    }
+
+    template<size_t Index>
+    inline unsigned char &get_component(hsi_pixel &p);
+
+    template<>
+    inline unsigned char &get_component<0>(hsi_pixel &p)
+    {
+        return p.h;
+    }
+
+    template<>
+    inline unsigned char &get_component<1>(hsi_pixel &p)
+    {
+        return p.s;
+    }
+
+    template<>
+    inline unsigned char &get_component<2>(hsi_pixel &p)
+    {
+        return p.i;
+    }
+
     // ----------------------------------------------------------------------------------------
 
     struct lab_pixel
@@ -258,7 +445,50 @@ namespace dlib
                 && this->a == that.a
                 && this->b == that.b;
         }
+
     };
+
+    template<size_t Index>
+    inline unsigned char get_component(lab_pixel const &p);
+
+    template<>
+    inline unsigned char get_component<0>(lab_pixel const &p)
+    {
+        return p.l;
+    }
+
+    template<>
+    inline  unsigned char get_component<1>(lab_pixel const &p)
+    {
+        return p.a;
+    }
+
+    template<>
+    inline unsigned char get_component<2>(lab_pixel const &p)
+    {
+        return p.b;
+    }
+
+    template<size_t Index>
+    inline unsigned char &get_component(lab_pixel &p);
+
+    template<>
+    inline unsigned char &get_component<0>(lab_pixel &p)
+    {
+        return p.l;
+    }
+
+    template<>
+    inline  unsigned char &get_component<1>(lab_pixel &p)
+    {
+        return p.a;
+    }
+
+    template<>
+    inline unsigned char &get_component<2>(lab_pixel &p)
+    {
+        return p.b;
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -588,6 +818,20 @@ namespace dlib
     template <> struct pixel_traits<std::complex<float> > :       public float_grayscale_pixel_traits<float> {};
     template <> struct pixel_traits<std::complex<double> > :      public float_grayscale_pixel_traits<double> {};
     template <> struct pixel_traits<std::complex<long double> > : public float_grayscale_pixel_traits<long double> {};
+
+    template<size_t Index, typename T>
+    inline typename std::enable_if<pixel_traits<T>::grayscale, T>::type get_component(T const &p)
+    {
+        COMPILE_TIME_ASSERT(Index == 0);
+        return p;
+    }
+
+    template<size_t Index, typename T>
+    inline typename std::enable_if<pixel_traits<T>::grayscale, T>::type &get_component(T &p)
+    {
+        COMPILE_TIME_ASSERT(Index == 0);
+        return p;
+    }
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -133,51 +133,12 @@ namespace dlib
                 && this->blue  == that.blue;
         }
 
+        bool operator != (const rgb_pixel& that) const
+        {
+            return !(*this == that);
+        }
+
     };
-
-    template<size_t Index>
-    inline unsigned char get_component(rgb_pixel const &p);
-
-    template<>
-    inline unsigned char get_component<0>(rgb_pixel const &p)
-    {
-        return p.red;
-    }
-
-    template<>
-    inline unsigned char get_component<1>(rgb_pixel const &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char get_component<2>(rgb_pixel const &p)
-    {
-        return p.blue;
-    }
-
-    template<size_t Index>
-    inline unsigned char &get_component(rgb_pixel &p);
-
-    template<>
-    inline unsigned char &get_component<0>(rgb_pixel &p)
-    {
-        return p.red;
-    }
-
-    template<>
-    inline unsigned char &get_component<1>(rgb_pixel &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char &get_component<2>(rgb_pixel &p)
-    {
-        return p.blue;
-    }
-
-
 
 // ----------------------------------------------------------------------------------------
 
@@ -211,49 +172,12 @@ namespace dlib
                 && this->red   == that.red;
         }
 
+        bool operator != (const bgr_pixel& that) const
+        {
+            return !(*this == that);
+        }
+
     };
-
-    template<size_t Index>
-    inline unsigned char get_component(bgr_pixel const &p);
-
-    template<>
-    inline unsigned char get_component<0>(bgr_pixel const &p)
-    {
-        return p.blue;
-    }
-
-    template<>
-    inline unsigned char get_component<1>(bgr_pixel const &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char get_component<2>(bgr_pixel const &p)
-    {
-        return p.red;
-    }
-
-    template<size_t Index>
-    inline unsigned char &get_component(bgr_pixel &p);
-
-    template<>
-    inline unsigned char &get_component<0>(bgr_pixel &p)
-    {
-        return p.blue;
-    }
-
-    template<>
-    inline unsigned char &get_component<1>(bgr_pixel &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char &get_component<2>(bgr_pixel &p)
-    {
-        return p.red;
-    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -288,61 +212,12 @@ namespace dlib
                 && this->alpha == that.alpha;
         }
 
+        bool operator != (const rgb_alpha_pixel& that) const
+        {
+            return !(*this == that);
+        }
+
     };
-
-    template<size_t Index>
-    inline unsigned char get_component(rgb_alpha_pixel const &p);
-
-    template<>
-    inline unsigned char get_component<0>(rgb_alpha_pixel const &p)
-    {
-        return p.red;
-    }
-
-    template<>
-    inline unsigned char get_component<1>(rgb_alpha_pixel const &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char get_component<2>(rgb_alpha_pixel const &p)
-    {
-        return p.blue;
-    }
-
-    template<>
-    inline unsigned char get_component<3>(rgb_alpha_pixel const &p)
-    {
-        return p.alpha;
-    }
-
-    template<size_t Index>
-    inline unsigned char &get_component(rgb_alpha_pixel &p);
-
-    template<>
-    inline unsigned char &get_component<0>(rgb_alpha_pixel &p)
-    {
-        return p.red;
-    }
-
-    template<>
-    inline unsigned char &get_component<1>(rgb_alpha_pixel &p)
-    {
-        return p.green;
-    }
-
-    template<>
-    inline unsigned char &get_component<2>(rgb_alpha_pixel &p)
-    {
-        return p.blue;
-    }
-
-    template<>
-    inline unsigned char &get_component<3>(rgb_alpha_pixel &p)
-    {
-        return p.alpha;
-    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -373,49 +248,12 @@ namespace dlib
                 && this->i == that.i;
         }
 
+        bool operator != (const hsi_pixel& that) const
+        {
+            return !(*this == that);
+        }
+
     };
-
-    template<size_t Index>
-    inline unsigned char get_component(hsi_pixel const &p);
-
-    template<>
-    inline unsigned char get_component<0>(hsi_pixel const &p)
-    {
-        return p.h;
-    }
-
-    template<>
-    inline unsigned char get_component<1>(hsi_pixel const &p)
-    {
-        return p.s;
-    }
-
-    template<>
-    inline unsigned char get_component<2>(hsi_pixel const &p)
-    {
-        return p.i;
-    }
-
-    template<size_t Index>
-    inline unsigned char &get_component(hsi_pixel &p);
-
-    template<>
-    inline unsigned char &get_component<0>(hsi_pixel &p)
-    {
-        return p.h;
-    }
-
-    template<>
-    inline unsigned char &get_component<1>(hsi_pixel &p)
-    {
-        return p.s;
-    }
-
-    template<>
-    inline unsigned char &get_component<2>(hsi_pixel &p)
-    {
-        return p.i;
-    }
 
     // ----------------------------------------------------------------------------------------
 
@@ -446,49 +284,12 @@ namespace dlib
                 && this->b == that.b;
         }
 
-    };
+        bool operator != (const lab_pixel& that) const
+        {
+            return !(*this == that);
+        }
 
-    template<size_t Index>
-    inline unsigned char get_component(lab_pixel const &p);
-
-    template<>
-    inline unsigned char get_component<0>(lab_pixel const &p)
-    {
-        return p.l;
-    }
-
-    template<>
-    inline  unsigned char get_component<1>(lab_pixel const &p)
-    {
-        return p.a;
-    }
-
-    template<>
-    inline unsigned char get_component<2>(lab_pixel const &p)
-    {
-        return p.b;
-    }
-
-    template<size_t Index>
-    inline unsigned char &get_component(lab_pixel &p);
-
-    template<>
-    inline unsigned char &get_component<0>(lab_pixel &p)
-    {
-        return p.l;
-    }
-
-    template<>
-    inline  unsigned char &get_component<1>(lab_pixel &p)
-    {
-        return p.a;
-    }
-
-    template<>
-    inline unsigned char &get_component<2>(lab_pixel &p)
-    {
-        return p.b;
-    }
+    };    
 
 // ----------------------------------------------------------------------------------------
 
@@ -818,20 +619,6 @@ namespace dlib
     template <> struct pixel_traits<std::complex<float> > :       public float_grayscale_pixel_traits<float> {};
     template <> struct pixel_traits<std::complex<double> > :      public float_grayscale_pixel_traits<double> {};
     template <> struct pixel_traits<std::complex<long double> > : public float_grayscale_pixel_traits<long double> {};
-
-    template<size_t Index, typename T>
-    inline typename std::enable_if<pixel_traits<T>::grayscale, T>::type get_component(T const &p)
-    {
-        COMPILE_TIME_ASSERT(Index == 0);
-        return p;
-    }
-
-    template<size_t Index, typename T>
-    inline typename std::enable_if<pixel_traits<T>::grayscale, T>::type &get_component(T &p)
-    {
-        COMPILE_TIME_ASSERT(Index == 0);
-        return p;
-    }
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -2039,8 +2039,7 @@ namespace
         }
 
     }
-    
-    template<typename interpolation_type = interpolate_bilinear>
+
     void test_null_rotate_image_with_interpolation()
     {
         {
@@ -2057,7 +2056,7 @@ namespace
             img_s(2, 1) = 100;
             img_s(2, 2) = 100;
 
-            rotate_image(img_s, img_d, 0, interpolation_type());
+            rotate_image(img_s, img_d, 0, interpolate_bilinear());
             DLIB_TEST((img_d(0, 0) == 0));
             DLIB_TEST((img_d(0, 1) == 100));
             DLIB_TEST((img_d(1, 0) == 100));
@@ -2078,7 +2077,7 @@ namespace
             img_s(2, 1) = { 10, 20, 30 };
             img_s(2, 2) = { 10, 20, 30 };
 
-            rotate_image(img_s, img_d, 0, interpolation_type());
+            rotate_image(img_s, img_d, 0, interpolate_bilinear());
             DLIB_TEST((img_d(0, 0) == rgb_pixel{ 0, 0, 0 }));
             DLIB_TEST((img_d(0, 1) == rgb_pixel{ 10, 20, 30 }));
             DLIB_TEST((img_d(1, 0) == rgb_pixel{ 10, 20, 30 }));
@@ -2099,13 +2098,70 @@ namespace
             img_s(2, 1) = { 100, 20, 30 };
             img_s(2, 2) = { 100, 20, 30 };
 
-            rotate_image(img_s, img_d, 0, interpolation_type());
+            rotate_image(img_s, img_d, 0, interpolate_bilinear());
             DLIB_TEST((img_d(0, 0) == lab_pixel{ 0, 0, 0 }));
             DLIB_TEST((img_d(0, 1) == lab_pixel{ 100, 20, 30 }));
             DLIB_TEST((img_d(1, 0) == lab_pixel{ 100, 20, 30 }));
             DLIB_TEST((img_d(1, 1) == lab_pixel{ 100, 20, 30 }));
         }
 
+    }
+
+    void test_null_rotate_image_with_interpolation_quadratic()
+    {
+        {
+            matrix<unsigned char> img_s(3, 3);
+            matrix<unsigned char> img_d;
+
+            img_s(0, 0) = 0;
+            img_s(0, 1) = 100;
+            img_s(0, 2) = 100;
+            img_s(1, 0) = 100;
+            img_s(1, 1) = 100;
+            img_s(1, 2) = 100;
+            img_s(2, 0) = 100;
+            img_s(2, 1) = 100;
+            img_s(2, 2) = 100;
+
+            rotate_image(img_s, img_d, 0, interpolate_quadratic());
+            DLIB_TEST((img_d(1, 1) == 111));
+        }
+
+        {
+            matrix<rgb_pixel> img_s(3, 3);
+            matrix<rgb_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 10, 20, 30 };
+            img_s(0, 2) = { 10, 20, 30 };
+            img_s(1, 0) = { 10, 20, 30 };
+            img_s(1, 1) = { 10, 20, 30 };
+            img_s(1, 2) = { 10, 20, 30 };
+            img_s(2, 0) = { 10, 20, 30 };
+            img_s(2, 1) = { 10, 20, 30 };
+            img_s(2, 2) = { 10, 20, 30 };
+
+            rotate_image(img_s, img_d, 0, interpolate_quadratic());
+            DLIB_TEST((img_d(1, 1) == rgb_pixel{ 11, 22, 33 }));
+        }
+
+        {
+            matrix<lab_pixel> img_s(3, 3);
+            matrix<lab_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 100, 20, 30 };
+            img_s(0, 2) = { 100, 20, 30 };
+            img_s(1, 0) = { 100, 20, 30 };
+            img_s(1, 1) = { 100, 20, 30 };
+            img_s(1, 2) = { 100, 20, 30 };
+            img_s(2, 0) = { 100, 20, 30 };
+            img_s(2, 1) = { 100, 20, 30 };
+            img_s(2, 2) = { 100, 20, 30 };
+
+            rotate_image(img_s, img_d, 0, interpolate_quadratic());
+            DLIB_TEST((img_d(1, 1) == lab_pixel{ 111, 22, 33 }));
+        }
     }
 
     void test_interpolate_bilinear()
@@ -2283,7 +2339,8 @@ namespace
 
             test_partition_pixels();
             test_resize_image_with_interpolation<interpolate_bilinear>();
-            test_null_rotate_image_with_interpolation<interpolate_bilinear>();
+            test_null_rotate_image_with_interpolation();
+            test_null_rotate_image_with_interpolation_quadratic();
             test_interpolate_bilinear();
         }
     } a;

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -1987,6 +1987,222 @@ namespace
         }
     }
 
+    template<typename interpolation_type = interpolate_bilinear>
+    void test_resize_image_with_interpolation()
+    {
+        {
+            matrix<unsigned char> img_s(2, 2);
+            matrix<unsigned char> img_d(3, 3);
+
+            img_s(0, 0) = 0;
+            img_s(0, 1) = 100;
+            img_s(1, 0) = 100;
+            img_s(1, 1) = 100;
+
+            resize_image(img_s, img_d, interpolation_type());
+            DLIB_TEST((img_d(0, 0) == 0));
+            DLIB_TEST((img_d(0, 1) == 50));
+            DLIB_TEST((img_d(1, 2) == 100));
+            DLIB_TEST((img_d(2, 2) == 100));
+        }
+
+        {
+            matrix<rgb_pixel> img_s(2, 2);
+            matrix<rgb_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 10, 20, 30 };
+            img_s(1, 0) = { 10, 20, 30 };
+            img_s(1, 1) = { 10, 20, 30 };
+
+            auto same = [](rgb_pixel p1, rgb_pixel p2)
+            {
+                return std::abs(p1.red - p2.red) + std::abs(p1.green - p2.green) + std::abs(p1.blue - p2.blue) == 0;
+            };
+
+            resize_image(img_s, img_d, interpolation_type());
+            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
+            DLIB_TEST((same(img_d(0, 1), { 5, 10, 15 })));
+            DLIB_TEST((same(img_d(1, 2), { 10, 20, 30 })));
+            DLIB_TEST((same(img_d(2, 2), { 10, 20, 30 })));
+        }
+
+        {
+            matrix<lab_pixel> img_s(2, 2);
+            matrix<lab_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 100, 20, 30 };
+            img_s(1, 0) = { 100, 20, 30 };
+            img_s(1, 1) = { 100, 20, 30 };
+
+            auto same = [](lab_pixel p1, lab_pixel p2)
+            {
+                return std::abs(p1.l - p2.l) + std::abs(p1.a - p2.a) + std::abs(p1.b - p2.b) == 0;
+            };
+
+            resize_image(img_s, img_d, interpolation_type());
+            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
+            DLIB_TEST((same(img_d(0, 1), { 50, 10, 15 })));
+            DLIB_TEST((same(img_d(1, 2), { 100, 20, 30 })));
+            DLIB_TEST((same(img_d(2, 2), { 100, 20, 30 })));
+        }
+
+    }
+    
+    template<typename interpolation_type = interpolate_bilinear>
+    void test_null_rotate_image_with_interpolation()
+    {
+        {
+            matrix<unsigned char> img_s(3, 3);
+            matrix<unsigned char> img_d;
+
+            img_s(0, 0) = 0;
+            img_s(0, 1) = 100;
+            img_s(0, 2) = 100;
+            img_s(1, 0) = 100;
+            img_s(1, 1) = 100;
+            img_s(1, 2) = 100;
+            img_s(2, 0) = 100;
+            img_s(2, 1) = 100;
+            img_s(2, 2) = 100;
+
+            rotate_image(img_s, img_d, 0, interpolation_type());
+            DLIB_TEST((img_d(0, 0) == 0));
+            DLIB_TEST((img_d(0, 1) == 100));
+            DLIB_TEST((img_d(1, 0) == 100));
+            DLIB_TEST((img_d(1, 1) == 100));
+        }
+
+        {
+            matrix<rgb_pixel> img_s(3, 3);
+            matrix<rgb_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 10, 20, 30 };
+            img_s(0, 2) = { 10, 20, 30 };
+            img_s(1, 0) = { 10, 20, 30 };
+            img_s(1, 1) = { 10, 20, 30 };
+            img_s(1, 2) = { 10, 20, 30 };
+            img_s(2, 0) = { 10, 20, 30 };
+            img_s(2, 1) = { 10, 20, 30 };
+            img_s(2, 2) = { 10, 20, 30 };
+
+            auto same = [](rgb_pixel p1, rgb_pixel p2)
+            {
+                return std::abs(p1.red - p2.red) + std::abs(p1.green - p2.green) + std::abs(p1.blue - p2.blue) == 0;
+            };
+
+            rotate_image(img_s, img_d, 0, interpolation_type());
+            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
+            DLIB_TEST((same(img_d(0, 1), { 10, 20, 30 })));
+            DLIB_TEST((same(img_d(1, 0), { 10, 20, 30 })));
+            DLIB_TEST((same(img_d(1, 1), { 10, 20, 30 })));
+        }
+
+        {
+            matrix<lab_pixel> img_s(3, 3);
+            matrix<lab_pixel> img_d(3, 3);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 100, 20, 30 };
+            img_s(0, 2) = { 100, 20, 30 };
+            img_s(1, 0) = { 100, 20, 30 };
+            img_s(1, 1) = { 100, 20, 30 };
+            img_s(1, 2) = { 100, 20, 30 };
+            img_s(2, 0) = { 100, 20, 30 };
+            img_s(2, 1) = { 100, 20, 30 };
+            img_s(2, 2) = { 100, 20, 30 };
+
+            auto same = [](lab_pixel p1, lab_pixel p2)
+            {
+                return std::abs(p1.l - p2.l) + std::abs(p1.a - p2.a) + std::abs(p1.b - p2.b) == 0;
+            };
+
+            rotate_image(img_s, img_d, 0, interpolation_type());
+            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
+            DLIB_TEST((same(img_d(0, 1), { 100, 20, 30 })));
+            DLIB_TEST((same(img_d(1, 0), { 100, 20, 30 })));
+            DLIB_TEST((same(img_d(1, 1), { 100, 20, 30 })));
+        }
+
+    }
+
+    void test_interpolate_bilinear()
+    {
+        {
+            matrix<unsigned char> img_s(2, 2);
+
+            img_s(0, 0) = 0;
+            img_s(0, 1) = 100;
+            img_s(1, 0) = 100;
+            img_s(1, 1) = 100;
+
+            const_image_view<matrix<unsigned char>> imgv(img_s);
+
+            unsigned char result;
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.0 }, result);
+                DLIB_TEST(result == 50);
+            }
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.5 }, result);
+                DLIB_TEST(result == 75);
+            }
+        }
+
+        {
+            matrix<rgb_pixel> img_s(2, 2);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 10, 20, 30 };
+            img_s(1, 0) = { 10, 20, 30 };
+            img_s(1, 1) = { 10, 20, 30 };
+
+            const_image_view<matrix<rgb_pixel>> imgv(img_s);
+
+            rgb_pixel result;
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.0 }, result);
+                DLIB_TEST(result.red == 5);
+                DLIB_TEST(result.green == 10);
+                DLIB_TEST(result.blue == 15);
+            }
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.5 }, result);
+                DLIB_TEST(result.red == 7);
+                DLIB_TEST(result.green == 15);
+                DLIB_TEST(result.blue == 22);
+            }
+        }
+
+        {
+            matrix<lab_pixel> img_s(2, 2);
+
+            img_s(0, 0) = { 0, 0, 0 };
+            img_s(0, 1) = { 100, 20, 30 };
+            img_s(1, 0) = { 100, 20, 30 };
+            img_s(1, 1) = { 100, 20, 30 };
+
+            const_image_view<matrix<lab_pixel>> imgv(img_s);
+
+            lab_pixel result;
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.0 }, result);
+                DLIB_TEST(result.l == 50);
+                DLIB_TEST(result.a == 10);
+                DLIB_TEST(result.b == 15);
+            }
+            {
+                interpolate_bilinear()(imgv, dlib::vector<double, 2>{ 0.5, 0.5 }, result);
+                DLIB_TEST(result.l == 75);
+                DLIB_TEST(result.a == 15);
+                DLIB_TEST(result.b == 22);
+            }
+        }
+    }
+    
+
 // ----------------------------------------------------------------------------------------
 
     class image_tester : public tester
@@ -2086,6 +2302,9 @@ namespace
             }
 
             test_partition_pixels();
+            test_resize_image_with_interpolation<interpolate_bilinear>();
+            test_null_rotate_image_with_interpolation<interpolate_bilinear>();
+            test_interpolate_bilinear();
         }
     } a;
 

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -2015,16 +2015,11 @@ namespace
             img_s(1, 0) = { 10, 20, 30 };
             img_s(1, 1) = { 10, 20, 30 };
 
-            auto same = [](rgb_pixel p1, rgb_pixel p2)
-            {
-                return std::abs(p1.red - p2.red) + std::abs(p1.green - p2.green) + std::abs(p1.blue - p2.blue) == 0;
-            };
-
             resize_image(img_s, img_d, interpolation_type());
-            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
-            DLIB_TEST((same(img_d(0, 1), { 5, 10, 15 })));
-            DLIB_TEST((same(img_d(1, 2), { 10, 20, 30 })));
-            DLIB_TEST((same(img_d(2, 2), { 10, 20, 30 })));
+            DLIB_TEST((img_d(0, 0) == rgb_pixel{ 0, 0, 0 }));
+            DLIB_TEST((img_d(0, 1) == rgb_pixel{ 5, 10, 15 }));
+            DLIB_TEST((img_d(1, 2) == rgb_pixel{ 10, 20, 30 }));
+            DLIB_TEST((img_d(2, 2) == rgb_pixel{ 10, 20, 30 }));
         }
 
         {
@@ -2036,16 +2031,11 @@ namespace
             img_s(1, 0) = { 100, 20, 30 };
             img_s(1, 1) = { 100, 20, 30 };
 
-            auto same = [](lab_pixel p1, lab_pixel p2)
-            {
-                return std::abs(p1.l - p2.l) + std::abs(p1.a - p2.a) + std::abs(p1.b - p2.b) == 0;
-            };
-
             resize_image(img_s, img_d, interpolation_type());
-            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
-            DLIB_TEST((same(img_d(0, 1), { 50, 10, 15 })));
-            DLIB_TEST((same(img_d(1, 2), { 100, 20, 30 })));
-            DLIB_TEST((same(img_d(2, 2), { 100, 20, 30 })));
+            DLIB_TEST((img_d(0, 0) == lab_pixel{ 0, 0, 0 }));
+            DLIB_TEST((img_d(0, 1) == lab_pixel{ 50, 10, 15 }));
+            DLIB_TEST((img_d(1, 2) == lab_pixel{ 100, 20, 30 }));
+            DLIB_TEST((img_d(2, 2) == lab_pixel{ 100, 20, 30 }));
         }
 
     }
@@ -2072,6 +2062,7 @@ namespace
             DLIB_TEST((img_d(0, 1) == 100));
             DLIB_TEST((img_d(1, 0) == 100));
             DLIB_TEST((img_d(1, 1) == 100));
+            //DLIB_TEST(img_d == img_s);
         }
 
         {
@@ -2088,16 +2079,12 @@ namespace
             img_s(2, 1) = { 10, 20, 30 };
             img_s(2, 2) = { 10, 20, 30 };
 
-            auto same = [](rgb_pixel p1, rgb_pixel p2)
-            {
-                return std::abs(p1.red - p2.red) + std::abs(p1.green - p2.green) + std::abs(p1.blue - p2.blue) == 0;
-            };
-
             rotate_image(img_s, img_d, 0, interpolation_type());
-            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
-            DLIB_TEST((same(img_d(0, 1), { 10, 20, 30 })));
-            DLIB_TEST((same(img_d(1, 0), { 10, 20, 30 })));
-            DLIB_TEST((same(img_d(1, 1), { 10, 20, 30 })));
+            DLIB_TEST((img_d(0, 0) == rgb_pixel{ 0, 0, 0 }));
+            DLIB_TEST((img_d(0, 1) == rgb_pixel{ 10, 20, 30 }));
+            DLIB_TEST((img_d(1, 0) == rgb_pixel{ 10, 20, 30 }));
+            DLIB_TEST((img_d(1, 1) == rgb_pixel{ 10, 20, 30 }));
+            //DLIB_TEST(img_d == img_s);
         }
 
         {
@@ -2114,16 +2101,12 @@ namespace
             img_s(2, 1) = { 100, 20, 30 };
             img_s(2, 2) = { 100, 20, 30 };
 
-            auto same = [](lab_pixel p1, lab_pixel p2)
-            {
-                return std::abs(p1.l - p2.l) + std::abs(p1.a - p2.a) + std::abs(p1.b - p2.b) == 0;
-            };
-
             rotate_image(img_s, img_d, 0, interpolation_type());
-            DLIB_TEST((same(img_d(0, 0), { 0, 0, 0 })));
-            DLIB_TEST((same(img_d(0, 1), { 100, 20, 30 })));
-            DLIB_TEST((same(img_d(1, 0), { 100, 20, 30 })));
-            DLIB_TEST((same(img_d(1, 1), { 100, 20, 30 })));
+            DLIB_TEST((img_d(0, 0) == lab_pixel{ 0, 0, 0 }));
+            DLIB_TEST((img_d(0, 1) == lab_pixel{ 100, 20, 30 }));
+            DLIB_TEST((img_d(1, 0) == lab_pixel{ 100, 20, 30 }));
+            DLIB_TEST((img_d(1, 1) == lab_pixel{ 100, 20, 30 }));
+            //DLIB_TEST(img_d == img_s);
         }
 
     }

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -2062,7 +2062,6 @@ namespace
             DLIB_TEST((img_d(0, 1) == 100));
             DLIB_TEST((img_d(1, 0) == 100));
             DLIB_TEST((img_d(1, 1) == 100));
-            //DLIB_TEST(img_d == img_s);
         }
 
         {
@@ -2084,7 +2083,6 @@ namespace
             DLIB_TEST((img_d(0, 1) == rgb_pixel{ 10, 20, 30 }));
             DLIB_TEST((img_d(1, 0) == rgb_pixel{ 10, 20, 30 }));
             DLIB_TEST((img_d(1, 1) == rgb_pixel{ 10, 20, 30 }));
-            //DLIB_TEST(img_d == img_s);
         }
 
         {
@@ -2106,7 +2104,6 @@ namespace
             DLIB_TEST((img_d(0, 1) == lab_pixel{ 100, 20, 30 }));
             DLIB_TEST((img_d(1, 0) == lab_pixel{ 100, 20, 30 }));
             DLIB_TEST((img_d(1, 1) == lab_pixel{ 100, 20, 30 }));
-            //DLIB_TEST(img_d == img_s);
         }
 
     }

--- a/dlib/test/serialize.cpp
+++ b/dlib/test/serialize.cpp
@@ -15,28 +15,6 @@
 
 #include "tester.h"
 
-namespace dlib
-{
-    static bool operator!=(const rgb_pixel& a, const rgb_pixel& b)
-    {
-        return !(a.red==b.red && a.green==b.green && a.blue==b.blue);
-    }
-    static bool operator!=(const bgr_pixel& a, const bgr_pixel& b)
-    {
-        return !(a.red==b.red && a.green==b.green && a.blue==b.blue);
-    }
-
-    static bool operator!=(const hsi_pixel& a, const hsi_pixel& b)
-    {
-        return !(a.h==b.h && a.s==b.s && a.i==b.i);
-    }
-    static bool operator!=(const rgb_alpha_pixel& a, const rgb_alpha_pixel& b)
-    {
-        return !(a.red==b.red && a.green==b.green && a.blue==b.blue && a.alpha==b.alpha);
-    }
-
-}
-
 namespace  
 {
 


### PR DESCRIPTION
Now `lab_pixel` and `rgb_alpha_pixel` will work with `interpolate_bilinear()`. Previously `lab_pixel` would become desaturated on interpolation.

Added `get_component<index>(pixel)` to ease up generic template programming.

Code is ready for any color space represented with cartesian coordinates and won't compile for polar ones (HSI), as it would require a bit more complicated blending.

Seems CIELAB is actually perfect for interpolation and theoretically should perform better for DNN than e.g. HSI where H component "wraps around":
http://davidjohnstone.net/pages/lch-lab-colour-gradient-picker
http://fse.studenttheses.ub.rug.nl/15441/1/CS_BA_2017_Jonathan_Hogervorst.pdf
https://en.wikipedia.org/wiki/CIELAB_color_space
https://en.wikipedia.org/wiki/HSL_and_HSV

`interpolate_quadratic` not improved, but for it `lab_pixel` was luckily returning compilation error.

Fixes #2089