### PR TITLE
fix find_min_global finding wrong answers

### DIFF
--- a/dlib/global_optimization/find_max_global.h
+++ b/dlib/global_optimization/find_max_global.h
@@ -161,6 +161,11 @@ template <typename T> static auto go(T&& f, const matrix<double, 0, 1>& a) -> de
             {
                 initial_function_evals.resize(specs.size());
             }
+            for (auto& evals : initial_function_evals) {
+              for (auto& eval  : evals) {
+                 eval.y *= ymult;
+              }
+            }
 
             global_function_search opt(specs, {initial_function_evals});
             opt.set_solver_epsilon(solver_epsilon);

--- a/dlib/global_optimization/find_max_global.h
+++ b/dlib/global_optimization/find_max_global.h
@@ -162,9 +162,9 @@ template <typename T> static auto go(T&& f, const matrix<double, 0, 1>& a) -> de
                 initial_function_evals.resize(specs.size());
             }
             for (auto& evals : initial_function_evals) {
-              for (auto& eval  : evals) {
-                 eval.y *= ymult;
-              }
+                for (auto& eval : evals) {
+                    eval.y *= ymult;
+                }
             }
 
             global_function_search opt(specs, {initial_function_evals});


### PR DESCRIPTION
Previously, find_min_global would produce wrong output when passed
a collection of initial evaluations because the solver expected the y values to
be multiplied by -1.  This fix does that when minimizing.

closes #2283