### PR TITLE
Make Github Actions build more stuff (in particular, the examples)

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -27,7 +27,7 @@ jobs:
       working-directory: ${{ github.workspace }}/dlib/test
       run: cmake . -B ${{ env.build_dir }}
 
-    - name: Build
+    - name: Build just tests
       working-directory: ${{ github.workspace }}/dlib/test
       run: cmake --build ${{ env.build_dir }} --config ${{ env.config }} --target dtest
 
@@ -41,3 +41,8 @@ jobs:
         else
           ./dtest --runall -q
         fi;
+
+    - name: Build examples, etc
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      working-directory: ${{ github.workspace }}/dlib/test
+      run: cmake --build ${{ env.build_dir }} --config ${{ env.config }}


### PR DESCRIPTION
Thought it might be nice to have Github Actions build the examples, too? Just to catch as many issues as soon as possible?

Apparently there's some issue with the Windows builds (think @arrufat ran into that as well?), but I don't think this needs to prevent us from doing it on the other OSes/compilers?