### PR TITLE
vectorstream updates: added seekoff and seekpos

### DIFF
--- a/dlib/test/vectorstream.cpp
+++ b/dlib/test/vectorstream.cpp
@@ -21,6 +21,116 @@ namespace
 
 
     logger dlog("test.vectorstream");
+    
+    namespace helper 
+    {        
+        /*
+        * This class helps test the functionality of dlib::vectorstream when an object reference is treated as:
+        * - dlib::vectorstream&
+        * - std::iostream&
+        * Depending on which is used, the underlying function calls might have different call stacks.
+        */
+        struct test1_helper
+        {
+            test1_helper(
+                std::vector<char>& buf_
+            ) : buf(buf_)
+            {}
+
+            template <typename T>
+            void operator()(T& s)
+            {
+                for (int i = -1000; i <= 1000; ++i)
+                {
+                    char ch = i;
+                    s.put(ch);
+                }
+
+                DLIB_TEST(buf.size() == 2001);
+
+                int cnt = -1000;
+                for (unsigned long i = 0; i < buf.size(); ++i)
+                {
+                    char ch = cnt;
+                    DLIB_TEST(buf[i] == ch);
+                    ++cnt;
+                }
+
+                for (int i = -1000; i <= 1000; ++i)
+                {
+                    DLIB_TEST(s.peek() != EOF);
+                    char ch1 = i;
+                    char ch2 = s.get();
+                    DLIB_TEST(ch1 == ch2);
+                }
+
+                DLIB_TEST(s.peek() == EOF);
+                DLIB_TEST(s.get() == EOF);
+
+                s.clear();
+                s.seekg(6);
+
+                for (int i = -1000+6; i <= 1000; ++i)
+                {
+                    DLIB_TEST(s.peek() != EOF);
+                    char ch1 = i;
+                    char ch2 = s.get();
+                    DLIB_TEST(ch1 == ch2);
+                }
+
+                DLIB_TEST(s.peek() == EOF);
+                DLIB_TEST(s.get() == EOF);
+
+                std::string temp;
+                temp = "one two three!";
+
+                s.clear();
+                s.seekg(0);
+                buf.clear();
+
+                serialize(temp, s);
+                std::string temp2;
+                deserialize(temp2, s);
+                DLIB_TEST(temp2 == temp);
+
+                s.put('1');
+                s.put('2');
+                s.put('3');
+                s.put('4');
+                DLIB_TEST(s.get() == '1');
+                DLIB_TEST(s.get() == '2');
+                DLIB_TEST(s.get() == '3');
+                DLIB_TEST(s.get() == '4');
+
+                s.putback('4');
+                DLIB_TEST(s.get() == '4');
+                s.putback('4');
+                s.putback('3');
+                s.putback('2');
+                s.putback('1');
+                DLIB_TEST(s.get() == '1');
+                DLIB_TEST(s.get() == '2');
+                DLIB_TEST(s.get() == '3');
+                DLIB_TEST(s.get() == '4');
+                DLIB_TEST(s.good() == true);
+                DLIB_TEST(s.get() == EOF);
+                DLIB_TEST(s.good() == false);
+
+                // make sure seeking to a crazy offset doesn't mess things up
+                s.clear();
+                s.seekg(1000000);
+                DLIB_TEST(s.get() == EOF);
+                DLIB_TEST(s.good() == false);
+                s.clear();
+                s.seekg(1000000);
+                char sbuf[100];
+                s.read(sbuf, sizeof(sbuf));
+                DLIB_TEST(s.good() == false);
+            }
+
+            std::vector<char>& buf;
+        };
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -28,95 +138,20 @@ namespace
     {
         print_spinner();
 
-        std::vector<char> buf;
-        vectorstream s(buf);
-
-        for (int i = -1000; i <= 1000; ++i)
         {
-            char ch = i;
-            s.put(ch);
+            std::vector<char> buf;
+            vectorstream s1(buf);
+            helper::test1_helper t(buf);
+            t(s1);
         }
-
-        DLIB_TEST(buf.size() == 2001);
-
-        int cnt = -1000;
-        for (unsigned long i = 0; i < buf.size(); ++i)
+        
         {
-            char ch = cnt;
-            DLIB_TEST(buf[i] == ch);
-            ++cnt;
-        }
-
-        for (int i = -1000; i <= 1000; ++i)
-        {
-            DLIB_TEST(s.peek() != EOF);
-            char ch1 = i;
-            char ch2 = s.get();
-            DLIB_TEST(ch1 == ch2);
-        }
-
-        DLIB_TEST(s.peek() == EOF);
-        DLIB_TEST(s.get() == EOF);
-
-        s.clear();
-        s.seekg(6);
-
-        for (int i = -1000+6; i <= 1000; ++i)
-        {
-            DLIB_TEST(s.peek() != EOF);
-            char ch1 = i;
-            char ch2 = s.get();
-            DLIB_TEST(ch1 == ch2);
-        }
-
-        DLIB_TEST(s.peek() == EOF);
-        DLIB_TEST(s.get() == EOF);
-
-        std::string temp;
-        temp = "one two three!";
-
-        s.seekg(0);
-        buf.clear();
-        s.clear();
-
-        serialize(temp, s);
-        std::string temp2;
-        deserialize(temp2, s);
-        DLIB_TEST(temp2 == temp);
-
-        s.put('1');
-        s.put('2');
-        s.put('3');
-        s.put('4');
-        DLIB_TEST(s.get() == '1');
-        DLIB_TEST(s.get() == '2');
-        DLIB_TEST(s.get() == '3');
-        DLIB_TEST(s.get() == '4');
-
-        s.putback('4');
-        DLIB_TEST(s.get() == '4');
-        s.putback('4');
-        s.putback('3');
-        s.putback('2');
-        s.putback('1');
-        DLIB_TEST(s.get() == '1');
-        DLIB_TEST(s.get() == '2');
-        DLIB_TEST(s.get() == '3');
-        DLIB_TEST(s.get() == '4');
-        DLIB_TEST(s.good() == true);
-        DLIB_TEST(s.get() == EOF);
-        DLIB_TEST(s.good() == false);
-
-        // make sure seeking to a crazy offset doesn't mess things up
-        s.clear();
-        s.seekg(1000000);
-        DLIB_TEST(s.get() == EOF);
-        DLIB_TEST(s.good() == false);
-        s.clear();
-        s.seekg(1000000);
-        char sbuf[100];
-        s.read(sbuf, sizeof(sbuf));
-        DLIB_TEST(s.good() == false);
+            vector<char> buf;
+            dlib::vectorstream s1(buf);
+            std::iostream& s2(s1);
+            helper::test1_helper t(buf);
+            t(s2);
+        }        
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/test/vectorstream.cpp
+++ b/dlib/test/vectorstream.cpp
@@ -22,13 +22,6 @@ namespace
 
     logger dlog("test.vectorstream");
           
-    /*
-    * This class helps test the functionality of dlib::vectorstream when an object reference is treated as:
-    * - dlib::vectorstream&
-    * - std::iostream&
-    * Depending on which is used, the underlying function calls might have different call stacks.
-    */
-
     template <typename stream>
     void test1_variant(std::vector<char>& buf, stream& s)
     {
@@ -60,6 +53,20 @@ namespace
         DLIB_TEST(s.get() == EOF);
 
         s.clear();
+        s.seekg(6); //Let iostream decide which path to take. In theory it could decide to use any.
+
+        for (int i = -1000+6; i <= 1000; ++i)
+        {
+            DLIB_TEST(s.peek() != EOF);
+            char ch1 = i;
+            char ch2 = s.get();
+            DLIB_TEST(ch1 == ch2);
+        }
+
+        DLIB_TEST(s.peek() == EOF);
+        DLIB_TEST(s.get() == EOF);
+        
+        s.clear();
         s.seekg(6, std::ios_base::beg);
 
         for (int i = -1000+6; i <= 1000; ++i)
@@ -74,8 +81,10 @@ namespace
         DLIB_TEST(s.get() == EOF);
         
         s.clear();
-        s.seekg(1000, std::ios_base::beg); //read_pos should be 1000
-        s.seekg(6,    std::ios_base::cur); //read_pos should be 1006
+        s.seekg(1000, std::ios_base::beg);  //read_pos should be 1000
+        DLIB_TEST(s.good());                //yep, still good
+        DLIB_TEST(s.peek() == char(0));     //read_pos should still be 1000
+        s.seekg(6, std::ios_base::cur);     //read_pos should be 1006
         
         for (int i = 6; i <= 1000; ++i)
         {
@@ -164,7 +173,7 @@ namespace
         {
             vector<char> buf;
             dlib::vectorstream s1(buf);
-            std::iostream& s2(s1);
+            std::iostream& s2 = s1;
             test1_variant(buf, s2);
         }        
     }

--- a/dlib/test/vectorstream.cpp
+++ b/dlib/test/vectorstream.cpp
@@ -21,115 +21,132 @@ namespace
 
 
     logger dlog("test.vectorstream");
-    
-    namespace helper 
-    {        
-        /*
-        * This class helps test the functionality of dlib::vectorstream when an object reference is treated as:
-        * - dlib::vectorstream&
-        * - std::iostream&
-        * Depending on which is used, the underlying function calls might have different call stacks.
-        */
-        struct test1_helper
+          
+    /*
+    * This class helps test the functionality of dlib::vectorstream when an object reference is treated as:
+    * - dlib::vectorstream&
+    * - std::iostream&
+    * Depending on which is used, the underlying function calls might have different call stacks.
+    */
+
+    template <typename stream>
+    void test1_variant(std::vector<char>& buf, stream& s)
+    {
+        for (int i = -1000; i <= 1000; ++i)
         {
-            test1_helper(
-                std::vector<char>& buf_
-            ) : buf(buf_)
-            {}
+            char ch = i;
+            s.put(ch);
+        }
 
-            template <typename T>
-            void operator()(T& s)
-            {
-                for (int i = -1000; i <= 1000; ++i)
-                {
-                    char ch = i;
-                    s.put(ch);
-                }
+        DLIB_TEST(buf.size() == 2001);
 
-                DLIB_TEST(buf.size() == 2001);
+        int cnt = -1000;
+        for (unsigned long i = 0; i < buf.size(); ++i)
+        {
+            char ch = cnt;
+            DLIB_TEST(buf[i] == ch);
+            ++cnt;
+        }
 
-                int cnt = -1000;
-                for (unsigned long i = 0; i < buf.size(); ++i)
-                {
-                    char ch = cnt;
-                    DLIB_TEST(buf[i] == ch);
-                    ++cnt;
-                }
+        for (int i = -1000; i <= 1000; ++i)
+        {
+            DLIB_TEST(s.peek() != EOF);
+            char ch1 = i;
+            char ch2 = s.get();
+            DLIB_TEST(ch1 == ch2);
+        }
 
-                for (int i = -1000; i <= 1000; ++i)
-                {
-                    DLIB_TEST(s.peek() != EOF);
-                    char ch1 = i;
-                    char ch2 = s.get();
-                    DLIB_TEST(ch1 == ch2);
-                }
+        DLIB_TEST(s.peek() == EOF);
+        DLIB_TEST(s.get() == EOF);
 
-                DLIB_TEST(s.peek() == EOF);
-                DLIB_TEST(s.get() == EOF);
+        s.clear();
+        s.seekg(6, std::ios_base::beg);
 
-                s.clear();
-                s.seekg(6);
+        for (int i = -1000+6; i <= 1000; ++i)
+        {
+            DLIB_TEST(s.peek() != EOF);
+            char ch1 = i;
+            char ch2 = s.get();
+            DLIB_TEST(ch1 == ch2);
+        }
 
-                for (int i = -1000+6; i <= 1000; ++i)
-                {
-                    DLIB_TEST(s.peek() != EOF);
-                    char ch1 = i;
-                    char ch2 = s.get();
-                    DLIB_TEST(ch1 == ch2);
-                }
+        DLIB_TEST(s.peek() == EOF);
+        DLIB_TEST(s.get() == EOF);
+        
+        s.clear();
+        s.seekg(1000, std::ios_base::beg); //read_pos should be 1000
+        s.seekg(6,    std::ios_base::cur); //read_pos should be 1006
+        
+        for (int i = 6; i <= 1000; ++i)
+        {
+            DLIB_TEST(s.peek() != EOF);
+            char ch1 = i;
+            char ch2 = s.get();
+            DLIB_TEST(ch1 == ch2);
+        }
 
-                DLIB_TEST(s.peek() == EOF);
-                DLIB_TEST(s.get() == EOF);
+        DLIB_TEST(s.peek() == EOF);
+        DLIB_TEST(s.get() == EOF);
+        
+        s.clear();
+        s.seekg(-6, std::ios_base::end); //read_pos should be 1995
 
-                std::string temp;
-                temp = "one two three!";
+        for (int i = 995; i <= 1000; ++i)
+        {
+            DLIB_TEST(s.peek() != EOF);
+            char ch1 = i;
+            char ch2 = s.get();
+            DLIB_TEST(ch1 == ch2);
+        }
+        
+        DLIB_TEST(s.peek() == EOF);
+        DLIB_TEST(s.get() == EOF);
+        
+        std::string temp;
+        temp = "one two three!";
 
-                s.clear();
-                s.seekg(0);
-                buf.clear();
+        s.clear();
+        s.seekg(0);
+        buf.clear();
 
-                serialize(temp, s);
-                std::string temp2;
-                deserialize(temp2, s);
-                DLIB_TEST(temp2 == temp);
+        serialize(temp, s);
+        std::string temp2;
+        deserialize(temp2, s);
+        DLIB_TEST(temp2 == temp);
 
-                s.put('1');
-                s.put('2');
-                s.put('3');
-                s.put('4');
-                DLIB_TEST(s.get() == '1');
-                DLIB_TEST(s.get() == '2');
-                DLIB_TEST(s.get() == '3');
-                DLIB_TEST(s.get() == '4');
+        s.put('1');
+        s.put('2');
+        s.put('3');
+        s.put('4');
+        DLIB_TEST(s.get() == '1');
+        DLIB_TEST(s.get() == '2');
+        DLIB_TEST(s.get() == '3');
+        DLIB_TEST(s.get() == '4');
 
-                s.putback('4');
-                DLIB_TEST(s.get() == '4');
-                s.putback('4');
-                s.putback('3');
-                s.putback('2');
-                s.putback('1');
-                DLIB_TEST(s.get() == '1');
-                DLIB_TEST(s.get() == '2');
-                DLIB_TEST(s.get() == '3');
-                DLIB_TEST(s.get() == '4');
-                DLIB_TEST(s.good() == true);
-                DLIB_TEST(s.get() == EOF);
-                DLIB_TEST(s.good() == false);
+        s.putback('4');
+        DLIB_TEST(s.get() == '4');
+        s.putback('4');
+        s.putback('3');
+        s.putback('2');
+        s.putback('1');
+        DLIB_TEST(s.get() == '1');
+        DLIB_TEST(s.get() == '2');
+        DLIB_TEST(s.get() == '3');
+        DLIB_TEST(s.get() == '4');
+        DLIB_TEST(s.good() == true);
+        DLIB_TEST(s.get() == EOF);
+        DLIB_TEST(s.good() == false);
 
-                // make sure seeking to a crazy offset doesn't mess things up
-                s.clear();
-                s.seekg(1000000);
-                DLIB_TEST(s.get() == EOF);
-                DLIB_TEST(s.good() == false);
-                s.clear();
-                s.seekg(1000000);
-                char sbuf[100];
-                s.read(sbuf, sizeof(sbuf));
-                DLIB_TEST(s.good() == false);
-            }
-
-            std::vector<char>& buf;
-        };
+        // make sure seeking to a crazy offset doesn't mess things up
+        s.clear();
+        s.seekg(1000000);
+        DLIB_TEST(s.get() == EOF);
+        DLIB_TEST(s.good() == false);
+        s.clear();
+        s.seekg(1000000);
+        char sbuf[100];
+        s.read(sbuf, sizeof(sbuf));
+        DLIB_TEST(s.good() == false);
     }
 
 // ----------------------------------------------------------------------------------------
@@ -141,16 +158,14 @@ namespace
         {
             std::vector<char> buf;
             vectorstream s1(buf);
-            helper::test1_helper t(buf);
-            t(s1);
+            test1_variant(buf, s1);
         }
         
         {
             vector<char> buf;
             dlib::vectorstream s1(buf);
             std::iostream& s2(s1);
-            helper::test1_helper t(buf);
-            t(s2);
+            test1_variant(buf, s2);
         }        
     }
 

--- a/dlib/vectorstream/vectorstream.h
+++ b/dlib/vectorstream/vectorstream.h
@@ -12,7 +12,6 @@
 #include <cstdio>
 #include "../algs.h"
 
-
 #ifdef _MSC_VER
 // Disable the warning about inheriting from std::iostream 'via dominance' since this warning is a warning about
 // visual studio conforming to the standard and is ignorable.  See http://connect.microsoft.com/VisualStudio/feedback/details/733720/inheriting-from-std-fstream-produces-c4250-warning
@@ -42,6 +41,32 @@ namespace dlib
             void seekg(size_type pos)
             {
                 read_pos = pos;
+            }
+            
+            pos_type seekpos(pos_type pos, std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
+            {
+                return seekoff(pos - pos_type(off_type(0)), std::ios_base::beg, mode);
+            }
+
+            pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                             std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out )
+            {
+                (void)mode; //don't care what mode is. This class handles both
+                switch (dir)
+                {
+                    case std::ios_base::beg:
+                        read_pos = off;
+                        break;
+                    case std::ios_base::cur:
+                        read_pos += off;
+                        break;
+                    case std::ios_base::end:
+                        read_pos = buffer.size() + off;
+                        break;
+                    default:
+                        break;
+                }
+                return pos_type(read_pos);
             }
 
             // ------------------------ OUTPUT FUNCTIONS ------------------------
@@ -120,14 +145,15 @@ namespace dlib
             std::iostream(&buf),
             buf(buffer)
         {}
-
-        std::istream& seekg (
-            std::streampos pos
-        )
-        {
-            buf.seekg(pos);
-            return *this;
-        }
+            
+        vectorstream(const vectorstream& ori) = delete;
+            
+        vectorstream(
+            vectorstream&& item
+        ) : 
+            std::iostream(std::move(item)), 
+            buf(std::move(item.buf))
+        {}
 
     private:
         vector_streambuf buf;

--- a/dlib/vectorstream/vectorstream.h
+++ b/dlib/vectorstream/vectorstream.h
@@ -149,8 +149,6 @@ namespace dlib
             
         vectorstream(const vectorstream& ori) = delete;
         vectorstream(vectorstream&& item) = delete;
-        vectorstream& operator=(const vectorstream& ori) = delete;
-        vectorstream& operator=(vectorstream&& item) = delete;
             
     private:
         vector_streambuf buf;

--- a/dlib/vectorstream/vectorstream.h
+++ b/dlib/vectorstream/vectorstream.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <cstdio>
 #include "../algs.h"
+#include "../assert.h"
 
 #ifdef _MSC_VER
 // Disable the warning about inheriting from std::iostream 'via dominance' since this warning is a warning about
@@ -51,7 +52,7 @@ namespace dlib
             pos_type seekoff(off_type off, std::ios_base::seekdir dir,
                              std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out )
             {
-                (void)mode; //don't care what mode is. This class handles both
+                DLIB_ASSERT(mode == std::ios_base::in, "vectorstream does not support std::ios_base::out");
                 switch (dir)
                 {
                     case std::ios_base::beg:
@@ -147,14 +148,10 @@ namespace dlib
         {}
             
         vectorstream(const vectorstream& ori) = delete;
+        vectorstream(vectorstream&& item) = delete;
+        vectorstream& operator=(const vectorstream& ori) = delete;
+        vectorstream& operator=(vectorstream&& item) = delete;
             
-        vectorstream(
-            vectorstream&& item
-        ) : 
-            std::iostream(std::move(item)), 
-            buf(std::move(item.buf))
-        {}
-
     private:
         vector_streambuf buf;
     };


### PR DESCRIPTION
These updates ensure that casting ```dlib::vectorstream&``` to ```std::iostream&``` still works fine.