### PR TITLE
Fix unused parameter warning in visitor_net_to_xml

### DIFF
--- a/dlib/dnn/utilities.h
+++ b/dlib/dnn/utilities.h
@@ -64,13 +64,13 @@ namespace dlib
             }
 
             template <unsigned long ID, typename U, typename E>
-            void operator()(size_t idx, const add_tag_layer<ID,U,E>& l) 
+            void operator()(size_t idx, const add_tag_layer<ID,U,E>& /*l*/) 
             {
                 out << "<layer idx='"<<idx<<"' type='tag' id='"<<ID<<"'/>\n";
             }
 
             template <template<typename> class T, typename U>
-            void operator()(size_t idx, const add_skip_layer<T,U>& l) 
+            void operator()(size_t idx, const add_skip_layer<T,U>& /*l*/) 
             {
                 out << "<layer idx='"<<idx<<"' type='skip' id='"<<(tag_id<T>::id)<<"'/>\n";
             }


### PR DESCRIPTION
Minor fix, but when compiling with `-Wall -Wextra -pedantic`, I got a really huge nested warning when converting big networks to xml.

EDIT: I hope I am not bothering you with all these tiny PR...