### PR TITLE
Add function to compute string dimensions in pixels

### DIFF
--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -227,33 +227,33 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    struct string_dims
+    {
+        string_dims() = default;
+        string_dims (
+            unsigned long width,
+            unsigned long height
+        ) : width(width), height(height) {}
+        unsigned long width = 0;
+        unsigned long height = 0;
+    };
+
     template <
         typename T, typename traits,
         typename alloc
     >
-    std::pair<long, long> compute_string_dimensions (
+    string_dims compute_string_dims (
         const std::basic_string<T, traits, alloc>& str,
-        const std::shared_ptr<font>& f_ptr = default_font::get_font(),
-        typename std::basic_string<T,traits,alloc>::size_type first = 0,
-        typename std::basic_string<T,traits,alloc>::size_type last = (std::basic_string<T,traits,alloc>::npos)
+        const std::shared_ptr<font>& f_ptr = default_font::get_font()
     )
     {
         using string = std::basic_string<T, traits, alloc>;
-        DLIB_ASSERT((last == string::npos) || (first <= last && last < str.size()),
-                    "\tvoid dlib::compute_string_dimensions()"
-                    << "\n\tlast == string::npos: " << ((last == string::npos)?"true":"false")
-                    << "\n\tfirst: " << (unsigned long)first
-                    << "\n\tlast:  " << (unsigned long)last
-                    << "\n\tstr.size():  " << (unsigned long)str.size());
-
-        if (last == string::npos)
-            last = str.size();
 
         const font& f = *f_ptr;
 
         long height = f.height();
         long width = 0;
-        for (typename string::size_type i = first; i <= last; ++i)
+        for (typename string::size_type i = 0; i < str.size(); ++i)
         {
             // ignore the '\r' character
             if (str[i] == '\r')
@@ -277,7 +277,7 @@ namespace dlib
             const letter& l = f[str[i]];
             width += l.width();
         }
-        return std::make_pair(width, height);
+        return string_dims(width, height);
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -82,6 +82,27 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <
+        typename T, typename traits,
+        typename alloc
+    >
+    std::pair<long, long> compute_string_dimensions (
+        const std::basic_string<T, traits, alloc>& str,
+        const std::shared_ptr<font>& f_ptr = default_font::get_font(),
+        typename std::basic_string<T,traits,alloc>::size_type first = 0,
+        typename std::basic_string<T,traits,alloc>::size_type last = (std::basic_string<T,traits,alloc>::npos)
+    )
+
+    /*!
+        ensures
+            - computes the size of the given string with the specified font in pixels.  To be very specific,
+              if dims is the returned object by this function, then:
+              - dims.first == width of the string
+              - dims.second == height of the string
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
+    template <
         typename T,
         typename traits,
         typename alloc,

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -81,23 +81,40 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    struct string_dims
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This is a simple structs that represents the size (width and height) of a
+                string in pixels.
+        !*/
+
+        string_dims() = default;
+        string_dims (
+            unsigned long width,
+            unsigned long height
+        ) : width(width), height(height) {}
+        unsigned long width = 0;
+        unsigned long height = 0;
+    };
+
+// ----------------------------------------------------------------------------------------
+
     template <
         typename T, typename traits,
         typename alloc
     >
-    std::pair<long, long> compute_string_dimensions (
+    string_dims compute_string_dims (
         const std::basic_string<T, traits, alloc>& str,
-        const std::shared_ptr<font>& f_ptr = default_font::get_font(),
-        typename std::basic_string<T,traits,alloc>::size_type first = 0,
-        typename std::basic_string<T,traits,alloc>::size_type last = (std::basic_string<T,traits,alloc>::npos)
+        const std::shared_ptr<font>& f_ptr = default_font::get_font()
     )
 
     /*!
         ensures
             - computes the size of the given string with the specified font in pixels.  To be very specific,
               if dims is the returned object by this function, then:
-              - dims.first == width of the string
-              - dims.second == height of the string
+              - dims.width == width of the string
+              - dims.height == height of the string
     !*/
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -85,7 +85,7 @@ namespace dlib
     {
         /*!
             WHAT THIS OBJECT REPRESENTS
-                This is a simple structs that represents the size (width and height) of a
+                This is a simple struct that represents the size (width and height) of a
                 string in pixels.
         !*/
 
@@ -213,6 +213,5 @@ namespace dlib
 }
 
 #endif // DLIB_DRAW_IMAGe_ABSTRACT
-
 
 


### PR DESCRIPTION
In this PR, I added a function to compute the dimensions (in pixels) of the given string, using a particular font, similar to OpenCV's [getTextSize](https://docs.opencv.org/4.5.3/d6/d6e/group__imgproc__draw.html#ga3d2abfcb995fd2db908c8288199dba82).

It is mostly copy-paste of the `draw_string` function, but I couldn't see an easy way to reuse it.

I have some doubts:
- right now, I am returning a `std::pair<long, long>` so we can do `auto [w, h] = compute_string_dimensions("hello");`
- maybe `width` and `height` should be out parameters in the function, instead, or return a `matrix<long>`? I find structured bindings really convenient, though.
- I kept the `first` and `last` parameters, for coherence with the other methods, but I don't know if they are useful here.
- I am not sure about the name of this function, open to suggestions... like `get_string_shape` or other combinations.

With this function, we can draw boxes around text, get some pretty nice looking bounding boxes (drawn 100% using dlib):
![detections](https://user-images.githubusercontent.com/1671644/127770757-bd60766b-e181-48fd-b5f4-48b894b37bd7.jpg)

