### PR TITLE
[SERIALIZATION] use std::shared_ptr<char> as a buffer

### DIFF
--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -2284,6 +2284,27 @@ namespace dlib
         }
         
         explicit proxy_serialize (
+            dlib::shared_buf<char>& buf
+        ) : fout_optional_owning_ptr(new vectorstream(buf)),
+            fout(*fout_optional_owning_ptr)
+        {
+        }
+        
+        explicit proxy_serialize (
+            dlib::shared_buf<int8_t>& buf
+        ) : fout_optional_owning_ptr(new vectorstream(buf)),
+            fout(*fout_optional_owning_ptr)
+        {
+        }
+        
+        explicit proxy_serialize (
+            dlib::shared_buf<uint8_t>& buf
+        ) : fout_optional_owning_ptr(new vectorstream(buf)),
+            fout(*fout_optional_owning_ptr)
+        {
+        }
+        
+        explicit proxy_serialize (
             std::ostream& ss
         ) : fout_optional_owning_ptr(nullptr),
             fout(ss)
@@ -2333,6 +2354,30 @@ namespace dlib
          
         explicit proxy_deserialize (
             std::vector<uint8_t>& buf
+        ) : fin_optional_owning_ptr(new vectorstream(buf)),
+            fin(*fin_optional_owning_ptr)   
+        {
+            init();
+        }
+        
+        explicit proxy_deserialize (
+            dlib::shared_buf<char>& buf
+        ) : fin_optional_owning_ptr(new vectorstream(buf)),
+            fin(*fin_optional_owning_ptr)   
+        {
+            init();
+        }
+        
+        explicit proxy_deserialize (
+            dlib::shared_buf<int8_t>& buf
+        ) : fin_optional_owning_ptr(new vectorstream(buf)),
+            fin(*fin_optional_owning_ptr)   
+        {
+            init();
+        }
+         
+        explicit proxy_deserialize (
+            dlib::shared_buf<uint8_t>& buf
         ) : fin_optional_owning_ptr(new vectorstream(buf)),
             fin(*fin_optional_owning_ptr)   
         {
@@ -2451,6 +2496,12 @@ namespace dlib
     { return proxy_serialize(buf); }
     inline proxy_serialize serialize(std::vector<uint8_t>& buf)
     { return proxy_serialize(buf); }
+    inline proxy_serialize serialize(dlib::shared_buf<char>& buf)
+    { return proxy_serialize(buf); }
+    inline proxy_serialize serialize(dlib::shared_buf<int8_t>& buf)
+    { return proxy_serialize(buf); }
+    inline proxy_serialize serialize(dlib::shared_buf<uint8_t>& buf)
+    { return proxy_serialize(buf); }
     inline proxy_deserialize deserialize(const std::string& filename)
     { return proxy_deserialize(filename); }
     inline proxy_deserialize deserialize(std::istream& ss)
@@ -2460,6 +2511,12 @@ namespace dlib
     inline proxy_deserialize deserialize(std::vector<int8_t>& buf)
     { return proxy_deserialize(buf); }
     inline proxy_deserialize deserialize(std::vector<uint8_t>& buf)
+    { return proxy_deserialize(buf); }
+    inline proxy_deserialize deserialize(dlib::shared_buf<char>& buf)
+    { return proxy_deserialize(buf); }
+    inline proxy_deserialize deserialize(dlib::shared_buf<int8_t>& buf)
+    { return proxy_deserialize(buf); }
+    inline proxy_deserialize deserialize(dlib::shared_buf<uint8_t>& buf)
     { return proxy_deserialize(buf); }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/test/serialize.cpp
+++ b/dlib/test/serialize.cpp
@@ -1231,10 +1231,110 @@ namespace
             DLIB_TEST(pointers_values_equal(uptr2, uptr4));
         }
         
