### PR TITLE
Automatically build and publish binary wheels upon release

### DIFF
--- a/.github/workflows/build_python_wheels.yaml
+++ b/.github/workflows/build_python_wheels.yaml
@@ -1,0 +1,38 @@
+name: Build python wheels
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.10.0
+        env:
+          CIBW_BEFORE_BUILD: 'pip install cmake'
+          CIBW_BUILD: 'cp37-* cp38-* cp39-*'
+          CIBW_ARCHS: auto64
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          skip_existing: true

--- a/.github/workflows/build_python_wheels.yaml
+++ b/.github/workflows/build_python_wheels.yaml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Python
+      - name: Setup python
         uses: actions/setup-python@v2
 
       - name: Build wheels
@@ -27,11 +27,24 @@ jobs:
           CIBW_BUILD: 'cp37-* cp38-* cp39-*'
           CIBW_ARCHS: auto64
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
 
-      - uses: pypa/gh-action-pypi-publish@master
+  publish_on_pypi:
+    name: "Publish on pypi.org"
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish wheels
+        uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Hi,
with this pull request I propose to leverage the Github Actions service to automatically build binary wheels and publish them to pypi.org. This is useful for people that might want to try dlib without the burden of compiling the project from scratch.

The jobs defined in the yaml file compile dlib for linux, macOS and windows operating systems on amd64 architecture, and  other os/architectures may be easily added afterwards (e.g. linux and macOS on arm64).

The linux wheels are fully [manylinux2010](https://www.python.org/dev/peps/pep-0571/) compliant, thus they can be installed on almost every linux distro released in the past 10 years.

The jobs are automatically triggered upon every GitHub release, but there is also the option to trigger them manually at any commit if needed.

Here you can find an [example of run](https://github.com/alesanfra/dlib/actions/runs/702756170) tested on the forked repo. Of course the "publish to pypi.org" step failed because I didn't set the proper pypi.org credentials. If this PR is merged in order to have working upload to pypi.org the administrator of this repo must add the PYPI_PASSWORD to the[ repo secrets](https://docs.github.com/en/actions/reference/encrypted-secrets).

The wheels are built with the default flags, so they require GUI support to work; we can discuss whether it makes sense to set DLIB_NO_GUI_SUPPORT=ON or not.

As a final note, I'm also the maintainer of [dlib-bin](https://pypi.org/project/dlib-bin/) package, which is just a binary distribution of dlib similar to what I'm proposing to build here. If you want to take a look to the repo to get an idea on how it works this is the repo: https://github.com/alesanfra/dlib-wheels .

Hope this will help the project, I'm available for questions and comments. 