### PR TITLE
Add Layer Normalization

### DIFF
--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1260,6 +1260,177 @@ namespace dlib
 
     // -----------------------------------------------------------------------------------
 
+        void layer_normalize (
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& means,
+            resizable_tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            const tensor& beta
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(
+                have_same_dimensions(gamma, beta) &&
+                src.num_samples() == gamma.size() &&
+                src.num_samples() == beta.size() &&
+                eps > 0,
+                "\ngamma.k():  " << gamma.k() <<
+                "\ngamma.nr(): " << gamma.nr() <<
+                "\ngamma.nc(): " << gamma.nc() <<
+                "\nbeta.k():   " << beta.k() <<
+                "\nbeta.nr():  " << beta.nr() <<
+                "\nbeta.nc():  " << beta.nc() <<
+                "\nsrc.k():   " << src.k() <<
+                "\nsrc.nr():  " << src.nr() <<
+                "\nsrc.nc():  " << src.nc() <<
+                "\neps:  " << eps
+            );
+
+            dest.copy_size(src);
+            means.set_size(src.num_samples());
+            invstds.set_size(src.num_samples());
+
+            // first compute means and invstds
+            means = 0;
+            invstds = 0;
+            const auto p_invstds = invstds.host();
+            const auto p_means = means.host();
+            auto p_src = src.host();
+            // compute means, and sum of squares
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    float val = p_src[n*num+i];
+                    p_means[n] += val;
+                    p_invstds[n] += val*val;
+                }
+            }
+            means /= num;
+            invstds /= num;
+            // copy data back to host
+            invstds.host(); means.host();
+
+            // compute variances
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                auto var = p_invstds[n] - p_means[n] * p_means[n];
+                p_invstds[n] = 1.0f / std::sqrt(var + eps);
+            }
+
+            p_src = src.host();
+            auto p_dest = dest.host();
+            auto p_gamma = gamma.host();
+            auto p_beta = beta.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    *p_dest = (*p_src - p_means[n])*p_invstds[n];
+                    *p_dest = (*p_dest)*p_gamma[n] + p_beta[n];
+                    ++p_src;
+                    ++p_dest;
+                }
+            }
+        }
+
+        void layer_normalize_gradient (
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& means,
+            const tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad,
+            tensor& beta_grad
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(src.num_samples() == means.size());
+            DLIB_CASSERT(src.num_samples() == invstds.size());
+            DLIB_CASSERT(src.num_samples() == gamma.size());
+            DLIB_CASSERT(src.num_samples() == gamma_grad.size());
+            DLIB_CASSERT(src.num_samples() == beta_grad.size());
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src));
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src_grad));
+            DLIB_CASSERT(eps > 0);
+
+            beta_grad = 0;
+            gamma_grad = 0;
+            auto p_grad = gradient_input.host();
+            auto p_src = src.host();
+            const auto p_gamma = gamma.host();
+            const auto p_gamma_grad = gamma_grad.host();
+            const auto p_beta_grad = beta_grad.host();
+            const auto p_invstds = invstds.host();
+            const auto p_means = means.host();
+
+            resizable_tensor dvars, dmeans;
+            dvars.copy_size(invstds);
+            dmeans.copy_size(means);
+            dvars = 0;
+            dmeans = 0;
+            const auto p_dvars = dvars.host();
+            const auto p_dmeans = dmeans.host();
+
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    const float x_hat = (*p_src - p_means[n])*p_invstds[n];
+                    p_beta_grad[n] += *p_grad;
+                    p_gamma_grad[n] += (*p_grad)*x_hat;
+
+                    const float dx = *p_grad * p_gamma[n];
+
+                    p_dvars[n] += dx*(*p_src - p_means[n])*-0.5*std::pow(p_invstds[n], 3.0f);
+
+                    ++p_grad;
+                    ++p_src;
+                }
+            }
+
+            const float invnum = 1.0f/num;
+            p_grad = gradient_input.host();
+            p_src = src.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    const float dx = *p_grad * p_gamma[n];
+
+                    p_dmeans[n] += dx*-p_invstds[n] + p_dvars[n] * -2*(*p_src - p_means[n])*invnum;
+
+                    ++p_grad;
+                    ++p_src;
+                }
+            }
+            p_grad = gradient_input.host();
+            p_src = src.host();
+            auto p_src_grad = src_grad.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    const float dx = *p_grad * p_gamma[n];
+
+                    *p_src_grad += dx*p_invstds[n] +
+                        p_dvars[n] *2*(*p_src - p_means[n])*invnum +
+                        p_dmeans[n]*invnum;
+
+
+                    ++p_grad;
+                    ++p_src;
+                    ++p_src_grad;
+                }
+            }
+        }
+
+    // -----------------------------------------------------------------------------------
+
         void threshold (
             tensor& data,
             float thresh

--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1328,6 +1328,7 @@ namespace dlib
             {
                 for (long i = 0; i < num; ++i)
                 {
+                    // printf("%ld, %ld: %f, %f, %f\n", n, i, *p_src, p_means[n], p_invstds[n]);
                     *p_dest = (*p_src - p_means[n])*p_invstds[n];
                     *p_dest = (*p_dest)*p_gamma[n] + p_beta[n];
                     ++p_src;

--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1328,7 +1328,6 @@ namespace dlib
             {
                 for (long i = 0; i < num; ++i)
                 {
-                    // printf("%ld, %ld: %f, %f, %f\n", n, i, *p_src, p_means[n], p_invstds[n]);
                     *p_dest = (*p_src - p_means[n])*p_invstds[n];
                     *p_dest = (*p_dest)*p_gamma[n] + p_beta[n];
                     ++p_src;

--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -231,6 +231,30 @@ namespace dlib
 
     // -----------------------------------------------------------------------------------
 
+        void layer_normalize (
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& means,
+            resizable_tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            const tensor& beta
+        );
+
+        void layer_normalize_gradient (
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& means,
+            const tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad,
+            tensor& beta_grad
+        );
+
+    // -----------------------------------------------------------------------------------
+
         void threshold (
             tensor& data,
             float thresh

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -338,6 +338,30 @@ namespace dlib
 
     // -----------------------------------------------------------------------------------
 
+        void layer_normalize (
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& means,
+            resizable_tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            const tensor& beta
+        );
+
+        void layer_normalize_gradient (
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& means,
+            const tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad,
+            tensor& beta_grad
+        );
+
+    // -----------------------------------------------------------------------------------
+
         void threshold (
             tensor& data,
             float thresh
@@ -508,7 +532,7 @@ namespace dlib
                 tensor& gradient,
                 double& loss
             );
-            
+
             mutable cuda_data_void_ptr buf;
         };
 

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -668,7 +668,11 @@ namespace dlib { namespace tt
         const tensor& beta
     )
     {
+#ifdef DLIB_USE_CUDA
+        cuda::layer_normalize(eps, dest, means, vars, src, gamma, beta);
+#else
         cpu::layer_normalize(eps, dest, means, vars, src, gamma, beta);
+#endif
     }
 
     void layer_normalize_gradient (

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -658,6 +658,36 @@ namespace dlib { namespace tt
 
 // ----------------------------------------------------------------------------------------
 
+    void layer_normalize (
+        const double eps,
+        resizable_tensor& dest,
+        resizable_tensor& means,
+        resizable_tensor& vars,
+        const tensor& src,
+        const tensor& gamma,
+        const tensor& beta
+    )
+    {
+        cpu::layer_normalize(eps, dest, means, vars, src, gamma, beta);
+    }
+
+    void layer_normalize_gradient (
+        const double eps,
+            const tensor& gradient_input,
+            const tensor& means,
+            const tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad,
+            tensor& beta_grad
+    )
+    {
+        cpu::layer_normalize_gradient(eps, gradient_input, means, invstds, src, gamma, src_grad, gamma_grad, beta_grad);
+    }
+
+// ----------------------------------------------------------------------------------------
+
     void threshold (
         tensor& data,
         float thresh

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -802,6 +802,30 @@ namespace dlib { namespace tt
 
 // -----------------------------------------------------------------------------------
 
+    void layer_normalize (
+        const double eps,
+        resizable_tensor& dest,
+        resizable_tensor& means,
+        resizable_tensor& invstds,
+        const tensor& src,
+        const tensor& gamma,
+        const tensor& beta
+    );
+
+    void layer_normalize_gradient (
+        const double eps,
+            const tensor& gradient_input,
+            const tensor& means,
+            const tensor& invstds,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad,
+            tensor& beta_grad
+    );
+
+    // -----------------------------------------------------------------------------------
+
     void threshold (
         tensor& data,
         float thresh

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1722,6 +1722,7 @@ namespace dlib
                 // ignore other layer types
             }
 
+            // handle the standard case
             template <typename U, typename E>
             void disable_input_bias(add_layer<layer_norm_, U, E>& l)
             {
@@ -1730,7 +1731,6 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
             }
 
-            // handle the standard case
             template <layer_mode mode, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, U, E>& l)
             {
@@ -1748,9 +1748,22 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
             }
 
+            template <size_t N, template <typename> class R, typename U, typename E>
+            void disable_input_bias(add_layer<layer_norm_, repeat<N, R, U>, E>& l)
+            {
+                disable_bias(l.subnet().get_repeated_layer(0).layer_details());
+                set_bias_learning_rate_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
+                set_bias_weight_decay_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
+            }
+
             // handle input repeat layer with tag case
             template <layer_mode mode, unsigned long ID, typename E, typename F>
-            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& l)
+            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& )
+            {
+            }
+
+            template <unsigned long ID, typename E, typename F>
+            void disable_input_bias(add_layer<layer_norm_, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& )
             {
             }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1730,6 +1730,7 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
             }
 
+            // handle the standard case
             template <layer_mode mode, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, U, E>& l)
             {
@@ -1738,12 +1739,19 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
             }
 
+            // handle input repeat layer case
             template <layer_mode mode, size_t N, template <typename> class R, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, repeat<N, R, U>, E>& l)
             {
                 disable_bias(l.subnet().get_repeated_layer(0).layer_details());
                 set_bias_learning_rate_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
                 set_bias_weight_decay_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
+            }
+
+            // handle input repeat layer with tag case
+            template <layer_mode mode, unsigned long ID, typename E, typename F>
+            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& l)
+            {
             }
 
             template<typename input_layer_type>

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1627,6 +1627,141 @@ namespace dlib
     }
 
 // ----------------------------------------------------------------------------------------
+
+    const double DEFAULT_LAYER_NORM_EPS = 1e-5;
+
+    class layer_norm_
+    {
+    public:
+        explicit layer_norm_(
+            double eps_ = DEFAULT_LAYER_NORM_EPS
+        ) :
+            learning_rate_multiplier(1),
+            weight_decay_multiplier(0),
+            bias_learning_rate_multiplier(1),
+            bias_weight_decay_multiplier(1),
+            eps(eps_)
+        {
+        }
+
+        double get_eps() const { return eps; }
+
+        double get_learning_rate_multiplier () const  { return learning_rate_multiplier; }
+        double get_weight_decay_multiplier () const   { return weight_decay_multiplier; }
+        void set_learning_rate_multiplier(double val) { learning_rate_multiplier = val; }
+        void set_weight_decay_multiplier(double val)  { weight_decay_multiplier  = val; }
+
+        double get_bias_learning_rate_multiplier () const  { return bias_learning_rate_multiplier; }
+        double get_bias_weight_decay_multiplier () const   { return bias_weight_decay_multiplier; }
+        void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
+        void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
+
+        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
+
+        template <typename SUBNET>
+        void setup (const SUBNET& sub)
+        {
+            gamma = alias_tensor(sub.get_output().num_samples());
+            beta = gamma;
+
+            params.set_size(gamma.size()+beta.size());
+
+            gamma(params,0) = 1;
+            beta(params,gamma.size()) = 0;
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            auto g = gamma(params,0);
+            auto b = beta(params,gamma.size());
+            tt::layer_normalize(eps, output, means, invstds, sub.get_output(), g, b);
+        }
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad)
+        {
+            auto g = gamma(params, 0);
+            auto g_grad = gamma(params_grad, 0);
+            auto b_grad = beta(params_grad, gamma.size());
+            tt::layer_normalize_gradient(eps, gradient_input, means, invstds, sub.get_output(), g, sub.get_gradient_input(), g_grad, b_grad);
+        }
+
+        const tensor& get_layer_params() const { return params; };
+        tensor& get_layer_params() { return params; };
+
+        friend void serialize(const layer_norm_& item, std::ostream& out)
+        {
+            serialize("layer_norm_", out);
+            serialize(item.params, out);
+            serialize(item.gamma, out);
+            serialize(item.beta, out);
+            serialize(item.means, out);
+            serialize(item.invstds, out);
+            serialize(item.learning_rate_multiplier, out);
+            serialize(item.weight_decay_multiplier, out);
+            serialize(item.bias_learning_rate_multiplier, out);
+            serialize(item.bias_weight_decay_multiplier, out);
+            serialize(item.eps, out);
+        }
+
+        friend void deserialize(layer_norm_& item, std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            if (version != "layer_norm_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::layer_norm_.");
+            deserialize(item.params, in);
+            deserialize(item.gamma, in);
+            deserialize(item.beta, in);
+            deserialize(item.means, in);
+            deserialize(item.invstds, in);
+            deserialize(item.learning_rate_multiplier, in);
+            deserialize(item.weight_decay_multiplier, in);
+            deserialize(item.bias_learning_rate_multiplier, in);
+            deserialize(item.bias_weight_decay_multiplier, in);
+            deserialize(item.eps, in);
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const layer_norm_& item)
+        {
+            out << "layer_norm";
+            out << " eps="<<item.eps;
+            out << " learning_rate_mult="<<item.learning_rate_multiplier;
+            out << " weight_decay_mult="<<item.weight_decay_multiplier;
+            out << " bias_learning_rate_mult="<<item.bias_learning_rate_multiplier;
+            out << " bias_weight_decay_mult="<<item.bias_weight_decay_multiplier;
+            return out;
+        }
+
+        friend void to_xml(const layer_norm_& item, std::ostream& out)
+        {
+            out << "layer_norm";
+            out << " eps='"<<item.eps<<"'";
+            out << " learning_rate_mult='"<<item.learning_rate_multiplier<<"'";
+            out << " weight_decay_mult='"<<item.weight_decay_multiplier<<"'";
+            out << " bias_learning_rate_mult='"<<item.bias_learning_rate_multiplier<<"'";
+            out << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'";
+            out << ">\n";
+            out << mat(item.params);
+            out << "</layer_norm>\n";
+        }
+
+    private:
+        resizable_tensor params;
+        alias_tensor gamma, beta;
+        resizable_tensor means, invstds;
+        double learning_rate_multiplier;
+        double weight_decay_multiplier;
+        double bias_learning_rate_multiplier;
+        double bias_weight_decay_multiplier;
+        double eps;
+    };
+
+    template <typename SUBNET>
+    using layer_norm = add_layer<layer_norm_, SUBNET>;
+
 // ----------------------------------------------------------------------------------------
 
     enum fc_bias_mode

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1302,6 +1302,141 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    const double DEFAULT_LAYER_NORM_EPS = 1e-5;
+
+    class layer_norm_
+    {
+    public:
+        explicit layer_norm_(
+            double eps_ = DEFAULT_LAYER_NORM_EPS
+        ) :
+            learning_rate_multiplier(1),
+            weight_decay_multiplier(0),
+            bias_learning_rate_multiplier(1),
+            bias_weight_decay_multiplier(1),
+            eps(eps_)
+        {
+        }
+
+        double get_eps() const { return eps; }
+
+        double get_learning_rate_multiplier () const  { return learning_rate_multiplier; }
+        double get_weight_decay_multiplier () const   { return weight_decay_multiplier; }
+        void set_learning_rate_multiplier(double val) { learning_rate_multiplier = val; }
+        void set_weight_decay_multiplier(double val)  { weight_decay_multiplier  = val; }
+
+        double get_bias_learning_rate_multiplier () const  { return bias_learning_rate_multiplier; }
+        double get_bias_weight_decay_multiplier () const   { return bias_weight_decay_multiplier; }
+        void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
+        void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
+
+        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
+
+        template <typename SUBNET>
+        void setup (const SUBNET& sub)
+        {
+            gamma = alias_tensor(sub.get_output().num_samples());
+            beta = gamma;
+
+            params.set_size(gamma.size()+beta.size());
+
+            gamma(params,0) = 1;
+            beta(params,gamma.size()) = 0;
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            auto g = gamma(params,0);
+            auto b = beta(params,gamma.size());
+            tt::layer_normalize(eps, output, means, invstds, sub.get_output(), g, b);
+        }
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad)
+        {
+            auto g = gamma(params, 0);
+            auto g_grad = gamma(params_grad, 0);
+            auto b_grad = beta(params_grad, gamma.size());
+            tt::layer_normalize_gradient(eps, gradient_input, means, invstds, sub.get_output(), g, sub.get_gradient_input(), g_grad, b_grad);
+        }
+
+        const tensor& get_layer_params() const { return params; };
+        tensor& get_layer_params() { return params; };
+
+        friend void serialize(const layer_norm_& item, std::ostream& out)
+        {
+            serialize("layer_norm_", out);
+            serialize(item.params, out);
+            serialize(item.gamma, out);
+            serialize(item.beta, out);
+            serialize(item.means, out);
+            serialize(item.invstds, out);
+            serialize(item.learning_rate_multiplier, out);
+            serialize(item.weight_decay_multiplier, out);
+            serialize(item.bias_learning_rate_multiplier, out);
+            serialize(item.bias_weight_decay_multiplier, out);
+            serialize(item.eps, out);
+        }
+
+        friend void deserialize(layer_norm_& item, std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            if (version != "layer_norm_")
+                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::layer_norm_.");
+            deserialize(item.params, in);
+            deserialize(item.gamma, in);
+            deserialize(item.beta, in);
+            deserialize(item.means, in);
+            deserialize(item.invstds, in);
+            deserialize(item.learning_rate_multiplier, in);
+            deserialize(item.weight_decay_multiplier, in);
+            deserialize(item.bias_learning_rate_multiplier, in);
+            deserialize(item.bias_weight_decay_multiplier, in);
+            deserialize(item.eps, in);
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const layer_norm_& item)
+        {
+            out << "layer_norm";
+            out << " eps="<<item.eps;
+            out << " learning_rate_mult="<<item.learning_rate_multiplier;
+            out << " weight_decay_mult="<<item.weight_decay_multiplier;
+            out << " bias_learning_rate_mult="<<item.bias_learning_rate_multiplier;
+            out << " bias_weight_decay_mult="<<item.bias_weight_decay_multiplier;
+            return out;
+        }
+
+        friend void to_xml(const layer_norm_& item, std::ostream& out)
+        {
+            out << "layer_norm";
+            out << " eps='"<<item.eps<<"'";
+            out << " learning_rate_mult='"<<item.learning_rate_multiplier<<"'";
+            out << " weight_decay_mult='"<<item.weight_decay_multiplier<<"'";
+            out << " bias_learning_rate_mult='"<<item.bias_learning_rate_multiplier<<"'";
+            out << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'";
+            out << ">\n";
+            out << mat(item.params);
+            out << "</layer_norm>\n";
+        }
+
+    private:
+        resizable_tensor params;
+        alias_tensor gamma, beta;
+        resizable_tensor means, invstds;
+        double learning_rate_multiplier;
+        double weight_decay_multiplier;
+        double bias_learning_rate_multiplier;
+        double bias_weight_decay_multiplier;
+        double eps;
+    };
+
+    template <typename SUBNET>
+    using layer_norm = add_layer<layer_norm_, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
     enum layer_mode
     {
         CONV_MODE = 0,
@@ -1587,6 +1722,14 @@ namespace dlib
                 // ignore other layer types
             }
 
