### PR TITLE
Add letterbox image

### DIFF
--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -996,13 +996,11 @@ namespace dlib
         image_type temp;
         image_view<image_type> vtemp(temp);
         vtemp.set_size(std::round(scale * vimg_in.nr()), std::round(scale * vimg_in.nc()));
-        resize_image(vimg_in, temp);
         dpoint offset((size - vtemp.nc()) / 2.0, (size - vtemp.nr()) / 2.0);
-        const auto tform = point_transform_affine(identity_matrix<double>(2) * scale, offset);
         const auto r = rectangle(offset.x(), offset.y(), offset.x() + vtemp.nc() - 1, offset.y() + vtemp.nr() - 1);
         auto si = sub_image(img_out, r);
-        assign_image(si, vtemp);
-        return tform;
+        resize_image(vimg_in, si);
+        return point_transform_affine(identity_matrix<double>(2) * scale, offset);
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -967,6 +967,46 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <typename image_type>
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out,
+        long size
+    )
+    {
+        DLIB_CASSERT(size > 0, "size must be bigger than zero, but was " << size);
+        // the scaling factor of the image
+        const auto scale = size / std::max<double>(img_in.nr(), img_in.nc());
+
+        // early return if the image has already the requested size and no padding is needed
+        if (scale == 1 and img_in.nr() == img_in.nc())
+        {
+            img_out = img_in;
+            return point_transform_affine();
+        }
+
+        // black background
+        img_out.set_size(size, size);
+        assign_all_pixels(img_out, 0);
+
+        // resize the image so that it fits into a size x size image
+        image_type temp = img_in;
+        resize_image(scale, temp);
+
+        // get the row and column offsets (the padding size)
+        const point offset((size - temp.nc()) / 2, (size - temp.nr()) / 2);
+        for (long r = 0; r < temp.nr(); ++r)
+        {
+            for (long c = 0; c < temp.nc(); ++c)
+            {
+                img_out(offset.y() + r, offset.x() + c) = temp(r, c);
+            }
+        }
+        return point_transform_affine(identity_matrix<double>(2) * scale, offset);
+    }
+
+// ----------------------------------------------------------------------------------------
+
     template <
         typename image_type1,
         typename image_type2

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -979,7 +979,7 @@ namespace dlib
         const auto scale = size / std::max<double>(img_in.nr(), img_in.nc());
 
         // early return if the image has already the requested size and no padding is needed
-        if (scale == 1 and img_in.nr() == img_in.nc())
+        if (scale == 1 && img_in.nr() == img_in.nc())
         {
             img_out = img_in;
             return point_transform_affine();

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -967,11 +967,15 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <typename image_type>
+    template <
+        typename image_type,
+        typename interpolation_type
+        >
     point_transform_affine letterbox_image (
         const image_type& img_in,
         image_type& img_out,
-        long size
+        long size,
+        const interpolation_type& interp
     )
     {
         DLIB_CASSERT(size > 0, "size must be bigger than zero, but was " << size);
@@ -999,8 +1003,31 @@ namespace dlib
         dpoint offset((size - vtemp.nc()) / 2.0, (size - vtemp.nr()) / 2.0);
         const auto r = rectangle(offset.x(), offset.y(), offset.x() + vtemp.nc() - 1, offset.y() + vtemp.nr() - 1);
         auto si = sub_image(img_out, r);
-        resize_image(vimg_in, si);
+        resize_image(vimg_in, si, interp);
         return point_transform_affine(identity_matrix<double>(2) * scale, offset);
+    }
+
+    template <
+        typename image_type
+        >
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out,
+        long size
+    )
+    {
+        return letterbox_image(img_in, img_out, size, interpolate_bilinear());
+    }
+
+    template <
+        typename image_type
+        >
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out
+    )
+    {
+        return letterbox_image(img_in, img_out, std::max(num_rows(img_in), num_columns(img_in)), interpolate_bilinear());
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -968,19 +968,20 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <
-        typename image_type,
+        typename image_type1,
+        typename image_type2,
         typename interpolation_type
         >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out,
+        const image_type1& img_in,
+        image_type2& img_out,
         long size,
         const interpolation_type& interp
     )
     {
         DLIB_CASSERT(size > 0, "size must be bigger than zero, but was " << size);
-        const_image_view<image_type> vimg_in(img_in);
-        image_view<image_type> vimg_out(img_out);
+        const_image_view<image_type1> vimg_in(img_in);
+        image_view<image_type2> vimg_out(img_out);
 
         const auto scale = size / std::max<double>(vimg_in.nr(), vimg_in.nc());
 
@@ -1004,11 +1005,12 @@ namespace dlib
     }
 
     template <
