### PR TITLE
Make dnn_trainer print the minibatch size to ostream

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1372,6 +1372,7 @@ namespace dlib
         out << "  get_train_one_step_calls():                 " << trainer.get_train_one_step_calls() << endl;
         out << "  synchronization file:                       " << trainer.get_synchronization_file() << endl;
         out << "  trainer.get_solvers()[0]:                   " << trainer.get_solvers()[0] << endl;
+        out << "  mini batch size:                            " << trainer.get_mini_batch_size() << endl;
         auto sched = trainer.get_learning_rate_schedule();
         if (sched.size() != 0)
         {


### PR DESCRIPTION
So, maybe this a bit controversial...

When I train networks, I like to fill all the fields of the `dnn_trainer` so that they all appear in my training log, and then access them from the trainer (`get_min_learning_rate()`, `get_mini_batch_size()`, etc...)
I found myself logging the minibatch-size manually many times, so finally I decided to make the `dnn_trainer` print it.

I was hesitating to submit this PR because, when you build your minibatches manually, and print the trainer to the screen, users might be surprised to see a `128` for the minibatch size (default value). But then I thought that it is already the case with the minimum learning rate, if you train with your own custom loop.

Anyway, feel free to reject it if you think it's not a good idea :)