### PR TITLE
Add semicolon as separator for reading in a matrix

### DIFF
--- a/dlib/matrix/matrix_read_from_istream.h
+++ b/dlib/matrix/matrix_read_from_istream.h
@@ -21,6 +21,7 @@ namespace dlib
             return in.peek() == '\n' ||
                 in.peek() == ' ' || 
                 in.peek() == ',' || 
+                in.peek() == ';' ||
                 in.peek() == '\t' ||
                 in.peek() == '\r';
         }


### PR DESCRIPTION
This pull request deals with issue #2459 

It allows to read CSV with semicolon separator to matrix. It is a very small change but it helps!