+            template <typename U, typename E>
+            void set_input_no_bias(add_layer<layer_norm_, U, E>& l)
+            {
+                disable_bias(l.subnet().layer_details());
+                set_bias_learning_rate_multiplier(l.subnet().layer_details(), 0);
+                set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
+            }
+
             template <layer_mode mode, typename U, typename E>
             void set_input_no_bias(add_layer<bn_<mode>, U, E>& l)
             {
@@ -1625,142 +1768,6 @@ namespace dlib
     {
         visit_layers(net, impl::visitor_bn_input_no_bias());
     }
-
-// ----------------------------------------------------------------------------------------
-
-    const double DEFAULT_LAYER_NORM_EPS = 1e-5;
-
-    class layer_norm_
-    {
-    public:
-        explicit layer_norm_(
-            double eps_ = DEFAULT_LAYER_NORM_EPS
-        ) :
-            learning_rate_multiplier(1),
-            weight_decay_multiplier(0),
-            bias_learning_rate_multiplier(1),
-            bias_weight_decay_multiplier(1),
-            eps(eps_)
-        {
-        }
-
-        double get_eps() const { return eps; }
-
-        double get_learning_rate_multiplier () const  { return learning_rate_multiplier; }
-        double get_weight_decay_multiplier () const   { return weight_decay_multiplier; }
-        void set_learning_rate_multiplier(double val) { learning_rate_multiplier = val; }
-        void set_weight_decay_multiplier(double val)  { weight_decay_multiplier  = val; }
-
-        double get_bias_learning_rate_multiplier () const  { return bias_learning_rate_multiplier; }
-        double get_bias_weight_decay_multiplier () const   { return bias_weight_decay_multiplier; }
-        void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
-        void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
-
-        inline dpoint map_input_to_output (const dpoint& p) const { return p; }
-        inline dpoint map_output_to_input (const dpoint& p) const { return p; }
-
-        template <typename SUBNET>
-        void setup (const SUBNET& sub)
-        {
-            gamma = alias_tensor(sub.get_output().num_samples());
-            beta = gamma;
-
-            params.set_size(gamma.size()+beta.size());
-
-            gamma(params,0) = 1;
-            beta(params,gamma.size()) = 0;
-        }
-
-        template <typename SUBNET>
-        void forward(const SUBNET& sub, resizable_tensor& output)
-        {
-            auto g = gamma(params,0);
-            auto b = beta(params,gamma.size());
-            tt::layer_normalize(eps, output, means, invstds, sub.get_output(), g, b);
-        }
-
-        template <typename SUBNET>
-        void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad)
-        {
-            auto g = gamma(params, 0);
-            auto g_grad = gamma(params_grad, 0);
-            auto b_grad = beta(params_grad, gamma.size());
-            tt::layer_normalize_gradient(eps, gradient_input, means, invstds, sub.get_output(), g, sub.get_gradient_input(), g_grad, b_grad);
-        }
-
-        const tensor& get_layer_params() const { return params; };
-        tensor& get_layer_params() { return params; };
-
-        friend void serialize(const layer_norm_& item, std::ostream& out)
-        {
-            serialize("layer_norm_", out);
-            serialize(item.params, out);
-            serialize(item.gamma, out);
-            serialize(item.beta, out);
-            serialize(item.means, out);
-            serialize(item.invstds, out);
-            serialize(item.learning_rate_multiplier, out);
-            serialize(item.weight_decay_multiplier, out);
-            serialize(item.bias_learning_rate_multiplier, out);
-            serialize(item.bias_weight_decay_multiplier, out);
-            serialize(item.eps, out);
-        }
-
-        friend void deserialize(layer_norm_& item, std::istream& in)
-        {
-            std::string version;
-            deserialize(version, in);
-            if (version != "layer_norm_")
-                throw serialization_error("Unexpected version '"+version+"' found while deserializing dlib::layer_norm_.");
-            deserialize(item.params, in);
-            deserialize(item.gamma, in);
-            deserialize(item.beta, in);
-            deserialize(item.means, in);
-            deserialize(item.invstds, in);
-            deserialize(item.learning_rate_multiplier, in);
-            deserialize(item.weight_decay_multiplier, in);
-            deserialize(item.bias_learning_rate_multiplier, in);
-            deserialize(item.bias_weight_decay_multiplier, in);
-            deserialize(item.eps, in);
-        }
-
-        friend std::ostream& operator<<(std::ostream& out, const layer_norm_& item)
-        {
-            out << "layer_norm";
-            out << " eps="<<item.eps;
-            out << " learning_rate_mult="<<item.learning_rate_multiplier;
-            out << " weight_decay_mult="<<item.weight_decay_multiplier;
-            out << " bias_learning_rate_mult="<<item.bias_learning_rate_multiplier;
-            out << " bias_weight_decay_mult="<<item.bias_weight_decay_multiplier;
-            return out;
-        }
-
-        friend void to_xml(const layer_norm_& item, std::ostream& out)
-        {
-            out << "layer_norm";
-            out << " eps='"<<item.eps<<"'";
-            out << " learning_rate_mult='"<<item.learning_rate_multiplier<<"'";
-            out << " weight_decay_mult='"<<item.weight_decay_multiplier<<"'";
-            out << " bias_learning_rate_mult='"<<item.bias_learning_rate_multiplier<<"'";
-            out << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'";
-            out << ">\n";
-            out << mat(item.params);
-            out << "</layer_norm>\n";
-        }
-
-    private:
-        resizable_tensor params;
-        alias_tensor gamma, beta;
-        resizable_tensor means, invstds;
-        double learning_rate_multiplier;
-        double weight_decay_multiplier;
-        double bias_learning_rate_multiplier;
-        double bias_weight_decay_multiplier;
-        double eps;
-    };
-
-    template <typename SUBNET>
-    using layer_norm = add_layer<layer_norm_, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1444,7 +1444,7 @@ namespace dlib
             WHAT THIS OBJECT REPRESENTS
                 This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
                 defined above.  In particular, it defines a batch normalization layer that
