### PR TITLE
Make clipped-relu inplace and fix docs for elu

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -3479,24 +3479,19 @@ namespace dlib
         {
         }
 
-        template <typename SUBNET>
-        void forward(
-            SUBNET& sub,
-            resizable_tensor& data_output
-        )
+        void forward_inplace(const tensor& input, tensor& output)
         {
-            data_output.copy_size(sub.get_output());
-            tt::clipped_relu(data_output, sub.get_output(), ceiling);
+            tt::clipped_relu(output, input, ceiling);
         }
 
-        template <typename SUBNET>
-        void backward(
+        void backward_inplace(
+            const tensor& computed_output,
             const tensor& gradient_input,
-            SUBNET& sub,
+            tensor& data_grad,
             tensor&
         )
         {
-            tt::clipped_relu_gradient(sub.get_gradient_input(), sub.get_output(), gradient_input, ceiling);
+            tt::clipped_relu_gradient(data_grad, computed_output, gradient_input, ceiling);
         }
 
         inline dpoint map_input_to_output (const dpoint& p) const { return p; }

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -2537,8 +2537,8 @@ namespace dlib
                 - returns the alpha parameter of the elu
         !*/
         template <typename SUBNET> void setup (const SUBNET& sub);
-        void forward_inplace(const tensor& input, tensor& output);
-        void backward_inplace(const tensor& computed_output, const tensor& gradient_input, tensor& data_grad, tensor& params_grad);
+        template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& data_output);
+        template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor&);
         dpoint map_input_to_output(dpoint p) const;
         dpoint map_output_to_input(dpoint p) const;
         const tensor& get_layer_params() const;


### PR DESCRIPTION
I just noticed that in #2285 I didn't implement the `clipped_relu` layer as an in place layer, so this PR fixes that.
Also, the documentation for `clipped_relu` and `elu` was lying about their in place behavior, so I fixed that, as well.

Sorry for missing it in the first PR... :(