### PR TITLE
Fix disable_duplicative_biases when the input is a skip layer

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1768,12 +1768,12 @@ namespace dlib
             }
 
             // handle skip layer case
-            template <layer_mode mode, template <typename> class TAG, typename E, typename U>
+            template <layer_mode mode, template <typename> class TAG, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, add_skip_layer<TAG, U>, E>& )
             {
             }
 
-            template <unsigned long ID, template <typename> class TAG, typename E, typename U>
+            template <template <typename> class TAG, typename U, typename E>
             void disable_input_bias(add_layer<layer_norm_, add_skip_layer<TAG, U>, E>& )
             {
             }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1767,6 +1767,17 @@ namespace dlib
             {
             }
 
+            // handle skip layer case
+            template <layer_mode mode, template <typename> class TAG, typename E, typename U>
+            void disable_input_bias(add_layer<bn_<mode>, add_skip_layer<TAG, U>, E>& )
+            {
+            }
+
+            template <unsigned long ID, template <typename> class TAG, typename E, typename U>
+            void disable_input_bias(add_layer<layer_norm_, add_skip_layer<TAG, U>, E>& )
+            {
+            }
+
             template<typename input_layer_type>
             void operator()(size_t , input_layer_type& ) const
             {


### PR DESCRIPTION
In [my implementation](https://github.com/dlib-users/dnn/blob/master/src/classification/repvgg.h) of the [RepVGG](https://arxiv.org/abs/2101.03697) network family, I was getting a compile error when running `disable_duplicative_biases`.
The case where a normalization layer has a skip layer as an input was not handled.