### PR TITLE
Add setargv.obj to CMakeLists.txt for wildcard expansion on Windows

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -105,6 +105,9 @@ target_link_libraries(assignment_learning_ex dlib::dlib)
 # your cmake projects and use the syntax shown above.
 macro(add_example name)
    add_executable(${name} ${name}.cpp)
+IF(WIN32)
+	SET_TARGET_PROPERTIES(${name} PROPERTIES LINK_FLAGS "setargv.obj")
+ENDIF()
    target_link_libraries(${name} dlib::dlib )
 endmacro()
 

--- a/examples/face_detection_ex.cpp
+++ b/examples/face_detection_ex.cpp
@@ -75,8 +75,10 @@ int main(int argc, char** argv)
             // again to find even smaller faces, but note that every time we
             // upsample the image we make the detector run slower since it must
             // process a larger image.
+#ifdef PYRAMID_UP
+            // Make the image larger so we can detect small faces.
             pyramid_up(img);
-
+#endif
             // Now tell the face detector to give us a list of bounding boxes
             // around all the faces it can find in the image.
             std::vector<rectangle> dets = detector(img);
@@ -87,9 +89,10 @@ int main(int argc, char** argv)
             win.clear_overlay();
             win.set_image(img);
             win.add_overlay(dets, rgb_pixel(255,0,0));
-
+#ifdef DEBUG
             cout << "Hit enter to process the next image..." << endl;
             cin.get();
+#endif
         }
     }
     catch (exception& e)

--- a/examples/face_landmark_detection_ex.cpp
+++ b/examples/face_landmark_detection_ex.cpp
@@ -98,9 +98,9 @@ int main(int argc, char** argv)
         // Loop over all the images provided on the command line.
         for (int i = 2; i < argc; ++i)
         {
-            cout << "processing image " << argv[i] << endl;
+            const char* filename =  argv[i];
+            cout << "processing image " << filename << endl;
             // Output "index" and filename
-            ostream << (i - 2) << "\t" << argv[i] << "\t";
             array2d<rgb_pixel> img;
             load_image(img, argv[i]);
 #ifdef PYRAMID_UP
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
             for (unsigned long j = 0; j <nfaces; ++j)
             {
                 // output face rect to myfile
-                ostream << dets[j] << "\t";
+                ostream << (i - 2) << "\t" << filename << "\t" << dets[j] << "\t";
                 full_object_detection shape = sp(img, dets[j]);
                 int n = shape.num_parts();
                 cout << "number of parts: "<< n << endl;
@@ -132,8 +132,8 @@ int main(int argc, char** argv)
                 // you want them.  Here we just store them in shapes so we can
                 // put them on the screen.
                 shapes.push_back(shape);
+                ostream << endl;
             }
-            ostream << endl;
 
             // Now let's view our face poses on the screen.
             win.clear_overlay();


### PR DESCRIPTION
Possible improvement on Windows by enabling wildcard expansion in cmdline examples.

Also added some #ifdef COMPILE_OPTIONS to face_detection_ex.cpp and face_landmark_detection_ex.cpp (less useful/generic)