### PR TITLE
Relax MPC test for macOS

### DIFF
--- a/dlib/test/mpc.cpp
+++ b/dlib/test/mpc.cpp
@@ -403,7 +403,7 @@ namespace
                 dlog << LINFO << trans(alpha2);
                 dlog << LINFO << "objective value:  " << 0.5*trans(alpha)*Q*alpha + trans(b)*alpha;
                 dlog << LINFO << "objective value2: " << 0.5*trans(alpha2)*Q*alpha + trans(b)*alpha2;
-                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-7, max(abs(alpha-alpha2)));
+                DLIB_TEST_MSG(max(abs(alpha-alpha2)) < 1e-6, max(abs(alpha-alpha2)));
             }
 
             test_with_positive_target_error_thresh();


### PR DESCRIPTION
I jast saw that the MPC test fails on macOS, so I relaxed the condition a bit.
https://github.com/arrufat/dlib/runs/5046699340?check_suite_focus=true