### PR TITLE
Make GitHub actions use `gcc-11` in parallel with the default `gcc-9` that comes with `ubuntu-latest`

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -23,6 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install gcc 11
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt update
+        sudo apt install gcc-11 g++-11
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
+          
     - name: Configure
       working-directory: ${{ github.workspace }}/dlib/test
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -14,17 +14,25 @@ defaults:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        include:
+          - displayTargetName: ubuntu-latest-gcc-default
+            runs_on: ubuntu-latest
+          - displayTargetName: ubuntu-latest-gcc-11
+            runs_on: ubuntu-latest
+          - displayTargetName: windows-latest
+            runs_on: windows-latest
+          - displayTargetName: macos-latest
+            runs_on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install gcc 11
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.displayTargetName == 'ubuntu-latest-gcc-11'
       run: |
         sudo apt update
         sudo apt install gcc-11 g++-11


### PR DESCRIPTION
Resolves #2508.

At some point, not using a matrix might be more convenient.