### PR TITLE
Add progress information to console_progress_indicator

### DIFF
--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -30,7 +30,8 @@ namespace dlib
                     }
 
                 The above code will print a message to the console each iteration
-                which shows how much time is remaining until the loop terminates.
+                which shows the current progress and how much time is remaining until
+                the loop terminates.
         !*/
 
     public:
@@ -72,8 +73,8 @@ namespace dlib
         /*!
             ensures
                 - print_status() assumes it is called with values which are linearly
-                  approaching target().  It will attempt to predict how much time is
-                  remaining until cur becomes equal to target().
+                  approaching target().  It will display the current progress and attempt
+                  to predict how much time is remaining until cur becomes equal to target().
                 - prints a status message to out which indicates how much more time is
                   left until cur is equal to target()
                 - if (always_print) then
@@ -155,6 +156,15 @@ namespace dlib
 
             out.setf(std::ios::fixed,std::ios::floatfield);
             std::streamsize ss;
+
+            if (std::fmod(target_val, 1.0) == 0)
+                ss = out.precision(0);
+            else
+                ss = out.precision(2);
+
+            out << "Progress: " << cur << "/" << target_val;
+            ss = out.precision(2);
+            out << " (" << cur / target_val * 100. << "%). ";
 
             if (seconds < 60)
             {

--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -157,7 +157,7 @@ namespace dlib
             out.setf(std::ios::fixed,std::ios::floatfield);
             std::streamsize ss;
 
-            if (std::fmod(target_val, 1.0) == 0)
+            if (std::trunc(target_val) == target_val)
                 ss = out.precision(0);
             else
                 ss = out.precision(2);

--- a/dlib/image_processing/shape_predictor_trainer.h
+++ b/dlib/image_processing/shape_predictor_trainer.h
@@ -346,7 +346,7 @@ namespace dlib
             }
 
             if (_verbose)
-                std::cout << "Training complete                          " << std::endl;
+                std::cout << "\nTraining complete" << std::endl;
 
             return shape_predictor(initial_shape, forests, pixel_coordinates);
         }


### PR DESCRIPTION
This PR adds progress information (current/total and percent) to console_progress_indicator.

Before it used to look like this:
```
Time remaining: 12 seconds.
```
But now it looks like this
```
Progress: 2172/5000 (43.44%). Time remaining: 12 seconds.
```

I've found myself adding this extra information many times in my code: most of the time, I want to know the actual number of elements completed out of the total, and the actual progress.

If you don't think this is useful, either close this PR, or tell me to add an extra `display_percent` parameter to the function.