### PR TITLE
Fix dnn_trainer trying to decrease the learning rate

### DIFF
--- a/dlib/dnn/trainer.h
+++ b/dlib/dnn/trainer.h
@@ -1061,7 +1061,7 @@ namespace dlib
                     // lower one instead.
                     if (prob_loss_increasing_thresh >= prob_loss_increasing_thresh_max_value)
                     {
-                        if (verbose)
+                        if (verbose && learning_rate_shrink != 1)
                             std::cout << "(and while at it, also shrinking the learning rate)" << std::endl;
 
                         learning_rate = learning_rate_shrink * learning_rate;


### PR DESCRIPTION
If the `learning_rate_shrink == 1` (because we have a custom learning rate schedule), the `dnn_trainer` will tell us that it will decrease the learning rate, when the loss is increasing, but in reality it won't.  I am not sure how to properly address this case, but at least it shouldn't lie about it.