### PR TITLE
Add support for fused convolutions

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -108,6 +108,7 @@ namespace dlib
         void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
         void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
         void disable_bias() { use_bias = false; }
+        void enable_bias() { use_bias = true; }
         bool bias_is_disabled() const { return !use_bias; }
 
         inline dpoint map_input_to_output (
@@ -2390,6 +2391,12 @@ namespace dlib
                     tt::multiply_conv(true, data_grad, gradient_input, g);
             }
         }
+
+        alias_tensor_instance get_gamma() { return gamma(params, 0); };
+        alias_tensor_const_instance get_gamma() const { return gamma(params, 0); };
+
+        alias_tensor_instance get_beta() { return beta(params, gamma.size()); };
+        alias_tensor_const_instance get_beta() const { return beta(params, gamma.size()); };
 
         const tensor& get_layer_params() const { return empty_params; }
         tensor& get_layer_params() { return empty_params; }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2569,7 +2569,7 @@ namespace dlib
             }
 
             template <typename input_layer_type>
-            void operator()(size_t , input_layer_type& l) const
+            void operator()(size_t , input_layer_type& ) const
             {
                 // ignore other layers
             }
@@ -2587,6 +2587,7 @@ namespace dlib
         net_type& net
     )
     {
+        DLIB_CASSERT(count_parameters(net) > 0, "The network has to be allocated before fusing the convolutions.");
         visit_layers_backwards(net, impl::visitor_fuse_convolutions());
     }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2532,13 +2532,13 @@ namespace dlib
                 // set the new number of parameters for this convolution and enable bias if needed
                 const size_t num_params = num_filters_in * num_filters_out * num_rows * num_cols + num_filters_out;
                 resizable_tensor new_params(num_params);
+                std::copy(params.begin(), params.end(), new_params.begin());
                 alias_tensor filters(num_filters_out, num_filters_in, num_rows, num_cols);
                 alias_tensor biases(1, num_filters_out);
                 if (conv.bias_is_disabled())
                 {
                     conv.enable_bias();
                     new_params.set_size(num_params);
-                    std::copy(params.begin(), params.end(), new_params.begin());
                     biases(new_params, filters.size()) = 0;
                 }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2478,8 +2478,8 @@ namespace dlib
             else
                 out << "<affine_fc";
             if (item.is_disabled)
-                out << " disabled='"<<(item.is_disabled?"true":"false");
-            out << "'>\n";
+                out << " disabled='"<< std::boolalpha << item.is_disabled << "'";
+            out << ">\n";
             out << mat(item.params);
 
             if (item.mode==CONV_MODE)

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2540,6 +2540,7 @@ namespace dlib
                     DLIB_CASSERT(num_params == conv.params.size() + conv.num_filters());
                     conv.enable_bias();
                     conv.params.set_size(num_params);
+                    conv.biases = alias_tensor(1, conv.num_filters());
                     conv.biases(conv.params, conv.filters.size()) = 0;
                 }
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -115,8 +115,8 @@ namespace dlib
                 return;
             else
                 use_bias = true;
