### PR TITLE
Additional documentation for failed dlib::layer<> use.

### DIFF
--- a/dlib/dnn/core.h
+++ b/dlib/dnn/core.h
@@ -2684,6 +2684,9 @@ namespace dlib
         {
             static_assert(i < T::num_layers, "Call to layer() attempted to access non-existing layer in neural network.");
             static T& makeT();
+            // If you get error here mentioning lack of member "subnet" in "dlib::input<...>",
+            // then likely your "dlib::layer<...>" invocation wasn't able to find requested layer.
+            // This could happen for instance when trying to use skip layer for non-existing tag.
             using next_type = typename std::remove_reference<decltype(makeT().subnet())>::type;
             using type = typename layer_helper<i-1,next_type>::type;
             static type& layer(T& n)


### PR DESCRIPTION
I got this error few times and each time spent a lot of time guessing what I did wrong. In bigger networks it's easy to by mistake create `add_skip_layer<123, ...>` where there is no `add_tag_layer<123, ...>`. This produces gibberish error in header far from place of mistake.
Hopefully with this comment me and other people will easier get what's wrong.

The error one gets now in MVSC is:
`error C2039: 'subnet': is not a member of 'dlib::input<std::array<dlib::matrix<T,0,0,dlib::default_memory_manager,dlib::assignable_ptr_matrix<T>::layout_type>,3>>'`
... that for just network type definition:
`relu<skip1<tag2<input<::std::array<matrix<float>, 3>>>>> test;`