-         {
+        {
             std::vector<int8_t> buf1;
             dlib::serialize(buf1) << t1 << t2 << v1 << uptr1 << uptr2;
             std::vector<uint8_t> buf2(buf1.begin(), buf1.end());
+            dlib::deserialize(buf2) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<char> buf;
+            dlib::serialize(buf) << t1 << t2 << v1 << uptr1 << uptr2;
+            dlib::deserialize(buf) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<int8_t> buf;
+            dlib::serialize(buf) << t1 << t2 << v1 << uptr1 << uptr2;
+            dlib::deserialize(buf) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<uint8_t> buf;
+            dlib::serialize(buf) << t1 << t2 << v1 << uptr1 << uptr2;
+            dlib::deserialize(buf) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<char> buf1;
+            dlib::serialize(buf1) << t1 << t2 << v1 << uptr1 << uptr2;
+            
+            dlib::shared_buf<int8_t> buf2;
+            buf2.insert(buf2.end(), buf1.begin(), buf1.end());
+            
+            dlib::deserialize(buf2) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<char> buf1;
+            dlib::serialize(buf1) << t1 << t2 << v1 << uptr1 << uptr2;
+            
+            dlib::shared_buf<uint8_t> buf2;
+            buf2.insert(buf2.end(), buf1.begin(), buf1.end());
+            
+            dlib::deserialize(buf2) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            dlib::shared_buf<int8_t> buf1;
+            dlib::serialize(buf1) << t1 << t2 << v1 << uptr1 << uptr2;
+            
+            dlib::shared_buf<uint8_t> buf2;
+            buf2.insert(buf2.end(), buf1.begin(), buf1.end());
+            
+            dlib::deserialize(buf2) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
+
+            DLIB_TEST(t1 == t3);
+            DLIB_TEST(t2 == t4);
+            DLIB_TEST(v1 == v2);
+            DLIB_TEST(pointers_values_equal(uptr1, uptr3));
+            DLIB_TEST(pointers_values_equal(uptr2, uptr4));
+        }
+        
+        {
+            std::vector<char> buf1;
+            dlib::serialize(buf1) << t1 << t2 << v1 << uptr1 << uptr2;
+            
+            dlib::shared_buf<uint8_t> buf2;
+            buf2.insert(buf2.end(), buf1.begin(), buf1.end());
+            
             dlib::deserialize(buf2) >> t3 >> t4 >> v2 >> uptr3 >> uptr4;
 
             DLIB_TEST(t1 == t3);

--- a/dlib/test/vectorstream.cpp
+++ b/dlib/test/vectorstream.cpp
@@ -22,8 +22,8 @@ namespace
 
     logger dlog("test.vectorstream");
           
-    template <typename CharType, typename stream>
-    void test1_variant(std::vector<CharType>& buf, stream& s)
+    template <typename VectorCharType, typename stream>
+    void test1_variant(VectorCharType& buf, stream& s)
     {
         for (int i = -1000; i <= 1000; ++i)
         {
@@ -198,6 +198,45 @@ namespace
         
         {
             vector<uint8_t> buf;
+            dlib::vectorstream s1(buf);
+            std::iostream& s2 = s1;
+            test1_variant(buf, s2);
+        }   
+        
+        {
+            dlib::shared_buf<char> buf;
+            vectorstream s1(buf);
+            test1_variant(buf, s1);
+        }
+        
+        {
+            dlib::shared_buf<char> buf;
+            dlib::vectorstream s1(buf);
+            std::iostream& s2 = s1;
+            test1_variant(buf, s2);
+        }   
+        
+        {
+            dlib::shared_buf<int8_t> buf;
+            vectorstream s1(buf);
+            test1_variant(buf, s1);
+        }
+        
+        {
+            dlib::shared_buf<int8_t> buf;
+            dlib::vectorstream s1(buf);
+            std::iostream& s2 = s1;
+            test1_variant(buf, s2);
+        }   
+        
+        {
+            dlib::shared_buf<uint8_t> buf;
+            vectorstream s1(buf);
+            test1_variant(buf, s1);
+        }
+        
+        {
+            dlib::shared_buf<uint8_t> buf;
             dlib::vectorstream s1(buf);
             std::iostream& s2 = s1;
             test1_variant(buf, s2);


### PR DESCRIPTION
This PR adds serialization support to and from ```std::shared_ptr<char>``` (and ```int8_t``` and ```uint8_t```). Now for most people, if they need to pass around ```std::shared_ptr<char>``` as a container for serialized data for whatever reason, they can just serialize to ```std::vector<char>``` then copy the data. Some people might argue they could do without the unecessary copy at the end. This PR addresses this. I haven't convinced myself that this is totally a good idea. It clutters ```dlib::vectorstream``` quite a bit and really ```std::shared_ptr``` is outside its scope. One could argue that another object similar to ```dlib::vectorstream``` would be more appropriate and could be generalized to support any "vector" like container, i.e. containers that satisfy a set of requirements, like has ```push_back```, has ```insert```, has ```size```, stuff like that. I don't know. These are all ideas. So please discuss. 
In my case, i need to pass around ```std::shared_ptr```, and ideally i would like to do without the copy at the end.