### PR TITLE
Show number of parameters if net is allocated

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1363,7 +1363,11 @@ namespace dlib
         net_type temp = trainer.get_net(); // make a copy so that we can clean it without mutating the trainer's net.
         temp.clean();
         serialize(temp, sout);
-        out << "  net size: " << sout.str().size()/1024.0/1024.0 << " MiB" << endl;
+        out << "  net size: " << sout.str().size()/1024.0/1024.0 << " MiB";
+        const auto num_params = count_parameters(temp);
+        if (num_params > 0)
+            out << " (" << num_params << " parameters)";
+        out << endl;
         // Don't include the loss params in the hash since we print them on the next line.
         // They also aren't really part of the "architecture" of the network.
         out << "  net architecture hash: " << md5(cast_to_string(trainer.get_net().subnet())) << endl;


### PR DESCRIPTION
This PR makes the trainer print the number of parameters next to the network size if it has already been allocated (to avoid printing 0)