### PR TITLE
replace a unicode character to suppress warnings

### DIFF
--- a/dlib/image_transforms/morphological_operations.h
+++ b/dlib/image_transforms/morphological_operations.h
@@ -758,7 +758,7 @@ namespace dlib
     {
         /*
             The implementation of this function is based on the paper
-            "A fast parallel algorithm for thinning digital patterns” by T.Y. Zhang and C.Y. Suen.
+            "A fast parallel algorithm for thinning digital patterns" by T.Y. Zhang and C.Y. Suen.
             and also the excellent discussion of it at:
             http://opencv-code.com/quick-tips/implementation-of-thinning-algorithm-in-opencv/
         */


### PR DESCRIPTION
Hi, I replaced a quote character in the comments of image_transforms/morphological_operations.h,
such that when compiling on Windows, it does not complain of file containing unicode character which is not in current codepage.

It is annoying because this warning pops up for every file compiled that includes this file.