### PR TITLE
Fix restoration of MSVC warnings in public headers

### DIFF
--- a/dlib/geometry/vector.h
+++ b/dlib/geometry/vector.h
@@ -14,6 +14,8 @@
 #include <array>
 
 #if defined(_MSC_VER) && _MSC_VER < 1400
+#pragma warning(push)
+
 // Despite my efforts to disabuse visual studio of its usual nonsense I can't find a 
 // way to make this warning go away without just disabling it.   This is the warning:
 //   dlib\geometry\vector.h(129) : warning C4805: '==' : unsafe mix of type 'std::numeric_limits<_Ty>::is_integer' and type 'bool' in operation
@@ -1378,8 +1380,8 @@ namespace std
 }
 
 #if defined(_MSC_VER) && _MSC_VER < 1400
-// turn this warning back on
-#pragma warning(default:4805)
+// restore warnings back to their previous settings
+#pragma warning(pop)
 #endif
 
 #endif // DLIB_VECTOr_H_

--- a/dlib/matrix/matrix.h
+++ b/dlib/matrix/matrix.h
@@ -25,6 +25,8 @@
 #endif
 
 #ifdef _MSC_VER
+#pragma warning(push)
+
 // Disable the following warnings for Visual Studio
 
 // This warning is:
@@ -2165,10 +2167,8 @@ namespace dlib
 }
 
 #ifdef _MSC_VER
-// put warnings back to their default settings
-#pragma warning(default : 4355)
-#pragma warning(default : 4723)
-#pragma warning(default : 4724)
+// restore warnings back to their previous settings
+#pragma warning(pop)
 #endif
 
 #endif // DLIB_MATRIx_


### PR DESCRIPTION
Previously they were restored to default values, which had the effect of negating the current setting of the calling code (whether set in the compiler options or by pragma previously)