### PR TITLE
Update __init__.py.in

### DIFF
--- a/tools/python/dlib/__init__.py.in
+++ b/tools/python/dlib/__init__.py.in
@@ -9,7 +9,7 @@ def add_lib_to_dll_path(path):
     try:
         import os
         os.add_dll_directory(os.path.join(os.path.dirname(path), '../../bin'))
-    except (AttributeError,KeyError):
+    except (AttributeError,KeyError,FileNotFoundError):
         pass
 
 if '@DLIB_USE_CUDA@' == 'ON':


### PR DESCRIPTION
When I run:
```python
import dlib
```

```shell
>>> import dlib

---------------------------------
Traceback (most recent call last):

  File "xxxxx.py", line 1, in <module>
    import dlib

  File "xxxxx\lib\site-packages\dlib\__init__.py", line 21, in <module>
    add_lib_to_dll_path('C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.6/lib/cudnn.lib')

  File "xxxxx\lib\site-packages\dlib\__init__.py", line 11, in add_lib_to_dll_path
    os.add_dll_directory(os.path.join(os.path.dirname(path), '../../bin'))

  File "xxxxx\lib\os.py", line 1109, in add_dll_directory
    cookie = nt._add_dll_directory(path)

FileNotFoundError: [WinError 2] The system cannot find the file specified : 'C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.6/lib\\../../bin'
```

----------------------------------------

My `__init__.py` is as  follow:

```python
# Copyright (C) 2020  Davis E. King (davis@dlib.net)
# License: Boost Software License   See LICENSE.txt for the full license.

def add_lib_to_dll_path(path):
    """ On windows you must call os.add_dll_directory() to allow linking to external DLLs.  See
    https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew.  This function adds the folder
    containing path to the dll search path. 
    """
    try:
        import os
        os.add_dll_directory(os.path.join(os.path.dirname(path), '../../bin'))
        os.add_dll_directory(os.path.join(os.path.dirname(path), '../bin'))
        
    except (AttributeError,KeyError):
        pass
    # except (AttributeError, KeyError, FileNotFoundError):
    #     pass


if 'ON' == 'ON':
    add_lib_to_dll_path('C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.6/lib/cudnn.lib')
    add_lib_to_dll_path('C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.6/lib/x64/cudart.lib')

from _dlib_pybind11 import *
from _dlib_pybind11 import __version__, __time_compiled__
```

So, to add `FileNotFoundError` is needed.

