### PR TITLE
Add get_random_beta to dlib::rand

### DIFF
--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -5,7 +5,6 @@
 
 #include <string>
 #include <complex>
-#include <random>
 #include "../algs.h"
 #include "rand_kernel_abstract.h"
 #include "mersenne_twister.h"

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -299,7 +299,7 @@ namespace dlib
                 DLIB_CASSERT(beta > 0, "beta must be greater than zero");
                 auto u = std::pow(get_random_double(), 1 / alpha);
                 auto v = std::pow(get_random_double(), 1 / beta);
-                while ((u + v) > 1 || u == 0 || v == 0)
+                while ((u + v) > 1 || (u == 0 && v == 0))
                 {
                     u = std::pow(get_random_double(), 1 / alpha);
                     v = std::pow(get_random_double(), 1 / beta);

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -295,7 +295,8 @@ namespace dlib
                 double beta
             )
             {
-                DLIB_CASSERT(alpha > 0 && beta > 0, "a and b must be greater than zero");
+                DLIB_CASSERT(alpha > 0, "alpha must be greater than zero")
+                DLIB_CASSERT(beta > 0, "beta must be greater than zero");
                 auto u = std::pow(get_random_double(), 1 / alpha);
                 auto v = std::pow(get_random_double(), 1 / beta);
                 while ((u + v) > 1 || u == 0 || v == 0)

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <complex>
+#include <random>
 #include "../algs.h"
 #include "rand_kernel_abstract.h"
 #include "mersenne_twister.h"
@@ -288,6 +289,47 @@ namespace dlib
                 while (u == 0.0)
                     u = get_random_double();
                 return gamma + lambda*std::pow(-std::log(u), 1.0 / k);
+            }
+
+            double get_random_beta (
+                double a,
+                double b
+            )
+            {
+                DLIB_CASSERT(a > 0 && b > 0);
+                if ((a <= 1) && (b <= 1))
+                {
+                    double u = 0, v = 0;
+                    while (true)
+                    {
+                        while (u == 0 || v == 0)
+                        {
+                            u = get_random_double();
+                            v = get_random_double();
+                        }
+                        const auto x = std::pow(u, 1 / a);
+                        const auto y = std::pow(v, 1 / b);
+                        const auto z = x + y;
+                        if ((z <= 1) && (z > 0))
+                        {
+                            return x / z;
+                        }
+                        else
+                        {
+                            auto log_x = std::log(u) / a;
+                            auto log_y = std::log(v) / b;
+                            const auto log_m = std::max(log_x, log_y);
+                            log_x -= log_m;
+                            log_y -= log_m;
+                            return std::exp(log_x - std::log(std::exp(log_x) + std::exp(log_y)));
+                        }
+                    }
+                }
+                else
+                {
+                    std::gamma_distribution<> g(a, b);
+                    return g(mt);
+                }
             }
             
             void swap (

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -292,17 +292,17 @@ namespace dlib
             }
 
             double get_random_beta (
-                double a,
-                double b
+                double alpha,
+                double beta
             )
             {
-                DLIB_CASSERT(a > 0 && b > 0, "a and b must be greater than zero");
-                auto u = std::pow(get_random_double(), 1 / a);
-                auto v = std::pow(get_random_double(), 1 / b);
-                while ((u + v) > 1 || (u == 0 && v == 0))
+                DLIB_CASSERT(alpha > 0 && beta > 0, "a and b must be greater than zero");
+                auto u = std::pow(get_random_double(), 1 / alpha);
+                auto v = std::pow(get_random_double(), 1 / beta);
+                while ((u + v) > 1 || u == 0 || v == 0)
                 {
-                    u = std::pow(get_random_double(), 1 / a);
-                    v = std::pow(get_random_double(), 1 / b);
+                    u = std::pow(get_random_double(), 1 / alpha);
+                    v = std::pow(get_random_double(), 1 / beta);
                 }
                 return u / (u + v);
             }

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <complex>
+#include <random>
 #include "../algs.h"
 #include "rand_kernel_abstract.h"
 #include "mersenne_twister.h"

--- a/dlib/rand/rand_kernel_1.h
+++ b/dlib/rand/rand_kernel_1.h
@@ -296,42 +296,17 @@ namespace dlib
                 double b
             )
             {
-                DLIB_CASSERT(a > 0 && b > 0);
-                if ((a <= 1) && (b <= 1))
+                DLIB_CASSERT(a > 0 && b > 0, "a and b must be greater than zero");
+                auto u = std::pow(get_random_double(), 1 / a);
+                auto v = std::pow(get_random_double(), 1 / b);
+                while ((u + v) > 1 || (u == 0 && v == 0))
                 {
-                    double u = 0, v = 0;
-                    while (true)
-                    {
-                        while (u == 0 || v == 0)
-                        {
-                            u = get_random_double();
-                            v = get_random_double();
-                        }
-                        const auto x = std::pow(u, 1 / a);
-                        const auto y = std::pow(v, 1 / b);
-                        const auto z = x + y;
-                        if ((z <= 1) && (z > 0))
-                        {
-                            return x / z;
-                        }
-                        else
-                        {
-                            auto log_x = std::log(u) / a;
-                            auto log_y = std::log(v) / b;
-                            const auto log_m = std::max(log_x, log_y);
-                            log_x -= log_m;
-                            log_y -= log_m;
-                            return std::exp(log_x - std::log(std::exp(log_x) + std::exp(log_y)));
-                        }
-                    }
+                    u = std::pow(get_random_double(), 1 / a);
+                    v = std::pow(get_random_double(), 1 / b);
                 }
-                else
-                {
-                    std::gamma_distribution<> g(a, b);
-                    return g(mt);
-                }
+                return u / (u + v);
             }