-            // setup biases if network has been allocated
-            if (params.size() > 0)
+            // setup biases if network has been allocated and it doesn't have bias
+            if (params.size() == filters.size())
             {
                 auto temp = params;
                 params.set_size(params.size() + num_filters_);

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2523,8 +2523,9 @@ namespace dlib
                 auto gamma = l.layer_details().get_gamma();
                 auto beta = l.layer_details().get_beta();
 
-                // get the convolution below the affine layer and its paramaters
+                // get the convolution below the affine layer
                 auto& conv = l.subnet().layer_details();
+
                 // guess the number of input channels
                 long k_in;
                 if (conv.bias_is_disabled())
@@ -2536,7 +2537,7 @@ namespace dlib
                 if (conv.bias_is_disabled())
                 {
                     const size_t num_params = k_in * conv.num_filters() * conv.nr() * conv.nc() + conv.num_filters();
-                    DLIB_CASSERT(conv.params.size() + conv.num_filters() == num_params);
+                    DLIB_CASSERT(num_params == conv.params.size() + conv.num_filters());
                     conv.enable_bias();
                     conv.params.set_size(num_params);
                     conv.biases(conv.params, conv.filters.size()) = 0;

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2498,6 +2498,98 @@ namespace dlib
     template <typename SUBNET>
     using affine = add_layer<affine_, SUBNET>;
 
+    namespace impl
+    {
+        class visitor_fuse_convolutions
+        {
+            public:
+            template <typename T> void fuse_convolutions(T&) const
+            {
+                // disable other layer types
+            }
+
+            // handle the standard case (convolutional layer followed by affine;
+            template <long nf, long nr, long nc, int sy, int sx, int py, int px, typename U, typename E>
+            void fuse_convolutions(add_layer<affine_, add_layer<con_<nf, nr, nc, sy, sx, py, px>, U>, E>& l)
+            {
+                // get the parameters from the affine layer as alias_tensor_instance
+                auto gamma = l.layer_details().get_gamma();
+                auto beta = l.layer_details().get_beta();
+
+                // get the convolution below the affine layer and its paramaters
+                auto& conv = l.subnet().layer_details();
+                const long num_filters_out = conv.num_filters();
+                const long num_rows = conv.nr();
+                const long num_cols = conv.nc();
+                tensor& params = conv.get_layer_params();
+                // guess the number of input filters
+                long num_filters_in;
+                if (conv.bias_is_disabled())
+                    num_filters_in = params.size() / num_filters_out / num_rows / num_cols;
+                else
+                    num_filters_in = (params.size() - num_filters_out) / num_filters_out / num_rows / num_cols;
+
+                // set the new number of parameters for this convolution and enable bias if needed
+                const size_t num_params = num_filters_in * num_filters_out * num_rows * num_cols + num_filters_out;
+                alias_tensor filters(num_filters_out, num_filters_in, num_rows, num_cols);
+                alias_tensor biases(1, num_filters_out);
+                if (conv.bias_is_disabled())
+                {
+                    conv.enable_bias();
+                    resizable_tensor new_params = params;
+                    new_params.set_size(num_params);
+                    biases(new_params, filters.size()) = 0;
+                    params = new_params;
+                }
+
+                // update the biases
+                auto b = biases(params, filters.size());
+                b+= mat(beta);
+
+                // rescale the filters
+                DLIB_CASSERT(filters.num_samples() == gamma.k());
+                auto t = filters(params, 0);
+                float* f = t.host();
+                const float* g = gamma.host();
+                for (long n = 0; n < filters.num_samples(); ++n)
+                {
+                    for (long k = 0; k < filters.k(); ++k)
+                    {
+                        for (long r = 0; r < filters.nr(); ++r)
+                        {
+                            for (long c = 0; c < filters.nc(); ++c)
+                            {
+                                f[tensor_index(t, n, k, r, c)] *= g[n];
+                            }
+                        }
+                    }
+                }
+                // disable the affine layer
+                l.layer_details().disable();
+            }
+
+            template <typename input_layer_type>
+            void operator()(size_t , input_layer_type& l) const
+            {
+                // ignore other layers
+            }
+
+            template <typename T, typename U, typename E>
+            void operator()(size_t , add_layer<T, U, E>& l)
+            {
+                fuse_convolutions(l);
+            }
+        };
+    }
+
+    template <typename net_type>
+    void fuse_convolutions(
+        net_type& net
+    )
+    {
+        visit_layers_backwards(net, impl::visitor_fuse_convolutions());
+    }
+
 // ----------------------------------------------------------------------------------------
 
     template <

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -113,7 +113,6 @@ namespace dlib
         void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
         void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
         void disable_bias() { use_bias = false; }
-        void enable_bias() { use_bias = true; }
         bool bias_is_disabled() const { return !use_bias; }
 
         inline dpoint map_input_to_output (
@@ -2538,7 +2537,7 @@ namespace dlib
                 {
                     const size_t num_params = k_in * conv.num_filters() * conv.nr() * conv.nc() + conv.num_filters();
                     DLIB_CASSERT(num_params == conv.params.size() + conv.num_filters());
-                    conv.enable_bias();
+                    conv.use_bias = true;
                     resizable_tensor filters = conv.params;
                     conv.params.set_size(num_params);
                     std::copy(filters.begin(), filters.end(), conv.params.begin());

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2539,7 +2539,9 @@ namespace dlib
                     const size_t num_params = k_in * conv.num_filters() * conv.nr() * conv.nc() + conv.num_filters();
                     DLIB_CASSERT(num_params == conv.params.size() + conv.num_filters());
                     conv.enable_bias();
+                    resizable_tensor filters = conv.params;
                     conv.params.set_size(num_params);
+                    std::copy(filters.begin(), filters.end(), conv.params.begin());
                     conv.biases = alias_tensor(1, conv.num_filters());
                     conv.biases(conv.params, conv.filters.size()) = 0;
                 }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -113,6 +113,7 @@ namespace dlib
         void set_bias_learning_rate_multiplier(double val) { bias_learning_rate_multiplier = val; }
         void set_bias_weight_decay_multiplier(double val)  { bias_weight_decay_multiplier  = val; }
         void disable_bias() { use_bias = false; }
+        void enable_bias() { use_bias = true; }
         bool bias_is_disabled() const { return !use_bias; }
 
         inline dpoint map_input_to_output (
@@ -2537,7 +2538,7 @@ namespace dlib
                 {
                     const size_t num_params = k_in * conv.num_filters() * conv.nr() * conv.nc() + conv.num_filters();
                     DLIB_CASSERT(num_params == conv.params.size() + conv.num_filters());
-                    conv.use_bias = true;
+                    conv.enable_bias();
                     resizable_tensor filters = conv.params;
                     conv.params.set_size(num_params);
                     std::copy(filters.begin(), filters.end(), conv.params.begin());

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1961,7 +1961,7 @@ namespace dlib
 
     template <typename net_type>
     void fuse_convolutions (
-        const net_type& net
+        net_type& net
     );
     /*!
         requires

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -926,6 +926,13 @@ namespace dlib
                 - bias_is_disabled() returns true
         !*/
 
+        void enable_bias(
+        );
+        /*!
+            ensures
+                - bias_is_disabled() returns false
+        !*/
+
         bool bias_is_disabled(
         ) const;
         /*!

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1967,6 +1967,7 @@ namespace dlib
         requires
             - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
               add_tag_layer.
+            - net has been properly allocated, that is: count_parameters(net) > 0.
         ensures
             - Disables all the affine_ layers that have a convolution as an input.
             - Updates the convolutions beneath the affine_ layers to produce the same output

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -931,7 +931,8 @@ namespace dlib
         /*!
             ensures
                 - bias_is_disabled() returns false
-                - if bias was disabled, it resizes the layer parameters to accommodate the biases
+                - if bias was disabled and not allocated, it resizes the layer parameters
+                  to accommodate the biases
                 - the biases are initialized to 0
         !*/
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -926,6 +926,13 @@ namespace dlib
                 - bias_is_disabled() returns true
         !*/
 
+        void enable_bias(
+        );
+        /*!
+            ensures
+                - bias_is_disabled() returns false
+        !*/
+
         bool bias_is_disabled(
         ) const;
         /*!
@@ -1897,6 +1904,30 @@ namespace dlib
         /*!
             ensures
                 - returns the mode of this layer, either CONV_MODE or FC_MODE.  
+        !*/
+
+        alias_tensor_instance get_gamma();
+        /*!
+            ensures
+                - returns the gamma that define the behavior of forward().
+        !*/
+
+        alias_tensor_const_instance get_gamma() const;
+        /*!
+            ensures
+                - returns the gamma that define the behavior of forward().
+        !*/
+
+        alias_tensor_instance get_beta();
+        /*!
+            ensures
+                - returns the beta that define the behavior of forward().
+        !*/
+
+        alias_tensor_const_instance get_beta() const;
+        /*!
+            ensures
+                - returns the beta that define the behavior of forward().
         !*/
 
         template <typename SUBNET> void setup (const SUBNET& sub);

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1906,6 +1906,14 @@ namespace dlib
                 - returns the mode of this layer, either CONV_MODE or FC_MODE.  
         !*/
 
+        void disable(
+        );
+        /*!
+            ensures
+                - sets the params.size() of this layer to 0.
+                - when forward_inplace and backward_inplace are called, they return immediately.
+        !*/
+
         alias_tensor_instance get_gamma();
         /*!
             ensures

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -926,13 +926,6 @@ namespace dlib
                 - bias_is_disabled() returns true
         !*/
 
-        void enable_bias(
-        );
-        /*!
-            ensures
-                - bias_is_disabled() returns false
-        !*/
-
         bool bias_is_disabled(
         ) const;
         /*!

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -931,6 +931,8 @@ namespace dlib
         /*!
             ensures
                 - bias_is_disabled() returns false
+                - if bias was disabled, it resizes the layer parameters to accommodate the biases
+                - the biases are initialized to 0
         !*/
 
         bool bias_is_disabled(

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1959,6 +1959,22 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <typename net_type>
+    void fuse_convolutions (
+        const net_type& net
+    );
+    /*!
+        requires
+            - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
+              add_tag_layer.
+        ensures
+            - Disables all the affine_ layers that have a convolution as an input.
+            - Updates the convolutions beneath the affine_ layers to produce the same output
+              as with the affine_ layers enabled.
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
     template <
         long _nr,
         long _nc,

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1909,25 +1909,25 @@ namespace dlib
         alias_tensor_instance get_gamma();
         /*!
             ensures
-                - returns the gamma that define the behavior of forward().
+                - returns the gamma parameter that defines the behavior of forward().
         !*/
 
         alias_tensor_const_instance get_gamma() const;
         /*!
             ensures
-                - returns the gamma that define the behavior of forward().
+                - returns the gamma parameter that defines the behavior of forward().
         !*/
 
         alias_tensor_instance get_beta();
         /*!
             ensures
-                - returns the beta that define the behavior of forward().
+                - returns the beta parameter that defines the behavior of forward().
         !*/
 
         alias_tensor_const_instance get_beta() const;
         /*!
             ensures
-                - returns the beta that define the behavior of forward().
+                - returns the beta parameter that defines the behavior of forward().
         !*/
 
         template <typename SUBNET> void setup (const SUBNET& sub);


### PR DESCRIPTION
I've been playing a bit with the idea of having fused convolutions (convolution + batch_norm) in dlib.
I think the first step would be to move all the operations that are done by the `affine_` layer into the convolution, that is, update the bias of the convolution and re-scale the filters.

This PR adds some helper methods that allow doing this. The next step could be adding a new layer that can be constructed from an `affine_` layer and it's a no-op, like the tag layers, or add a version of the affine layer that does nothing (just outputs its input, without copying or anything). How would you approach this?

Finally, here's an example that uses a visitor to update the convolutions that are below an affine layer.
It can be build from by putting the file into the examples folder and loading the pretrained resnet 50 from the [`dnn_introduction3_ex.cpp`](http://dlib.net/dnn_introduction3_ex.cpp.html). If we manage to make something interesting out of it, maybe it would be interesting to have this visitor, too.

``` cpp
#include "resnet.h"

#include <dlib/dnn.h>
#include <dlib/image_io.h>

using namespace std;
using namespace dlib;

class visitor_fuse_convolutions
{
    public:
    template <typename T> void fuse_convolutions(T&) const
    {
        // disable other layer types
    }

    // handle the standard case (convolutional layer followed by affine;
    template <long nf, long nr, long nc, int sy, int sx, int py, int px, typename U, typename E>
    void fuse_convolutions(add_layer<affine_, add_layer<con_<nf, nr, nc, sy, sx, py, px>, U>, E>& l)
    {
        // get the parameters from the affine layer as alias_tensor_instance
        auto gamma = l.layer_details().get_gamma();
        auto beta = l.layer_details().get_beta();

        // get the convolution below the affine layer and its paramaters
        auto& conv = l.subnet().layer_details();
        const long num_filters_out = conv.num_filters();
        const long num_rows = conv.nr();
        const long num_cols = conv.nc();
        tensor& params = conv.get_layer_params();
        // guess the number of input filters
        long num_filters_in;
        if (conv.bias_is_disabled())
            num_filters_in = params.size() / num_filters_out / num_rows / num_cols;
        else
            num_filters_in = (params.size() - num_filters_out) / num_filters_out / num_rows / num_cols;

        // set the new number of parameters for this convolution
        const size_t num_params = num_filters_in * num_filters_out * num_rows * num_cols + num_filters_out;
        alias_tensor filters(num_filters_out, num_filters_in, num_rows, num_cols);
        alias_tensor biases(1, num_filters_out);
        if (conv.bias_is_disabled())
        {
            conv.enable_bias();
            resizable_tensor new_params = params;
            new_params.set_size(num_params);
            biases(new_params, filters.size()) = 0;
            params = new_params;
        }

        // update the biases
        auto b = biases(params, filters.size());
        b+= mat(beta);

        // rescale the filters
        DLIB_CASSERT(filters.num_samples() == gamma.k());
        auto t = filters(params, 0);
        float* f = t.host();
        const float* g = gamma.host();
        for (long n = 0; n < filters.num_samples(); ++n)
        {
            for (long k = 0; k < filters.k(); ++k)
            {
                for (long r = 0; r < filters.nr(); ++r)
                {
                    for (long c = 0; c < filters.nc(); ++c)
                    {
                        f[tensor_index(t, n, k, r, c)] *= g[n];
                    }
                }
            }
        }

        // reset the affine layer
        gamma = 1;
        beta = 0;
    }

    template <typename input_layer_type>
    void operator()(size_t , input_layer_type& l) const
    {
        // ignore other layers
    }

    template <typename T, typename U, typename E>
    void operator()(size_t , add_layer<T, U, E>& l)
    {
        fuse_convolutions(l);
    }
};

int main(const int argc, const char** argv)
try
{
    resnet::infer_50 net1, net2;
    std::vector<std::string> labels;
    deserialize("resnet50_1000_imagenet_classifier.dnn") >> net1 >> labels;
    net2 = net1;
    matrix<rgb_pixel> image;
    load_image(image, "elephant.jpg");

    const auto& label1 = labels[net1(image)];
    const auto& out1 = net1.subnet().get_output();
    resizable_tensor probs(out1);
    tt::softmax(probs, out1);
    cout << "pred1: " << label1 << " (" << max(mat(probs)) << ")" << endl;


    // fuse the convolutions in the network
    dlib::visit_layers_backwards(net2, visitor_fuse_convolutions());
    const auto& label2 = labels[net2(image)];
    const auto& out2 = net2.subnet().get_output();
    tt::softmax(probs, out2);
    cout << "pred2: " << label2 << " (" << max(mat(probs)) << ")" << endl;

    cout << "max abs difference: " << max(abs(mat(out1) - mat(out2))) << endl;
    DLIB_CASSERT(max(abs(mat(out1) - mat(out2))) < 1e-2);
}
catch (const exception& e)
{
    cout << e.what() << endl;
    return EXIT_FAILURE;
}
```

output with this image (`elephant.jpg`):
![elephant](https://user-images.githubusercontent.com/1671644/106690392-12c24500-6615-11eb-95e3-1dcc13c7c3fb.jpg)

```
pred1: African_elephant (0.962677)
pred2: African_elephant (0.962623)
max abs difference: 0.00436211
```

UPDATE: make visitor more generic and show a results with a real image