-        typename image_type
+        typename image_type1,
+        typename image_type2
         >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out,
+        const image_type1& img_in,
+        image_type2& img_out,
         long size
     )
     {
@@ -1016,11 +1018,12 @@ namespace dlib
     }
 
     template <
-        typename image_type
+        typename image_type1,
+        typename image_type2
         >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out
+        const image_type1& img_in,
+        image_type2& img_out
     )
     {
         return letterbox_image(img_in, img_out, std::max(num_rows(img_in), num_columns(img_in)), interpolate_bilinear());

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -982,7 +982,6 @@ namespace dlib
         const_image_view<image_type> vimg_in(img_in);
         image_view<image_type> vimg_out(img_out);
 
-        // the scaling factor of the image
         const auto scale = size / std::max<double>(vimg_in.nr(), vimg_in.nc());
 
         // early return if the image has already the requested size and no padding is needed
@@ -992,16 +991,13 @@ namespace dlib
             return point_transform_affine();
         }
 
-        // black background
         vimg_out.set_size(size, size);
-        assign_all_pixels(vimg_out, 0);
 
-        // resize the image so that it fits into a size x size image
-        image_type temp;
-        image_view<image_type> vtemp(temp);
-        vtemp.set_size(std::round(scale * vimg_in.nr()), std::round(scale * vimg_in.nc()));
-        dpoint offset((size - vtemp.nc()) / 2.0, (size - vtemp.nr()) / 2.0);
-        const auto r = rectangle(offset.x(), offset.y(), offset.x() + vtemp.nc() - 1, offset.y() + vtemp.nr() - 1);
+        const long nr = std::round(scale * vimg_in.nr());
+        const long nc = std::round(scale * vimg_in.nc());
+        dpoint offset((size - nc) / 2.0, (size - nr) / 2.0);
+        const auto r = rectangle(offset.x(), offset.y(), offset.x() + nc - 1, offset.y() + nr - 1);
+        zero_border_pixels(vimg_out, r);
         auto si = sub_image(img_out, r);
         resize_image(vimg_in, si, interp);
         return point_transform_affine(identity_matrix<double>(2) * scale, offset);

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -439,18 +439,21 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <
-        typename image_type,
+        typename image_type1,
+        typename image_type2,
         typename interpolation_type
         >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out,
+        const image_type1& img_in,
+        image_type2& img_out,
         long size
         const interpolation_type interp
     );
     /*!
         requires
-            - image_type == an image object that implements the interface defined in
+            - image_type1 == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - image_type2 == an image object that implements the interface defined in
               dlib/image_processing/generic_image.h
             - interpolation_type == interpolate_nearest_neighbor, interpolate_bilinear,
               interpolate_quadratic, or a type with a compatible interface.
@@ -465,15 +468,20 @@ namespace dlib
               corresponding location in #out_img.
     !*/
 
-    template <typename image_type>
+    template <
+        typename image_type1,
+        typename image_type2
+        >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out,
+        const image_type1& img_in,
+        image_type2& img_out,
         long size
     );
     /*!
         requires
-            - image_type == an image object that implements the interface defined in
+            - image_type1 == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - image_type2 == an image object that implements the interface defined in
               dlib/image_processing/generic_image.h
             - size > 0
             - is_same_object(in_img, out_img) == false
@@ -486,14 +494,19 @@ namespace dlib
               corresponding location in #out_img.
     !*/
 
