### PR TITLE
Add support for matrix serialization to python API

### DIFF
--- a/tools/python/src/matrix.cpp
+++ b/tools/python/src/matrix.cpp
@@ -108,6 +108,16 @@ long matrix_double__len__(matrix<double>& c)
     return c.nr();
 }
 
+void matrix_serialize(const matrix<double>& m, const std::string& file)
+{
+    serialize(file) << m;
+}
+
+void matrix_deserialize(matrix<double>& m, const std::string& file)
+{
+    deserialize(file) >> m;
+}
+
 struct mat_row
 {
     mat_row() : data(0),size(0) {}
@@ -202,6 +212,8 @@ void bind_matrix(py::module& m)
         .def("__str__", &matrix_double__str__)
         .def("nr", &matrix<double>::nr, "Return the number of rows in the matrix.")
         .def("nc", &matrix<double>::nc, "Return the number of columns in the matrix.")
+        .def("serialize", &matrix_serialize, py::arg("file"), "Serialize the matrix to a file")
+        .def("deserialize", &matrix_deserialize, py::arg("file"), "Deserialize the matrix from a file")
         .def("__len__", &matrix_double__len__)
         .def("__getitem__", &matrix_double__getitem__, py::keep_alive<0,1>())
         .def_property_readonly("shape", &get_matrix_size)

--- a/tools/python/src/matrix.cpp
+++ b/tools/python/src/matrix.cpp
@@ -108,12 +108,12 @@ long matrix_double__len__(matrix<double>& c)
     return c.nr();
 }
 
-void matrix_serialize(const matrix<double>& m, const std::string& file)
+void matrix_double_serialize(const matrix<double>& m, const std::string& file)
 {
     serialize(file) << m;
 }
 
-void matrix_deserialize(matrix<double>& m, const std::string& file)
+void matrix_double_deserialize(matrix<double>& m, const std::string& file)
 {
     deserialize(file) >> m;
 }
@@ -212,8 +212,8 @@ void bind_matrix(py::module& m)
         .def("__str__", &matrix_double__str__)
         .def("nr", &matrix<double>::nr, "Return the number of rows in the matrix.")
         .def("nc", &matrix<double>::nc, "Return the number of columns in the matrix.")
-        .def("serialize", &matrix_serialize, py::arg("file"), "Serialize the matrix to a file")
-        .def("deserialize", &matrix_deserialize, py::arg("file"), "Deserialize the matrix from a file")
+        .def("serialize", &matrix_double_serialize, py::arg("file"), "Serialize the matrix to a file")
+        .def("deserialize", &matrix_double_deserialize, py::arg("file"), "Deserialize the matrix from a file")
         .def("__len__", &matrix_double__len__)
         .def("__getitem__", &matrix_double__getitem__, py::keep_alive<0,1>())
         .def_property_readonly("shape", &get_matrix_size)


### PR DESCRIPTION
I've added serialization support for matrices (I know they are already pickable).

I was facing the following problem: I had to load some numpy arrays, but I wanted to work with them in C++. After looking online on how to load them, I realized that the easiest way was to make dlib do it for me:

``` python
import numpy as np
from dlib import matrix
# get a numpy array
arr = np.random.rand(10, 2)
# convert it to a dlib.matrix and serialize it to disk
matrix(arr).serialize("rand.dat")
# create a new matrix
m = matrix()
# deserialize the previous matrix into this one
m.deserialize("rand.dat")
```
The good thing is that now I can deserialize the `rand.dat` from C++.

Maybe there's a better way of doing it, but I think having this is pretty convenient.