### PR TITLE
fix backtracking when losses stay at inf (fixes #2206)

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1113,10 +1113,10 @@ namespace dlib
             while (previous_loss_values_to_keep_until_disk_sync.size() > 2 * gradient_updates_since_last_sync)
                 previous_loss_values_to_keep_until_disk_sync.pop_front();
 
-            // Always retry if there are any nan values
+            // Always retry if there are any nan or inf values
             for (auto x : previous_loss_values_to_keep_until_disk_sync)
             {
-                if (std::isnan(x))
+                if (std::isnan(x) || std::isinf(x))
                     return true;
             }
 
@@ -1127,8 +1127,6 @@ namespace dlib
             // if the loss is very likely to be increasing then return true
             const double prob1 = probability_values_are_increasing(previous_loss_values_to_keep_until_disk_sync);
             const double prob2 = probability_values_are_increasing_robust(previous_loss_values_to_keep_until_disk_sync);
-            if (std::isnan(prob2))
-                return true;
             if (std::max(prob1, prob2) > prob_loss_increasing_thresh)
             {
                 // Exponentially decay the threshold towards 1 so that if we keep finding

--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1127,6 +1127,8 @@ namespace dlib
             // if the loss is very likely to be increasing then return true
             const double prob1 = probability_values_are_increasing(previous_loss_values_to_keep_until_disk_sync);
             const double prob2 = probability_values_are_increasing_robust(previous_loss_values_to_keep_until_disk_sync);
+            if (std::isnan(prob2))
+                return true;
             if (std::max(prob1, prob2) > prob_loss_increasing_thresh)
             {
                 // Exponentially decay the threshold towards 1 so that if we keep finding

--- a/dlib/test/statistics.cpp
+++ b/dlib/test/statistics.cpp
@@ -902,17 +902,12 @@ namespace
         }
 
         void test_probability_values_are_increasing() {
-            const auto inf = std::numeric_limits<double>::infinity();
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{1,2,3,4,5,6,7,8}) > 0.99);
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{8,7,6,5,4,4,3,2}) < 0.01);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,3,4,5,6,7,8}) > 0.99);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{8,7,6,5,4,4,3,2}) < 0.01);
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{1,2,1e10,3,4,5,6,7,8}) < 0.3);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,1e100,3,4,5,6,7,8}) > 0.99);
-            DLIB_TEST(std::isnan(probability_values_are_increasing(std::vector<double>{1,2,inf,3,4,5,6,7,8})));
-            DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,inf,3,4,5,6,7,8}) > 0.99);
-            DLIB_TEST(std::isnan(probability_values_are_increasing(std::vector<double>{1,inf,inf,inf,inf,inf})));
-            DLIB_TEST(std::isnan(probability_values_are_increasing_robust(std::vector<double>{1,inf,inf,inf,inf,inf})));
         }
 
         void test_event_corr()

--- a/dlib/test/statistics.cpp
+++ b/dlib/test/statistics.cpp
@@ -902,12 +902,17 @@ namespace
         }
 
         void test_probability_values_are_increasing() {
+            const auto inf = std::numeric_limits<double>::infinity();
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{1,2,3,4,5,6,7,8}) > 0.99);
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{8,7,6,5,4,4,3,2}) < 0.01);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,3,4,5,6,7,8}) > 0.99);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{8,7,6,5,4,4,3,2}) < 0.01);
             DLIB_TEST(probability_values_are_increasing(std::vector<double>{1,2,1e10,3,4,5,6,7,8}) < 0.3);
             DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,1e100,3,4,5,6,7,8}) > 0.99);
+            DLIB_TEST(std::isnan(probability_values_are_increasing(std::vector<double>{1,2,inf,3,4,5,6,7,8})));
+            DLIB_TEST(probability_values_are_increasing_robust(std::vector<double>{1,2,inf,3,4,5,6,7,8}) > 0.99);
+            DLIB_TEST(std::isnan(probability_values_are_increasing(std::vector<double>{1,inf,inf,inf,inf,inf})));
+            DLIB_TEST(std::isnan(probability_values_are_increasing_robust(std::vector<double>{1,inf,inf,inf,inf,inf})));
         }
 
         void test_event_corr()


### PR DESCRIPTION
This PR adresses issue #2206, which makes the `dnn_trainer` backtrack to a previous state when the loss sequence looks like:
```
1, inf, inf, inf, inf
```

https://github.com/davisking/dlib/blob/3ba004f875d02c4c326f8cec5d9ec46b5708ea5a/dlib/dnn/trainer.h#L1128-L1129

`probability_values_are_increasing` gives `nan` whenever an `inf` value is present, but not `probability_values_are_increasing_robust`. However, the latter will give `nan` if there are still `inf` values after discarding 10% of the samples.

Here we just check that `probability_values_are_increasing_robust` is not `nan` before saving to disk.
I've also added some checks to make sure we get the expected `nan` values, since the `dnn_trainer` relies on them.