### PR TITLE
Handle tag layers as inputs to disable_duplicative_biases

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1757,13 +1757,24 @@ namespace dlib
             }
 
             // handle input repeat layer with tag case
-            template <layer_mode mode, unsigned long ID, typename E, typename F>
-            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& )
+            template <layer_mode mode, unsigned long ID, typename E>
+            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer>, E>& )
             {
             }
 
-            template <unsigned long ID, typename E, typename F>
-            void disable_input_bias(add_layer<layer_norm_, add_tag_layer<ID, impl::repeat_input_layer, E>, F>& )
+            template <unsigned long ID, typename E>
+            void disable_input_bias(add_layer<layer_norm_, add_tag_layer<ID, impl::repeat_input_layer>, E>& )
+            {
+            }
+
+            // handle tag layer case
+            template <layer_mode mode, unsigned long ID, typename U, typename E>
+            void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, U>, E>& )
+            {
+            }
+
+            template <unsigned long ID, typename U, typename E>
+            void disable_input_bias(add_layer<layer_norm_, add_tag_layer<ID, U>, E>& )
             {
             }
 


### PR DESCRIPTION
`disable_duplicative_biases` prevents from building successfully if the input of the batch normalization layer is a tag layer, but there is no repeat layer afterwards. This PR fixes that.