### PR TITLE
Adding move semantics to type_safe_union

### DIFF
--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -115,7 +115,6 @@ namespace std
 #include "enable_if.h"
 #include "uintn.h"
 #include "numeric_constants.h"
-#include "platform.h" // for WIN32
 #include "memory_manager_stateless/memory_manager_stateless_kernel_1.h" // for the default memory manager
 
 
@@ -426,7 +425,6 @@ namespace dlib
     
 // ----------------------------------------------------------------------------------------
     
-#ifndef WIN32 //For some reason, the visual studio compiler throws error : error C2210: 'to': pack expansions cannot be used as arguments to non-packed parameters in alias templates
     /*!A is_any 
 
         This is a template where is_any<T,U,V>::value == true when T is the same type as U or V and false otherwise.   
@@ -442,7 +440,6 @@ namespace dlib
     struct is_any<T, First, Rest...>
         : std::integral_constant<bool, std::is_same<T, First>::value || is_any<T, Rest...>::value>
     {};
-#endif
 // ----------------------------------------------------------------------------------------
 
     /*!A is_float_type
@@ -469,7 +466,6 @@ namespace dlib
     template <typename from, typename to>
     using is_convertible = std::is_convertible<from,to>;    
     
-#ifndef WIN32 //For some reason, the visual studio compiler throws error : error C2210: 'to': pack expansions cannot be used as arguments to non-packed parameters in alias templates
     template<typename T, typename... Rest>
     struct is_convertible_any : std::false_type {};
 
@@ -480,7 +476,6 @@ namespace dlib
     struct is_convertible_any<T, First, Rest...>
         : std::integral_constant<bool, is_convertible<T, First>::value || is_convertible<T, Rest...>::value>
     {};
-#endif 
 // ----------------------------------------------------------------------------------------
 
     struct general_ {};

--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -115,6 +115,7 @@ namespace std
 #include "enable_if.h"
 #include "uintn.h"
 #include "numeric_constants.h"
+#include "platform.h" // for WIN32
 #include "memory_manager_stateless/memory_manager_stateless_kernel_1.h" // for the default memory manager
 
 
@@ -425,6 +426,7 @@ namespace dlib
     
 // ----------------------------------------------------------------------------------------
     
+#ifndef WIN32 //For some reason, the visual studio compiler throws error : error C2210: 'to': pack expansions cannot be used as arguments to non-packed parameters in alias templates
     /*!A is_any 
 
         This is a template where is_any<T,U,V>::value == true when T is the same type as U or V and false otherwise.   
@@ -440,7 +442,7 @@ namespace dlib
     struct is_any<T, First, Rest...>
         : std::integral_constant<bool, std::is_same<T, First>::value || is_any<T, Rest...>::value>
     {};
-
+#endif
 // ----------------------------------------------------------------------------------------
 
     /*!A is_float_type
@@ -467,6 +469,7 @@ namespace dlib
     template <typename from, typename to>
     using is_convertible = std::is_convertible<from,to>;    
     
+#ifndef WIN32 //For some reason, the visual studio compiler throws error : error C2210: 'to': pack expansions cannot be used as arguments to non-packed parameters in alias templates
     template<typename T, typename... Rest>
     struct is_convertible_any : std::false_type {};
 
@@ -477,7 +480,7 @@ namespace dlib
     struct is_convertible_any<T, First, Rest...>
         : std::integral_constant<bool, is_convertible<T, First>::value || is_convertible<T, Rest...>::value>
     {};
-
+#endif 
 // ----------------------------------------------------------------------------------------
 
     struct general_ {};

--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -423,6 +423,8 @@ namespace dlib
     template <typename T, typename U>
     using is_same_type = std::is_same<T,U>;
     
+    
+    struct _void{};
 // ----------------------------------------------------------------------------------------
     
     /*!A is_any 
@@ -430,6 +432,7 @@ namespace dlib
         This is a template where is_any<T,U,V>::value == true when T is the same type as U or V and false otherwise.   
     !*/
     
