### PR TITLE
Fix pkg-config file

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -878,7 +878,15 @@ if (NOT TARGET dlib)
 
    # Install the library
    if (NOT DLIB_IN_PROJECT_BUILD)
-      string (REPLACE ";" " " pkg_config_dlib_needed_libraries "${dlib_needed_libraries}")
+      foreach(LIB ${dlib_needed_libraries})
+        if(LIB MATCHES "^/")
+          get_filename_component(LIB ${LIB} NAME_WE)
+          string(REGEX REPLACE "^lib" "-l" LIB ${LIB})
+        endif()
+        MESSAGE(LIB=${LIB})
+        set(pkg_config_dlib_needed_libraries "${pkg_config_dlib_needed_libraries} ${LIB}")
+      endforeach()
+
       # Make the -I include options for pkg-config
       foreach (ITR ${dlib_needed_includes})
          set (pkg_config_dlib_needed_includes "${pkg_config_dlib_needed_includes} -I${ITR}")

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -277,7 +277,6 @@ if (NOT TARGET dlib)
 
 
    set(dlib_needed_libraries)
-   set(dlib_needed_public_libraries)
    set(dlib_needed_includes)
 
    if (DLIB_ISO_CPP_ONLY)
@@ -423,7 +422,7 @@ if (NOT TARGET dlib)
          find_package(GIF QUIET)
          if (GIF_FOUND)
             set (dlib_needed_includes ${dlib_needed_includes} ${GIF_INCLUDE_DIR})
-            set (dlib_needed_public_libraries ${dlib_needed_public_libraries} ${GIF_LIBRARY})
+            set (dlib_needed_libraries ${dlib_needed_libraries} ${GIF_LIBRARY})
          else()
             set(DLIB_GIF_SUPPORT OFF CACHE STRING ${DLIB_GIF_SUPPORT_STR} FORCE )
             toggle_preprocessor_switch(DLIB_GIF_SUPPORT)
@@ -879,22 +878,13 @@ if (NOT TARGET dlib)
 
    # Install the library
    if (NOT DLIB_IN_PROJECT_BUILD)
-      set(pkg_config_dlib_needed_libraries)
       foreach(LIB ${dlib_needed_libraries})
         if(LIB MATCHES "^/")
           get_filename_component(LIB ${LIB} NAME_WE)
           string(REGEX REPLACE "^lib" "-l" LIB ${LIB})
         endif()
+        MESSAGE(LIB=${LIB})
         set(pkg_config_dlib_needed_libraries "${pkg_config_dlib_needed_libraries} ${LIB}")
-      endforeach()
-
-      set(pkg_config_dlib_needed_public_libraries)
-      foreach(LIB ${dlib_needed_public_libraries})
-        if(LIB MATCHES "^/")
-          get_filename_component(LIB ${LIB} NAME_WE)
-          string(REGEX REPLACE "^lib" "-l" LIB ${LIB})
-        endif()
-        set(pkg_config_dlib_needed_public_libraries "${pkg_config_dlib_needed_public_libraries} ${LIB}")
       endforeach()
 
       # Make the -I include options for pkg-config

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -277,6 +277,7 @@ if (NOT TARGET dlib)
 
 
    set(dlib_needed_libraries)
+   set(dlib_needed_public_libraries)
    set(dlib_needed_includes)
 
    if (DLIB_ISO_CPP_ONLY)
@@ -422,7 +423,7 @@ if (NOT TARGET dlib)
          find_package(GIF QUIET)
          if (GIF_FOUND)
             set (dlib_needed_includes ${dlib_needed_includes} ${GIF_INCLUDE_DIR})
-            set (dlib_needed_libraries ${dlib_needed_libraries} ${GIF_LIBRARY})
+            set (dlib_needed_public_libraries ${dlib_needed_public_libraries} ${GIF_LIBRARY})
          else()
             set(DLIB_GIF_SUPPORT OFF CACHE STRING ${DLIB_GIF_SUPPORT_STR} FORCE )
             toggle_preprocessor_switch(DLIB_GIF_SUPPORT)
@@ -878,13 +879,22 @@ if (NOT TARGET dlib)
 
    # Install the library
    if (NOT DLIB_IN_PROJECT_BUILD)
+      set(pkg_config_dlib_needed_libraries)
       foreach(LIB ${dlib_needed_libraries})
         if(LIB MATCHES "^/")
           get_filename_component(LIB ${LIB} NAME_WE)
           string(REGEX REPLACE "^lib" "-l" LIB ${LIB})
         endif()
-        MESSAGE(LIB=${LIB})
         set(pkg_config_dlib_needed_libraries "${pkg_config_dlib_needed_libraries} ${LIB}")
+      endforeach()
+
+      set(pkg_config_dlib_needed_public_libraries)
+      foreach(LIB ${dlib_needed_public_libraries})
+        if(LIB MATCHES "^/")
+          get_filename_component(LIB ${LIB} NAME_WE)
+          string(REGEX REPLACE "^lib" "-l" LIB ${LIB})
+        endif()
+        set(pkg_config_dlib_needed_public_libraries "${pkg_config_dlib_needed_public_libraries} ${LIB}")
       endforeach()
 
       # Make the -I include options for pkg-config

--- a/dlib/cmake_utils/dlib.pc.in
+++ b/dlib/cmake_utils/dlib.pc.in
@@ -4,5 +4,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: @PROJECT_NAME@
 Description: Numerical and networking C++ library
 Version: @VERSION@
-Libs: -L${libdir} -ldlib @pkg_config_dlib_needed_libraries@
+Libs: -L${libdir} -ldlib @pkg_config_dlib_needed_public_libraries@
+Libs.private: @pkg_config_dlib_needed_libraries@
 Cflags: -I${includedir} @pkg_config_dlib_needed_includes@

--- a/dlib/cmake_utils/dlib.pc.in
+++ b/dlib/cmake_utils/dlib.pc.in
@@ -4,6 +4,5 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: @PROJECT_NAME@
 Description: Numerical and networking C++ library
 Version: @VERSION@
-Libs: -L${libdir} -ldlib @pkg_config_dlib_needed_public_libraries@
-Libs.private: @pkg_config_dlib_needed_libraries@
+Libs: -L${libdir} -ldlib @pkg_config_dlib_needed_libraries@
 Cflags: -I${includedir} @pkg_config_dlib_needed_includes@


### PR DESCRIPTION
See #2111

* First commit only fix linker syntax
* Second commit move all libs to private, libgif is the only one I detect as needed (used in headers), 

Foreach loop inspired from libzip.

"libs" are enough for build against the shared library
```
$ pkg-config --libs dlib-1
-ldlib -lgif 

```


"libs.private" are needed for build against the static library
```
$ pkg-config --static --libs dlib-1
-ldlib -lgif -lpthread -lX11 -lXext -lpng -lz -ljpeg -lopenblasp -lsqlite3 

```
P.S. I not a cmake expert, nor a pkg-config expert, perhaps better way exists.