-            
+
             void swap (
                 rand& item
             )

--- a/dlib/rand/rand_kernel_abstract.h
+++ b/dlib/rand/rand_kernel_abstract.h
@@ -218,7 +218,6 @@ namespace dlib
                 requires
                     - alpha > 0
                     - beta > 0
-
                 ensures
                     - returns a random number sampled from a Beta distribution
                       with shape parameters alpha and beta.

--- a/dlib/rand/rand_kernel_abstract.h
+++ b/dlib/rand/rand_kernel_abstract.h
@@ -211,16 +211,17 @@ namespace dlib
             !*/
 
             double get_random_beta (
-                double a,
-                double b,
+                double alpha,
+                double beta,
             )
             /*!
                 requires
-                    - a > 0, b > 0
+                    - alpha > 0
+                    - beta > 0
 
                 ensures
                     - returns a random number sampled from a Beta distribution
-                      with shape parameters a and b.
+                      with shape parameters alpha and beta.
             !*/
 
             void swap (

--- a/dlib/rand/rand_kernel_abstract.h
+++ b/dlib/rand/rand_kernel_abstract.h
@@ -209,7 +209,20 @@ namespace dlib
                       with shape parameter k, scale parameter lambda and 
                       threshold parameter gamma.
             !*/
-            
+
+            double get_random_beta (
+                double a,
+                double b,
+            )
+            /*!
+                requires
+                    - a > 0, b > 0
+
+                ensures
+                    - returns a random number sampled from a Beta distribution
+                      with shape parameters a and b.
+            !*/
+
             void swap (
                 rand& item
             );

--- a/dlib/test/mpc.cpp
+++ b/dlib/test/mpc.cpp
@@ -403,7 +403,7 @@ namespace
                 dlog << LINFO << trans(alpha2);
                 dlog << LINFO << "objective value:  " << 0.5*trans(alpha)*Q*alpha + trans(b)*alpha;
                 dlog << LINFO << "objective value2: " << 0.5*trans(alpha2)*Q*alpha + trans(b)*alpha2;
-                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-6, max(abs(alpha-alpha2)));
+                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-4, max(abs(alpha-alpha2)));
             }
 
             test_with_positive_target_error_thresh();

--- a/dlib/test/mpc.cpp
+++ b/dlib/test/mpc.cpp
@@ -403,7 +403,7 @@ namespace
                 dlog << LINFO << trans(alpha2);
                 dlog << LINFO << "objective value:  " << 0.5*trans(alpha)*Q*alpha + trans(b)*alpha;
                 dlog << LINFO << "objective value2: " << 0.5*trans(alpha2)*Q*alpha + trans(b)*alpha2;
-                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-4, max(abs(alpha-alpha2)));
+                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-6, max(abs(alpha-alpha2)));
             }
 
             test_with_positive_target_error_thresh();

--- a/dlib/test/rand.cpp
+++ b/dlib/test/rand.cpp
@@ -475,12 +475,12 @@ namespace
 
         {
             dlib::rand rnd;
-            std::vector<uint32> out;
+            std::vector<long> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_random_32bit_number());
             }
 