-                implements the method described in the paper: 
+                implements the method described in the paper:
                     Layer Normalization by Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
 
                 In particular, this layer produces output tensors with the same
@@ -1519,7 +1519,7 @@ namespace dlib
 
         void set_weight_decay_multiplier(
             double val
-        ); 
+        );
         /*!
             requires
                 - val >= 0
@@ -1528,7 +1528,7 @@ namespace dlib
         !*/
 
         double get_bias_learning_rate_multiplier(
-        ) const; 
+        ) const;
         /*!
             ensures
                 - returns a multiplier number.  The interpretation is that this object is
@@ -1537,7 +1537,7 @@ namespace dlib
         !*/
 
         double get_bias_weight_decay_multiplier(
-        ) const; 
+        ) const;
         /*!
             ensures
                 - returns a multiplier number.  The interpretation is that this object is
@@ -1547,7 +1547,7 @@ namespace dlib
 
         void set_bias_learning_rate_multiplier(
             double val
-        ); 
+        );
         /*!
             requires
                 - val >= 0
@@ -1557,7 +1557,7 @@ namespace dlib
 
         void set_bias_weight_decay_multiplier(
             double val
-        ); 
+        );
         /*!
             requires
                 - val >= 0

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1810,7 +1810,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename net_type>
-    void set_all_bn_inputs_no_bias (
+    void disable_duplicative_bias (
         const net_type& net
     );
     /*!
@@ -1818,9 +1818,9 @@ namespace dlib
             - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
               add_tag_layer.
         ensures
-            - Disables bias for all bn_ layer inputs.
+            - Disables bias for all bn_ and layer_norm_ inputs.
             - Sets the get_bias_learning_rate_multiplier() and get_bias_weight_decay_multiplier()
-              to zero of all bn_ layer inputs.
+              to zero of all bn_ and layer_norm_ inputs.
     !*/
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1436,6 +1436,149 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    const double DEFAULT_LAYER_NORM_EPS = 1e-5;
+
+    class layer_norm_
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
+                defined above.  In particular, it defines a batch normalization layer that
+                implements the method described in the paper: 
+                    Layer Normalization by Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+                In particular, this layer produces output tensors with the same
+                dimensionality as the input tensors, except that the mean and variances of
+                the elements in each sample have been standardized to 0 and 1 respectively.
+                This is different from batch normalization, since this layer learns one scaling
+                factor and one bias for each sample in the batch, independently.  As a result,
+                this layer is batch-size independent.
+        !*/
+    public:
+        layer_norm_(
+        );
+        /*!
+            ensures
+                - #get_learning_rate_multiplier()       == 1
+                - #get_weight_decay_multiplier()        == 0
+                - #get_bias_learning_rate_multiplier()  == 1
+                - #get_bias_weight_decay_multiplier()   == 1
+                - #get_eps() == DEFAULT_LAYER_NORM_EPS
+        !*/
+
+        explicit layer_norm_(
+            double eps_ = DEFAULT_LAYER_NORM_EPS
+        )
+        /*!
+            requires
+                - eps > 0
+            ensures
+                - #get_learning_rate_multiplier()      == 1
+                - #get_weight_decay_multiplier()       == 0
+                - #get_bias_learning_rate_multiplier() == 1
+                - #get_bias_weight_decay_multiplier()  == 1
+                - #get_eps() == eps
+        !*/
+
+        double get_eps(
+        ) const;
+        /*!
+            ensures
+                - When doing layer normalization, we are dividing by the standard
+                  deviation.  This epsilon value returned by this function is added to the
+                  variance to prevent the division from dividing by zero.
+        !*/
+
+        double get_learning_rate_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                  requesting that the learning rate used to optimize its parameters be
+                  multiplied by get_learning_rate_multiplier().
+        !*/
+
+        double get_weight_decay_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                  requesting that the weight decay used to optimize its parameters be
+                  multiplied by get_weight_decay_multiplier().
+        !*/
+
+        void set_learning_rate_multiplier(
+            double val
+        );
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_learning_rate_multiplier() == val
+        !*/
+
+        void set_weight_decay_multiplier(
+            double val
+        ); 
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_weight_decay_multiplier() == val
+        !*/
+
+        double get_bias_learning_rate_multiplier(
+        ) const; 
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                  requesting that the learning rate used to optimize its bias parameters be
+                  multiplied by get_learning_rate_multiplier()*get_bias_learning_rate_multiplier().
+        !*/
+
+        double get_bias_weight_decay_multiplier(
+        ) const; 
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                  requesting that the weight decay used to optimize its bias parameters be
+                  multiplied by get_weight_decay_multiplier()*get_bias_weight_decay_multiplier().
+        !*/
+
+        void set_bias_learning_rate_multiplier(
+            double val
+        ); 
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_bias_learning_rate_multiplier() == val
+        !*/
+
+        void set_bias_weight_decay_multiplier(
+            double val
+        ); 
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_bias_weight_decay_multiplier() == val
+        !*/
+
+        template <typename SUBNET> void setup (const SUBNET& sub);
+        template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& output);
+        template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
+        dpoint map_input_to_output(dpoint p) const;
+        dpoint map_output_to_input(dpoint p) const;
+        const tensor& get_layer_params() const;
+        tensor& get_layer_params();
+        /*!
+            These functions are implemented as described in the EXAMPLE_COMPUTATIONAL_LAYER_ interface.
+        !*/
+    };
+
+// ----------------------------------------------------------------------------------------
+
     enum layer_mode
     {
         CONV_MODE = 0, // convolutional mode

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -504,7 +504,7 @@ namespace
                 }
             }
             DLIB_TEST(::std::abs(rs.mean()) < 1e-6);
