### PR TITLE
Do not round drectangle in rectangle transform

### DIFF
--- a/dlib/geometry/point_transforms.h
+++ b/dlib/geometry/point_transforms.h
@@ -235,14 +235,15 @@ namespace dlib
             // the above box.
             double scale = std::sqrt(new_area/temp.area());
 
-            return centered_rect(center(temp), std::round(temp.width()*scale), std::round(temp.height()*scale));
+            return centered_drect(dcenter(temp), temp.width()*scale, temp.height()*scale);
         }
 
         rectangle operator() (
             const rectangle& r
         ) const
         {
-            return (*this)(drectangle(r));
+            const auto temp = (*this)(drectangle(r));
+            return centered_rect(center(temp), std::round(temp.width()), std::round(temp.height()));
         }
 
         const point_transform_affine& get_tform(


### PR DESCRIPTION
I was thinking that it makes more sense, if I pass a `drectangle` to the `rectangle_transform`, to get a `drectangle` whose coordinates have not been rounded. What do you think?

I noticed this with YOLO detectors, since I use `letterbox_image`, I need to transform the detections back to the original image space. I was surprised to see that all detections had integer coordinates for their bounding boxes.