### PR TITLE
make mish activation an inplace layer

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -3331,24 +3331,19 @@ namespace dlib
         {
         }
 
-        template <typename SUBNET>
-        void forward(
-            const SUBNET& sub,
-            resizable_tensor& data_output
-        )
+        void forward_inplace(const tensor& input, tensor& output)
         {
-            data_output.copy_size(sub.get_output());
-            tt::mish(data_output, sub.get_output());
+            tt::mish(output, input);
         }
 
-        template <typename SUBNET>
-        void backward(
+        void backward_inplace(
+            const tensor& computed_output,
             const tensor& gradient_input,
-            SUBNET& sub,
+            tensor& data_grad,
             tensor&
         )
         {
-            tt::mish_gradient(sub.get_gradient_input(), sub.get_output(), gradient_input);
+            tt::mish_gradient(data_grad, computed_output, gradient_input);
         }
 
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -2402,8 +2402,8 @@ namespace dlib
         );
 
         template <typename SUBNET> void setup (const SUBNET& sub);
-        template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& data_output);
-        template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor&);
+        void forward_inplace(const tensor& input, tensor& output);
+        void backward_inplace(const tensor& computed_output, const tensor& gradient_input, tensor& data_grad, tensor& params_grad);
         dpoint map_input_to_output(dpoint p) const;
         dpoint map_output_to_input(dpoint p) const;
         const tensor& get_layer_params() const;


### PR DESCRIPTION
I noticed the the Mish layer, contrary to other activation layers, was not performing its computations inplace.

This PR fixes that. I didn't notice much of a speed gain, but on YOLOv4 the model uses around 200 MiB less of VRAM, so that's a win.

Also, I have a question about the `computed_output` parameter in the `backward_inplace` method: The documentation says that we can "_exclude the computed_output parameter from backward_inplace().  Doing this will allow dlib to make some layers execute in-place and therefore run a little faster and use less memory_".

I haven't seen any activation do that, only `dropout_`, `multiply_` and `affine_`. Is there a reason for that?