-    template <typename image_type>
+    template <
+        typename image_type1,
+        typename image_type2
+        >
     point_transform_affine letterbox_image (
-        const image_type& img_in,
-        image_type& img_out
+        const image_type1& img_in,
+        image_type2& img_out
     );
     /*!
         requires
-            - image_type == an image object that implements the interface defined in
+            - image_type1 == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - image_type2 == an image object that implements the interface defined in
               dlib/image_processing/generic_image.h
             - is_same_object(in_img, out_img) == false
         ensures

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -438,6 +438,33 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <
+        typename image_type,
+        typename interpolation_type
+        >
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out,
+        long size
+        const interpolation_type interp
+    );
+    /*!
+        requires
+            - image_type == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - interpolation_type == interpolate_nearest_neighbor, interpolate_bilinear,
+              interpolate_quadratic, or a type with a compatible interface.
+            - size > 0
+            - is_same_object(in_img, out_img) == false
+        ensures
+            - scales in_img so that it fits into a size * size square.
+            - preserves the aspect ratio of in_img by 0-padding the shortest side.
+            - uses the supplied interpolation routine interp to perform the necessary
+              pixel interpolation.
+            - returns a transformation object that maps points in in_img into their
+              corresponding location in #out_img.
+    !*/
+
     template <typename image_type>
     point_transform_affine letterbox_image (
         const image_type& img_in,
@@ -446,10 +473,32 @@ namespace dlib
     );
     /*!
         requires
+            - image_type == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
             - size > 0
+            - is_same_object(in_img, out_img) == false
         ensures
-            - scales #image so that it fits into a #size * #size square
-            - it preserves the aspect ratio of the #image by 0-padding the shortest side
+            - scales in_img so that it fits into a size * size square.
+            - preserves the aspect ratio of in_img by 0-padding the shortest side.
+            - uses the bilinear interpolation to perform the necessary pixel
+              interpolation.
+            - returns a transformation object that maps points in in_img into their
+              corresponding location in #out_img.
+    !*/
+
+    template <typename image_type>
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out
+    );
+    /*!
+        requires
+            - image_type == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - is_same_object(in_img, out_img) == false
+        ensures
+            - 0-pads in_img so that it fits into a square whose side is computed as
+              max(num_rows(in_img), num_columns(in_img)) and stores into #out_img.
             - returns a transformation object that maps points in in_img into their
               corresponding location in #out_img.
     !*/

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -460,11 +460,14 @@ namespace dlib
             - size > 0
             - is_same_object(in_img, out_img) == false
         ensures
-            - scales in_img so that it fits into a size * size square.
-            - preserves the aspect ratio of in_img by 0-padding the shortest side.
-            - uses the supplied interpolation routine interp to perform the necessary
+            - Scales in_img so that it fits into a size * size square.
+              In particular, we will have:
+                - #img_out.nr() == size
+                - #img_out.nc() == size
+            - Preserves the aspect ratio of in_img by 0-padding the shortest side.
+            - Uses the supplied interpolation routine interp to perform the necessary
               pixel interpolation.
-            - returns a transformation object that maps points in in_img into their
+            - Returns a transformation object that maps points in in_img into their
               corresponding location in #out_img.
     !*/
 
@@ -486,11 +489,14 @@ namespace dlib
             - size > 0
             - is_same_object(in_img, out_img) == false
         ensures
-            - scales in_img so that it fits into a size * size square.
-            - preserves the aspect ratio of in_img by 0-padding the shortest side.
-            - uses the bilinear interpolation to perform the necessary pixel
+            - Scales in_img so that it fits into a size * size square.
+              In particular, we will have:
+                - #img_out.nr() == size
+                - #img_out.nc() == size
+            - Preserves the aspect ratio of in_img by 0-padding the shortest side.
+            - Uses the bilinear interpolation to perform the necessary pixel
               interpolation.
