### PR TITLE
Fix running gradient crashing sometimes

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1121,7 +1121,7 @@ namespace dlib
             }
 
             // if we haven't seen much data yet then just say false.
-            if (gradient_updates_since_last_sync < 30)
+            if (previous_loss_values_to_keep_until_disk_sync.size() < 30)
                 return false;
 
             // if the loss is very likely to be increasing then return true

--- a/dlib/statistics/running_gradient.h
+++ b/dlib/statistics/running_gradient.h
@@ -270,6 +270,9 @@ namespace dlib
         double quantile_discard = 0.10
     )
     {
+        if (container.size() == 0)
+            return 0;
+
         const auto quantile_thresh = find_upper_quantile(container, quantile_discard); 
         running_gradient g;
         for (auto x : container)

--- a/dlib/statistics/running_gradient.h
+++ b/dlib/statistics/running_gradient.h
@@ -270,9 +270,6 @@ namespace dlib
         double quantile_discard = 0.10
     )
     {
-        if (container.size() == 0)
-            return 0;
-
         const auto quantile_thresh = find_upper_quantile(container, quantile_discard); 
         running_gradient g;
         for (auto x : container)


### PR DESCRIPTION
I've been experimenting a crash when I change the learning rate scheduler in the trainer:

```
step#: 1967  learning rate: 0.000933682  average loss: 10.9136      percent complete: 98.35%
burn-in finished

**************************** FATAL ERROR DETECTED ****************************

Error detected at line 234.
Error detected in file ../../external/dlib/dlib/../dlib/dnn/../statistics/running_gradient.h.
Error detected in function double dlib::find_upper_quantile(const T&, double) [with T = std::deque<double>].

Failing expression was container.size() > 0.


******************************************************************************
```

Relevant part of the code:
``` c++
std::cout << "burn-in finished" << std::endl;
trainer.get_net(dlib::force_flush_to_disk::no);
trainer.set_learning_rate(1e-3);
trainer.set_min_learning_rate(1e-6);
trainer.set_learning_rate_shrink_factor(0.1);
trainer.set_iterations_without_progress_threshold(10000); // the next line does not execute
trainer.get_net();
std::cout << trainer << std::endl;
```

Maybe I am doing something wrong (the training is running on multiple GPUs, that's why I do the `get_net` stuff).
Anyway, adding that condition fixes the crash.