-            const std::vector<uint32> expected = {
+            const std::vector<long> expected = {
                 725333953,251387296,3200466189,2466988778,2049276419,2620437198,2806522923,
                 2922190659,4151412029,2894696296,1344442829,1165961100,328304965,1533685458,
                 3399102146,3995382051,1569312238,2353373514,2512982725,2903494783,787425157,
@@ -492,12 +492,12 @@ namespace
         {
             dlib::rand rnd;
             rnd.set_seed("this seed");
-            std::vector<uint32> out;
+            std::vector<long> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_random_32bit_number());
             }
 
-            const std::vector<uint32> expected = {
+            const std::vector<long> expected = {
                 856663397,2356564049,1192662566,3478257893,1069117227,
                 1922448468,497418632,2504525324,987414451,769612124,77224022,2998161761,
                 1364481427,639342008,1778351952,1931573847,3213816676,3019312695,4179936779,
@@ -509,12 +509,12 @@ namespace
         {
             dlib::rand rnd;
             rnd.set_seed("some other seed");
-            std::vector<long long> out;
+            std::vector<long> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_integer(1000));
             }
 
-            const std::vector<long long> expected = {
+            const std::vector<long> expected = {
                 243,556,158,256,772,84,837,920,767,769,939,394,121,367,575,877,861,506,
                 451,845,870,638,825,516,327,25,646,373,386,227};
             DLIB_TEST(out == expected);

--- a/dlib/test/rand.cpp
+++ b/dlib/test/rand.cpp
@@ -412,7 +412,7 @@ namespace
     {
         print_spinner();
         dlib::rand rnd(0);
-        
+
         const size_t N = 1024*1024*4;
         const double tol = 0.01;
         double k=1.0, lambda=2.0, g=6.0;
@@ -426,26 +426,46 @@ namespace
         DLIB_TEST(std::abs(stats.mean() - expected_mean) < tol);
         DLIB_TEST(std::abs(stats.variance() - expected_var) < tol);
     }
-    
+
     void test_exponential_distribution()
     {
         print_spinner();
         dlib::rand rnd(0);
-        
+
         const size_t N = 1024*1024*5;
-        
+
         const double lambda = 1.5;
         print_spinner();
         dlib::running_stats<double> stats;
         for (size_t i = 0; i < N; i++) 
             stats.add(rnd.get_random_exponential(lambda));
-        
+
         DLIB_TEST(std::abs(stats.mean() - 1.0 / lambda) < 0.001);
         DLIB_TEST(std::abs(stats.variance() - 1.0 / (lambda*lambda)) < 0.001);
         DLIB_TEST(std::abs(stats.skewness() - 2.0) < 0.01);
         DLIB_TEST(std::abs(stats.ex_kurtosis() - 6.0) < 0.1);
     }
-    
+
+    void test_beta_distribution()
+    {
+        print_spinner();
+        dlib::rand rnd(0);
+
+        const size_t N = 1024*1024*5;
+
+        const double a = 0.2;
+        const double b = 1.5;
+
+        running_stats<double> stats;
+        for (size_t i = 0; i < N; i++)
+            stats.add(rnd.get_random_beta(a, b));
+
+        const double expected_mean = a / (a + b);
+        const double expected_var = a * b / (std::pow(a + b, 2) * (a + b + 1));
+        DLIB_TEST(std::abs(stats.mean() - expected_mean) < 1e-5);
+        DLIB_TEST(std::abs(stats.variance() - expected_var) < 1e-5);
+    }
+
     class rand_tester : public tester
     {
     public:
@@ -469,6 +489,7 @@ namespace
             test_get_integer();
             test_weibull_distribution();
             test_exponential_distribution();
+            test_beta_distribution();
         }
     } a;
 

--- a/dlib/test/rand.cpp
+++ b/dlib/test/rand.cpp
@@ -475,12 +475,12 @@ namespace
 
         {
             dlib::rand rnd;
-            std::vector<long> out;
+            std::vector<uint32> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_random_32bit_number());
             }
 
-            const std::vector<long> expected = {
+            const std::vector<uint32> expected = {
                 725333953,251387296,3200466189,2466988778,2049276419,2620437198,2806522923,
                 2922190659,4151412029,2894696296,1344442829,1165961100,328304965,1533685458,
                 3399102146,3995382051,1569312238,2353373514,2512982725,2903494783,787425157,
@@ -492,12 +492,12 @@ namespace
         {
             dlib::rand rnd;
             rnd.set_seed("this seed");
-            std::vector<long> out;
+            std::vector<uint32> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_random_32bit_number());
             }
 
-            const std::vector<long> expected = {
+            const std::vector<uint32> expected = {
                 856663397,2356564049,1192662566,3478257893,1069117227,
                 1922448468,497418632,2504525324,987414451,769612124,77224022,2998161761,
                 1364481427,639342008,1778351952,1931573847,3213816676,3019312695,4179936779,
@@ -509,12 +509,12 @@ namespace
         {
             dlib::rand rnd;
             rnd.set_seed("some other seed");
-            std::vector<long> out;
+            std::vector<long long> out;
             for (int i = 0; i < 30; ++i) {
                 out.push_back(rnd.get_integer(1000));
             }
 
-            const std::vector<long> expected = {
+            const std::vector<long long> expected = {
                 243,556,158,256,772,84,837,920,767,769,939,394,121,367,575,877,861,506,
                 451,845,870,638,825,516,327,25,646,373,386,227};
             DLIB_TEST(out == expected);


### PR DESCRIPTION
I was trying to implement the [mixup paper](https://arxiv.org/abs/1710.09412) and I noticed they use the beta distribution to generate the blending parameter α.

So, I tried to implement it myself and added to the `dlib::rand`.
I got **a lot** of “inspiration” from the [NumPy code](https://github.com/numpy/numpy/blob/1995e2cdfd17ec75e37cc6e69a42ce9000aac966/numpy/random/src/distributions/distributions.c#L406-L439).

@pfeatherstone, since you added already 2 distribution generators (Weibull and Exponential) would you mind having a look?
Specially, I am a bit puzzled about line 421 in the NumPy code. It looks like that condition will be always true inside that block. Am I missing something? If I implement it the same way as them, the code gets stuck in an infinite loop :(