### PR TITLE
do not attempt to build with gcc 4.8.5 or older

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -58,6 +58,7 @@ if(has_parent)
    endif()
 endif()
 
+# As of dlib 19.22, GCC 4.8.5 is no longer supported, building will fail, so let users know.
 if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 4.8.5)
     message(FATAL_ERROR "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_VERSION} is too old for dlib ${VERSION}.\n\
     Either update your compiler to be fully compliant with C++11 or build an older version of dlib, such as 19.21.")

--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -58,6 +58,11 @@ if(has_parent)
    endif()
 endif()
 
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 4.8.5)
+    message(FATAL_ERROR "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_VERSION} is too old for dlib ${VERSION}.\n\
+    Either update your compiler to be fully compliant with C++11 or build an older version of dlib, such as 19.21.")
+endif()
+
 if (COMMAND pybind11_add_module AND MSVC)
    # True when building a python extension module using Visual Studio.  We care
    # about this because a huge number of windows users have broken systems, and


### PR DESCRIPTION
As seen in #2353 and #2354, CentOS 7 ships with gcc 4.8.5, which is no longer supported in dlib since v19.22.

I think rejecting to build with that GCC version and pointing the users to an older version of dlib might be useful.