### PR TITLE
Release GIL before detecting faces

### DIFF
--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -52,16 +52,21 @@ namespace dlib
         if (is_image<unsigned char>(img))
         {
             array2d<unsigned char> temp;
+            auto img_view = make_image_view(numpy_image<unsigned char>(img));
+
+            // Release the GIL so that this code can be run in parallel.
+            py::gil_scoped_release release;
+
             if (upsampling_amount == 0)
             {
-                detector(numpy_image<unsigned char>(img), rect_detections, adjust_threshold);
+                detector(img_view, rect_detections, adjust_threshold);
                 split_rect_detections(rect_detections, rectangles,
                                       detection_confidences, weight_indices);
                 return rectangles;
             }
             else
             {
-                pyramid_up(numpy_image<unsigned char>(img), temp, pyr);
+                pyramid_up(img_view, temp, pyr);
                 unsigned int levels = upsampling_amount-1;
                 while (levels > 0)
                 {
@@ -82,16 +87,21 @@ namespace dlib
         else if (is_image<rgb_pixel>(img))
         {
             array2d<rgb_pixel> temp;
+            auto img_view = make_image_view(numpy_image<rgb_pixel>(img));
+
+            // Release the GIL so that this code can be run in parallel.
+            py::gil_scoped_release release;
+
             if (upsampling_amount == 0)
             {
-                detector(numpy_image<rgb_pixel>(img), rect_detections, adjust_threshold);
+                detector(img_view, rect_detections, adjust_threshold);
                 split_rect_detections(rect_detections, rectangles,
                                       detection_confidences, weight_indices);
                 return rectangles;
             }
             else
             {
-                pyramid_up(numpy_image<rgb_pixel>(img), temp, pyr);
+                pyramid_up(img_view, temp, pyr);
                 unsigned int levels = upsampling_amount-1;
                 while (levels > 0)
                 {
@@ -202,9 +212,6 @@ namespace dlib
 
     )
     {
-        // Release the GIL so that this code can be run in parallel.
-        py::gil_scoped_release release;
-
         std::vector<double> detection_confidences;
         std::vector<unsigned long> weight_indices;
         const double adjust_threshold = 0.0;

--- a/tools/python/src/simple_object_detector_py.h
+++ b/tools/python/src/simple_object_detector_py.h
@@ -202,6 +202,9 @@ namespace dlib
 
     )
     {
+        // Release the GIL so that this code can be run in parallel.
+        py::gil_scoped_release release;
+
         std::vector<double> detection_confidences;
         std::vector<unsigned long> weight_indices;
         const double adjust_threshold = 0.0;


### PR DESCRIPTION
A small modification to release the GIL in the face_detector. Since the face_detector seemed to be single-threaded, I made this change. 

I wrote some simple code to benchmark:
```python
files = sys.argv[1:] * 16

def basic():
    detector = dlib.get_frontal_face_detector()
    for f in files:
        img = dlib.load_rgb_image(f)
        # The 1 in the second argument indicates that we should upsample the image
        # 1 time.  This will make everything bigger and allow us to detect more
        # faces.
        dets = detector(img, 1)

def threads(num_threads=8):
  file_chunks = np.array_split(np.asarray(files), num_threads)

  def work(files):
      detector = dlib.get_frontal_face_detector()

      for f in files:
          img = dlib.load_rgb_image(f)
          # The 1 in the second argument indicates that we should upsample the image
          # 1 time.  This will make everything bigger and allow us to detect more
          # faces.
          dets = detector(img, 1)

  threads = []
  for i in range(num_threads):
    threads.append(threading.Thread(target=work, args=(file_chunks[i],)))
    threads[-1].start()
  for thread in threads:
    thread.join()

import os; print(os.cpu_count())
num = 1
print("basic", timeit.timeit("basic()", number=num, globals=globals()))
print("threads", timeit.timeit("threads()", number=num, globals=globals()))
```

For the [image](https://github.com/davisking/dlib/blob/master/examples/faces/bald_guys.jpg) which is processed 16 times by the face detector, I get the following results:
```
basic 19.069416782
threads 5.340275335000001
```

(Note that, different numbers of threads provide different amount of speedups, this is run with the code above).