### PR TITLE
[Fix] Same branches for inconsistent build check

### DIFF
--- a/dlib/test_for_odr_violations.h
+++ b/dlib/test_for_odr_violations.h
@@ -19,9 +19,6 @@ extern "C"
 #ifdef ENABLE_ASSERTS
     const extern int USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1;
     const int DLIB_NO_WARN_UNUSED dlib_check_assert_helper_variable = USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1;
-#else
-    const extern int USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1_;
-    const int DLIB_NO_WARN_UNUSED dlib_check_assert_helper_variable = USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1_;
 #endif
 
 


### PR DESCRIPTION
Inconsistent build configuration was checked regardless of ENABLE_ASSERTS.
It looks like an error, and dropping it helps with header only use.