### PR TITLE
Add error message for mismatched tensor sizes in dnn_trainer

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -764,7 +764,12 @@ namespace dlib
                         {
                             std::vector<tensor*> temp(all_tensors.size());
                             for (size_t j = 0; j < all_tensors.size(); ++j)
+                            {
                                 temp[j] = all_tensors[j][i];
+                                DLIB_CASSERT(temp[0]->size() == temp[j]->size(),
+                                "Make sure you don't modify the network structure "
+                                "or number of parameters after constructing the trainer.");
+                            }
                             // ignore layers that don't have parameters
                             if (temp[0]->size() != 0)
                                 averagers[i].set(temp);


### PR DESCRIPTION
As discussed in #2163, this PR adds a check and a helpful message to inform the user that the tensor sizes in the devices have different size, probably due to an external modification of some network parameters after trainer construction