-            - returns a transformation object that maps points in in_img into their
+            - Returns a transformation object that maps points in in_img into their
               corresponding location in #out_img.
     !*/
 
@@ -512,7 +518,10 @@ namespace dlib
         ensures
             - 0-pads in_img so that it fits into a square whose side is computed as
               max(num_rows(in_img), num_columns(in_img)) and stores into #out_img.
-            - returns a transformation object that maps points in in_img into their
+              In particular, we will have:
+                - #img_out.nr() == max(num_rows(in_img), num_columns(in_img))
+                - #img_out.nc() == max(num_rows(in_img), num_columns(in_img))
+            - Returns a transformation object that maps points in in_img into their
               corresponding location in #out_img.
     !*/
 

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -438,6 +438,24 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <typename image_type>
+    point_transform_affine letterbox_image (
+        const image_type& img_in,
+        image_type& img_out,
+        long size
+    );
+    /*!
+        requires
+            - size > 0
+        ensures
+            - scales #image so that it fits into a #size * #size square
+            - it preserves the aspect ratio of the #image by padding the shortest side
+            - returns a transformation object that maps points in in_img into their
+              corresponding location in #out_img.
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
     template <
         typename image_type1,
         typename image_type2

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -449,7 +449,7 @@ namespace dlib
             - size > 0
         ensures
             - scales #image so that it fits into a #size * #size square
-            - it preserves the aspect ratio of the #image by padding the shortest side
+            - it preserves the aspect ratio of the #image by 0-padding the shortest side
             - returns a transformation object that maps points in in_img into their
               corresponding location in #out_img.
     !*/

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -2278,7 +2278,6 @@ namespace
         auto si = sub_image(img_t, r);
         assign_image(si, img_w);
         DLIB_TEST(img_d == img_t);
-
     }
 
     void test_draw_string()

--- a/dlib/test/image.cpp
+++ b/dlib/test/image.cpp
@@ -2257,6 +2257,30 @@ namespace
         }
     }
 
+    void test_letterbox_image()
+    {
+        print_spinner();
+        rgb_pixel black(0, 0, 0);
+        rgb_pixel white(255, 255, 255);
+        matrix<rgb_pixel> img_s(40, 60);
+        matrix<rgb_pixel> img_d;
+        assign_all_pixels(img_s, white);
+        const auto tform = letterbox_image(img_s, img_d, 30, interpolate_nearest_neighbor());
+        DLIB_TEST(tform.get_m() == identity_matrix<double>(2) * 0.5);
+        DLIB_TEST(tform.get_b() == dpoint(0, 5));
+
+        // manually generate the target image
+        matrix<rgb_pixel> img_t(30, 30);
+        assign_all_pixels(img_t, rgb_pixel(0, 0, 0));
+        matrix<rgb_pixel> img_w(20, 30);
+        assign_all_pixels(img_w, rgb_pixel(255, 255, 255));
+        rectangle r (0, 5, 30 - 1, 25 - 1);
+        auto si = sub_image(img_t, r);
+        assign_image(si, img_w);
+        DLIB_TEST(img_d == img_t);
+
+    }
+
     void test_draw_string()
     {
         print_spinner();
@@ -2386,6 +2410,7 @@ namespace
             test_null_rotate_image_with_interpolation();
             test_null_rotate_image_with_interpolation_quadratic();
             test_interpolate_bilinear();
+            test_letterbox_image();
             test_draw_string();
         }
     } a;


### PR DESCRIPTION
Would you be interested in this kind of image transformation?
I have some doubts about this implementation:
- it's named `letterbox_image` but it also scales the image to fit a square of `size` × `size`
- I did this because it's the more common case and the user can always set it to `std::max(img_in.nr(), img_in.nc())`
- but maybe there should be an overload?

I have the (long term) goal of implementing YOLO training in dlib at some point in my life... This would come in handy, since YOLO trains with square images, and this would allow to convert the bounding boxes between the original and the letterboxed images.
I've already tried it locally initializing a `rectangle_transform` with the output of this function, and it's pretty convenient.