### PR TITLE
Fix build with clang on ppc64le

### DIFF
--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -524,7 +524,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-#ifndef vec_rsqrt
+#if defined(DLIB_HAVE_VSX) && !defined(vec_rsqrt)
     extern inline __vector float __attribute__((always_inline)) vec_rsqrt(const __vector float& a)
     { return vec_div((__vector float){1, 1, 1, 1}, vec_sqrt(a)); }
 #endif

--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -524,6 +524,11 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+#ifndef vec_rsqrt
+    extern inline __vector float __attribute__((always_inline)) vec_rsqrt(const __vector float& a)
+    { return vec_div((__vector float){1, 1, 1, 1}, vec_sqrt(a)); }
+#endif
+
     inline simd4f reciprocal_sqrt (const simd4f& item)
     {
 #ifdef DLIB_HAVE_SSE2


### PR DESCRIPTION
Clang doesn't implement vec_rsqrt.
Code taken from https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/vsx_utils.hpp#L360