### PR TITLE
Fix nvidia pragma warning

### DIFF
--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -22,7 +22,11 @@
     // Disable the "statement is unreachable" message since it will go off on code that is
     // actually reachable but just happens to not be reachable sometimes during certain
     // template instantiations.
+    #ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+    #pragma nv_diag_suppress code_is_unreachable
+    #else
     #pragma diag_suppress code_is_unreachable
+    #endif
 #endif
 
 


### PR DESCRIPTION
After updating to CUDA 11.5, I got this warning:
```
dlib/algs.h(25): warning #20236-D: pragma "diag_suppress" is deprecated, use "nv_diag_suppress" instead
```

According to this [blog post](https://developer.nvidia.com/blog/reducing-application-build-times-using-cuda-c-compilation-aids/), diagnostic pragmas without the `nv_` prefix have been deprecated, so I applied the proposed fix.