+#ifndef WIN32
     template<typename T, typename... Rest>
     struct is_any : std::false_type {};
 
@@ -440,6 +443,76 @@ namespace dlib
     struct is_any<T, First, Rest...>
         : std::integral_constant<bool, std::is_same<T, First>::value || is_any<T, Rest...>::value>
     {};
+#else
+    //Visual studio workaround
+    template<typename T, 
+             typename T1,
+             typename T2 = _void,
+             typename T3 = _void,
+             typename T4 = _void,
+             typename T5 = _void, 
+             typename T6 = _void,
+             typename T7 = _void,
+             typename T8 = _void,
+             typename T9 = _void,
+             typename T10 = _void,
+
+             typename T11 = _void,
+             typename T12 = _void,
+             typename T13 = _void,
+             typename T14 = _void,
+             typename T15 = _void,
+             typename T16 = _void,
+             typename T17 = _void,
+             typename T18 = _void,
+             typename T19 = _void,
+             typename T20 = _void,
+            
+             typename T21 = _void,
+             typename T22 = _void,
+             typename T23 = _void,
+             typename T24 = _void,
+             typename T25 = _void,
+             typename T26 = _void,
+             typename T27 = _void,
+             typename T28 = _void,
+             typename T29 = _void,
+             typename T30 = _void>
+    struct is_any : std::integral_constant<bool, 
+                                           std::is_same<T, T1>::value || 
+                                           std::is_same<T, T2>::value || 
+                                           std::is_same<T, T3>::value || 
+                                           std::is_same<T, T4>::value || 
+                                           std::is_same<T, T5>::value || 
+                                           std::is_same<T, T6>::value || 
+                                           std::is_same<T, T7>::value || 
+                                           std::is_same<T, T8>::value || 
+                                           std::is_same<T, T9>::value || 
+                                           std::is_same<T, T10>::value || 
+                                           
+                                           std::is_same<T, T11>::value || 
+                                           std::is_same<T, T12>::value || 
+                                           std::is_same<T, T13>::value || 
+                                           std::is_same<T, T14>::value || 
+                                           std::is_same<T, T15>::value || 
+                                           std::is_same<T, T16>::value || 
+                                           std::is_same<T, T17>::value || 
+                                           std::is_same<T, T18>::value || 
+                                           std::is_same<T, T19>::value || 
+                                           std::is_same<T, T20>::value || 
+    
+                                           std::is_same<T, T21>::value || 
+                                           std::is_same<T, T22>::value || 
+                                           std::is_same<T, T23>::value || 
+                                           std::is_same<T, T24>::value || 
+                                           std::is_same<T, T25>::value || 
+                                           std::is_same<T, T26>::value || 
+                                           std::is_same<T, T27>::value || 
+                                           std::is_same<T, T28>::value || 
+                                           std::is_same<T, T29>::value || 
+                                           std::is_same<T, T30>::value 
+                                          > {};
+#endif
 // ----------------------------------------------------------------------------------------
 
     /*!A is_float_type
@@ -466,6 +539,7 @@ namespace dlib
     template <typename from, typename to>
     using is_convertible = std::is_convertible<from,to>;    
     
+#ifndef WIN32
     template<typename T, typename... Rest>
     struct is_convertible_any : std::false_type {};
 
@@ -476,6 +550,76 @@ namespace dlib
     struct is_convertible_any<T, First, Rest...>
         : std::integral_constant<bool, is_convertible<T, First>::value || is_convertible<T, Rest...>::value>
     {};
+#else
+        //Visual studio workaround
+    template<typename T, 
+             typename T1,
+             typename T2 = _void,
+             typename T3 = _void,
+             typename T4 = _void,
+             typename T5 = _void, 
+             typename T6 = _void,
+             typename T7 = _void,
+             typename T8 = _void,
+             typename T9 = _void,
+             typename T10 = _void,
+
+             typename T11 = _void,
+             typename T12 = _void,
+             typename T13 = _void,
+             typename T14 = _void,
+             typename T15 = _void,
+             typename T16 = _void,
+             typename T17 = _void,
+             typename T18 = _void,
+             typename T19 = _void,
+             typename T20 = _void,
+            
+             typename T21 = _void,
+             typename T22 = _void,
+             typename T23 = _void,
+             typename T24 = _void,
+             typename T25 = _void,
+             typename T26 = _void,
+             typename T27 = _void,
+             typename T28 = _void,
+             typename T29 = _void,
+             typename T30 = _void>
+    struct is_convertible_any : std::integral_constant<bool, 
+                                           std::is_convertible<T, T1>::value || 
+                                           std::is_convertible<T, T2>::value || 
+                                           std::is_convertible<T, T3>::value || 
+                                           std::is_convertible<T, T4>::value || 
+                                           std::is_convertible<T, T5>::value || 
+                                           std::is_convertible<T, T6>::value || 
+                                           std::is_convertible<T, T7>::value || 
+                                           std::is_convertible<T, T8>::value || 
+                                           std::is_convertible<T, T9>::value || 
+                                           std::is_convertible<T, T10>::value || 
+                                           
+                                           std::is_convertible<T, T11>::value || 
+                                           std::is_convertible<T, T12>::value || 
+                                           std::is_convertible<T, T13>::value || 
+                                           std::is_convertible<T, T14>::value || 
+                                           std::is_convertible<T, T15>::value || 
+                                           std::is_convertible<T, T16>::value || 
+                                           std::is_convertible<T, T17>::value || 
+                                           std::is_convertible<T, T18>::value || 
+                                           std::is_convertible<T, T19>::value || 
+                                           std::is_convertible<T, T20>::value || 
+    
+                                           std::is_convertible<T, T21>::value || 
+                                           std::is_convertible<T, T22>::value || 
+                                           std::is_convertible<T, T23>::value || 
+                                           std::is_convertible<T, T24>::value || 
+                                           std::is_convertible<T, T25>::value || 
+                                           std::is_convertible<T, T26>::value || 
+                                           std::is_convertible<T, T27>::value || 
+                                           std::is_convertible<T, T28>::value || 
+                                           std::is_convertible<T, T29>::value || 
+                                           std::is_convertible<T, T30>::value 
+                                          > {};
+#endif
 // ----------------------------------------------------------------------------------------
 
     struct general_ {};

--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -477,6 +477,17 @@ namespace dlib
     private:
         is_same_type();
     };
+    
+    template<typename T, typename... Rest>
+    struct is_any : std::false_type {};
+
+    template<typename T, typename First>
+    struct is_any<T, First> : std::is_same<T, First> {};
+
+    template<typename T, typename First, typename... Rest>
+    struct is_any<T, First, Rest...>
+        : std::integral_constant<bool, std::is_same<T, First>::value || is_any<T, Rest...>::value>
+    {};
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -26,7 +26,6 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    struct _void{};
     inline void serialize( const _void&, std::ostream&){}
     inline void deserialize(  _void&, std::istream&){}
 

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -122,29 +122,7 @@ namespace dlib
             // representable by this type_safe_union.  I.e. The given
             // type T isn't one of the ones given to this object's template
             // arguments.
-            COMPILE_TIME_ASSERT(( is_same_type<T,T1>::value ||
-                                 is_same_type<T,T2>::value ||
-                                 is_same_type<T,T3>::value ||
-                                 is_same_type<T,T4>::value ||
-                                 is_same_type<T,T5>::value ||
-                                 is_same_type<T,T6>::value ||
-                                 is_same_type<T,T7>::value ||
-                                 is_same_type<T,T8>::value ||
-                                 is_same_type<T,T9>::value ||
-                                 is_same_type<T,T10>::value ||
-
-                                 is_same_type<T,T11>::value ||
-                                 is_same_type<T,T12>::value ||
-                                 is_same_type<T,T13>::value ||
-                                 is_same_type<T,T14>::value ||
-                                 is_same_type<T,T15>::value ||
-                                 is_same_type<T,T16>::value ||
-                                 is_same_type<T,T17>::value ||
-                                 is_same_type<T,T18>::value ||
-                                 is_same_type<T,T19>::value ||
-                                 is_same_type<T,T20>::value 
-                                    ));
-
+            COMPILE_TIME_ASSERT((is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value));
         }
 
 
@@ -305,7 +283,7 @@ namespace dlib
         ) : type_identity(0)
         {
             validate_type<T>();
-            unchecked_get<T>() = std::move(item);
+            new(mem.get()) T(std::move(item)); 
             type_identity = get_type_id<T>();
         }
         
@@ -317,10 +295,16 @@ namespace dlib
         ) 
         { 
             validate_type<T>();
-            if (type_identity != 0 && type_identity != get_type_id<T>())
+            if( type_identity == get_type_id<T>() )
+            {
+                unchecked_get<T>() = std::move(item);
+            }
+            else
+            {
                 destruct();
-            unchecked_get<T>() = std::move(item);
-            type_identity = get_type_id<T>();
+                new(mem.get()) T(std::move(item)); 
+                type_identity = get_type_id<T>();
+            }
             return *this;
         }
         
@@ -622,40 +606,6 @@ namespace dlib
         type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>& a, 
         type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>& b 
     ) { a.swap(b); }   
-
-// ----------------------------------------------------------------------------------------
-
-    template <
-        typename from, 
-        typename T1, typename T2, typename T3, typename T4, typename T5,
-        typename T6, typename T7, typename T8, typename T9, typename T10,
-        typename T11, typename T12, typename T13, typename T14, typename T15,
-        typename T16, typename T17, typename T18, typename T19, typename T20
-        >
-    struct is_convertible<from,
-        type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20> >
-    {
-        const static bool value = is_convertible<from,T1>::value ||
-                                  is_convertible<from,T2>::value ||
-                                  is_convertible<from,T3>::value ||
-                                  is_convertible<from,T4>::value ||
-                                  is_convertible<from,T5>::value ||
-                                  is_convertible<from,T6>::value ||
-                                  is_convertible<from,T7>::value ||
-                                  is_convertible<from,T8>::value ||
-                                  is_convertible<from,T9>::value ||
-                                  is_convertible<from,T10>::value ||
-                                  is_convertible<from,T11>::value ||
-                                  is_convertible<from,T12>::value ||
-                                  is_convertible<from,T13>::value ||
-                                  is_convertible<from,T14>::value ||
-                                  is_convertible<from,T15>::value ||
-                                  is_convertible<from,T16>::value ||
-                                  is_convertible<from,T17>::value ||
-                                  is_convertible<from,T18>::value ||
-                                  is_convertible<from,T19>::value ||
-                                  is_convertible<from,T20>::value;
-    };
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -259,8 +259,24 @@ namespace dlib
         type_safe_union() : type_identity(0) 
         { 
         }
-
-        template <typename T>
+        
+        type_safe_union (
+            type_safe_union&& other
+        ) : type_identity(0)
+        {
+            swap(other);
+        }
+        
+        type_safe_union& operator= (
+            type_safe_union&& item
+        ) 
+        { 
+            swap(item); 
+            return *this;
+        }
+        
+        template <typename T, 
+                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
         type_safe_union (
             const T& item
         ) : type_identity(0)
@@ -268,7 +284,41 @@ namespace dlib
             validate_type<T>();
             construct(item);
         }
-
+        
+        template <typename T, 
+                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        type_safe_union& operator= ( 
+            const T& item
+        ) 
+        { 
+            get<T>() = item; 
+            return *this;
+        }
+        
+        template <typename T, typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        type_safe_union (
+            T&& item
+        ) : type_identity(0)
+        {
+            validate_type<T>();
+            unchecked_get<T>() = std::move(item);
+            type_identity = get_type_id<T>();
+        }
+        
+        template <typename T, 
+                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        type_safe_union& operator= ( 
+            T&& item
+        ) 
+        { 
+            validate_type<T>();
+            if (type_identity != 0 && type_identity != get_type_id<T>())
+                destruct();
+            unchecked_get<T>() = std::move(item);
+            type_identity = get_type_id<T>();
+            return *this;
+        }
+        
         ~type_safe_union()
         {
             destruct();
@@ -552,11 +602,7 @@ namespace dlib
                 return *static_cast<T*>(mem.get());
             else
                 throw bad_type_safe_union_cast();
-        }
-
-        template <typename T>
-        type_safe_union& operator= ( const T& item) { get<T>() = item; return *this; }
-
+        }        
     };
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -260,8 +260,8 @@ namespace dlib
             const T& item
         ) : type_identity(0)
         {
-            validate_type<T>();
-            construct(item);
+            new(mem.get()) T(item); 
+            type_identity = get_type_id<T>();
         }
         
         template <typename T 
@@ -282,7 +282,6 @@ namespace dlib
             T&& item
         ) : type_identity(0)
         {
-            validate_type<T>();
             new(mem.get()) T(std::move(item)); 
             type_identity = get_type_id<T>();
         }
@@ -294,7 +293,6 @@ namespace dlib
             T&& item
         ) 
         { 
-            validate_type<T>();
             if( type_identity == get_type_id<T>() )
             {
                 unchecked_get<T>() = std::move(item);

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -275,8 +275,9 @@ namespace dlib
             return *this;
         }
         
-        template <typename T, 
-                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        template <typename T 
+                  , typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr
+                 >
         type_safe_union (
             const T& item
         ) : type_identity(0)
@@ -285,8 +286,9 @@ namespace dlib
             construct(item);
         }
         
-        template <typename T, 
-                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        template <typename T 
+                  , typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr
+                 >
         type_safe_union& operator= ( 
             const T& item
         ) 
@@ -295,8 +297,9 @@ namespace dlib
             return *this;
         }
         
-        template <typename T, 
-                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        template <typename T 
+                  , typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr
+                 >
         type_safe_union (
             T&& item
         ) : type_identity(0)
@@ -306,8 +309,9 @@ namespace dlib
             type_identity = get_type_id<T>();
         }
         
-        template <typename T, 
-                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        template <typename T 
+                  , typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr
+                 >
         type_safe_union& operator= ( 
             T&& item
         ) 

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -295,7 +295,8 @@ namespace dlib
             return *this;
         }
         
-        template <typename T, typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
+        template <typename T, 
+                  typename std::enable_if<not std::is_same<T,type_safe_union<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>>::value>::type* = nullptr>
         type_safe_union (
             T&& item
         ) : type_identity(0)

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -85,7 +85,7 @@ namespace dlib
         }
 
 
-        const static size_t max_size = tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<
+        constexpr static size_t max_size = tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<
                                        tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<tmax<sizeof(T1),
                                                         sizeof(T2)>::value,
                                                         sizeof(T3)>::value,
@@ -560,31 +560,31 @@ namespace dlib
             }
         }
 
-        template <typename T> 
+        template <typename T
+                 ,typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr> 
         T& get(
         ) 
         { 
-            validate_type<T>();
             construct<T>();  
             return *static_cast<T*>(mem.get()); 
         }
 
-        template <typename T>
+        template <typename T
+                 ,typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr> 
         const T& cast_to (
         ) const
         {
-            validate_type<T>();
             if (contains<T>())
                 return *static_cast<const T*>(mem.get());
             else
                 throw bad_type_safe_union_cast();
         }
 
-        template <typename T>
+        template <typename T
+                 ,typename std::enable_if<dlib::is_any<T,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>::value>::type* = nullptr> 
         T& cast_to (
         ) 
         {
-            validate_type<T>();
             if (contains<T>())
                 return *static_cast<T*>(mem.get());
             else


### PR DESCRIPTION
Not quite ready for merge. Really need @davisking to have a look. I'm of the opinion that swaps should be written in terms of moves, not the other way round. And this would need some heavy unit testing.