### PR TITLE
remove wrong inplace implementations

### DIFF
--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1678,16 +1678,8 @@ namespace dlib
                 return e*omega/(delta*delta);
             };
 
-            if (is_same_object(gradient_input, grad))
-            {
-                for (size_t i = 0; i < src.size(); ++i)
-                    g[i] = in[i]*calculate_gradient(s[i]);
-            }
-            else
-            {
-                for (size_t i = 0; i < src.size(); ++i)
-                    g[i] += in[i]*calculate_gradient(s[i]);
-            }
+            for (size_t i = 0; i < src.size(); ++i)
+                g[i] += in[i]*calculate_gradient(s[i]);
         }
 
     // ------------------------------------------------------------------------------------
@@ -1892,16 +1884,8 @@ namespace dlib
             const auto g = grad.host();
             const auto s = src.host();
             const auto in = gradient_input.host();
-            if (is_same_object(grad, gradient_input))
-            {
-                for (size_t i = 0; i < src.size(); ++i)
-                    g[i] = in[i]*compute_gradient(s[i]);
-            }
-            else
-            {
-                for (size_t i = 0; i < src.size(); ++i)
-                    g[i] += in[i]*compute_gradient(s[i]);
-            }
+            for (size_t i = 0; i < src.size(); ++i)
+                g[i] += in[i]*compute_gradient(s[i]);
         }
 
     // ----------------------------------------------------------------------------------------

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -1454,12 +1454,6 @@ namespace dlib
             return e*omega/(delta*delta);
         }
 
-        __global__ void _cuda_mish_gradient_inplace(float* out, const float* s, const float* gi, size_t n)
-        {
-            for (auto i : grid_stride_range(0, n))
-                out[i] = gi[i]*mish_compute_gradient(s[i]);
-        }
-
         __global__ void _cuda_mish_gradient(float* out, const float* s, const float* gi, size_t n)
         {
             for (auto i : grid_stride_range(0, n))
@@ -1474,10 +1468,7 @@ namespace dlib
         {
             float* out = grad.device();
             const float* gi = gradient_input.device();
-            if (out == gi)
-                launch_kernel(_cuda_mish_gradient_inplace, max_jobs(grad.size()), out, src.device(), gi, grad.size());
-            else
-                launch_kernel(_cuda_mish_gradient, max_jobs(grad.size()), out, src.device(), gi, grad.size());
+            launch_kernel(_cuda_mish_gradient, max_jobs(grad.size()), out, src.device(), gi, grad.size());
         }
 
     // ----------------------------------------------------------------------------------------
@@ -1508,12 +1499,6 @@ namespace dlib
                 return cdf + x * pdf;
         }
 
-        __global__ void _cuda_gelu_gradient_inplace(float* out, const float* s, const float* gi, size_t n)
-        {
-            for (auto i : grid_stride_range(0, n))
-                out[i] = gi[i]*gelu_compute_gradient(s[i]);
-        }
-
         __global__ void _cuda_gelu_gradient(float* out, const float* s, const float* gi, size_t n)
         {
             for (auto i : grid_stride_range(0, n))
@@ -1528,10 +1513,7 @@ namespace dlib
         {
             float* out = grad.device();
             const float* gi = gradient_input.device();
-            if (out == gi)
-                launch_kernel(_cuda_gelu_gradient_inplace, max_jobs(grad.size()), out, src.device(), gi, grad.size());
-            else
-                launch_kernel(_cuda_gelu_gradient, max_jobs(grad.size()), out, src.device(), gi, grad.size());
+            launch_kernel(_cuda_gelu_gradient, max_jobs(grad.size()), out, src.device(), gi, grad.size());
         }
 
     // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
If I understood it correctly in #2312, there are some layers that have inplace implementations that are wrong.
Because of the nature of the functions, they can't be implemented inplace. This PR removes those functions.