-            DLIB_TEST(::std::abs(rs.variance() - 1.0f) < 0.02);
+            DLIB_TEST(::std::abs(rs.stddev() - 1.0f) < 0.01);
         }
         // check that the CPU and the CUDA implementation are equivalent
 #if DLIB_USE_CUDA

--- a/examples/dnn_dcgan_train_ex.cpp
+++ b/examples/dnn_dcgan_train_ex.cpp
@@ -134,8 +134,8 @@ int main(int argc, char** argv) try
     // setup all leaky_relu_ layers in the discriminator to have alpha = 0.2
     visit_computational_layers(discriminator, [](leaky_relu_& l){ l = leaky_relu_(0.2); });
     // Remove the bias learning from all bn_ inputs in both networks
-    set_all_bn_inputs_no_bias(generator);
-    set_all_bn_inputs_no_bias(discriminator);
+    disable_duplicative_bias(generator);
+    disable_duplicative_bias(discriminator);
     // Forward random noise so that we see the tensor size at each layer
     discriminator(generate_image(generator, make_noise(rnd)));
     cout << "generator (" << count_parameters(generator) << " parameters)" << endl;


### PR DESCRIPTION
This is a second step towards implementing transformers in dlib.

This PR adds [Layer Normalization](https://arxiv.org/abs/1607.06450) support to dlib.

I have added the CPU implementation and the forward GPU, but I have some doubts, so I would really appreciate if somebody could have a look to the CUDA implementation.

It runs slower than the CPU version and for big inputs (2, 3, 224, 224) results are not good, but for small inputs, it works.

Here's how I tried it, in case anyone wants to try

``` c++
#include <dlib/dnn.h>

using namespace dlib;

int main() try
{

    auto print_tensor_and_avg = [](const tensor& t)
    {
        float sum = 0;
        const float* p_t = t.host();
        for (long n = 0; n < t.num_samples(); ++n)
        {
            // std::cout << "sample: " << n << '\n';
            for (long k = 0; k < t.k(); ++k)
            {
                // std::cout << "\tk: " << k << '\n';
                for (long r = 0; r < t.nr(); ++r)
                {
                    for (long c = 0; c < t.nc(); ++c)
                    {
                        // std::cout << '\t' << p_t[tensor_index(t, n, k, r, c)] << ' ';
                        sum += p_t[tensor_index(t, n, k, r, c)];
                    }
                    // std::cout << '\n';
                }
            }
        }
        std::cout << "avg: " << sum / t.size() << '\n';
    };

    resizable_tensor x(2, 3, 224, 224);
    resizable_tensor y_cpu(x), y_cuda(x);
    tt::tensor_rand rnd(0);
    rnd.fill_uniform(x);
    resizable_tensor means(x.num_samples()), invstds(x.num_samples());
    resizable_tensor gamma(x.num_samples()), beta(x.num_samples());
    gamma = 1;
    beta = 0;

    print_tensor_and_avg(x);

    float eps = 1e-5;
    running_stats<float> rs;
    cpu::layer_normalize(eps, y_cpu, means, invstds, x, gamma, beta);
    print_tensor_and_avg(y_cpu);
    for (int i = 0; i < 1000; ++i)
    {
        const auto t0 = std::chrono::steady_clock::now();
        cpu::layer_normalize(eps, y_cpu, means, invstds, x, gamma, beta);
        const auto t1 = std::chrono::steady_clock::now();
        rs.add(std::chrono::duration_cast<std::chrono::duration<float, std::micro>>(t1 - t0).count());
    }
    std::cout << "inference time: " << rs.mean() << " ± " << rs.stddev() << " µs\n";

    rs.clear();
    cuda::layer_normalize(eps, y_cuda, means, invstds, x, gamma, beta);
    print_tensor_and_avg(y_cuda);
    for (int i = 0; i < 1000; ++i)
    {
        const auto t0 = std::chrono::steady_clock::now();
        cuda::layer_normalize(eps, y_cuda, means, invstds, x, gamma, beta);
        const auto t1 = std::chrono::steady_clock::now();
        rs.add(std::chrono::duration_cast<std::chrono::duration<float, std::micro>>(t1 - t0).count());
    }
    std::cout << "inference time: " << rs.mean() << " ± " << rs.stddev() << " µs\n";

    std::cout << "difference: " << sum(squared(mat(y_cpu) - mat(y_cuda))) << '\n';

    return EXIT_SUCCESS;
}
catch (const std::exception& e)
{
    std::cout << e.what() << '\n';
    return EXIT_FAILURE;
}
```
With a size of (2, 3, 4, 5), I get this:
``` c++
// cpu
avg: 7.05322e-08
inference time: 29.3967 ± 0.475304 µs
// cuda
avg: 6.25849e-08
inference time: 49.7305 ± 1.50192 µs
difference: 2.39537e-12
```
But with a size of (2, 3, 224, 224):
``` c++
// cpu
avg: -4.32392e-06
inference time: 777.195 ± 16.5298 µs
// cuda
avg: -379502
inference time: 4188.05 ± 267.693 µs
difference: nan
```

Thanks in advance for any help