### PR TITLE
Fix error calling `cudnnGetConvolutionBackwardFilterWorkspaceSize`

### DIFF
--- a/dlib/cuda/cudnn_dlibapi.cpp
+++ b/dlib/cuda/cudnn_dlibapi.cpp
@@ -912,6 +912,7 @@ namespace dlib
                     &backward_filters_best_algo));
 #endif
 
+#if CUDNN_MAJOR < 7
             // cuDNN 5.1 has a bug that causes
             // cudnnGetConvolutionBackwardFilterAlgorithm() to pick the winograd
             // algorithm even for cases where cuDNN doesn't support it, leading to
@@ -926,7 +927,7 @@ namespace dlib
                 backward_filters_best_algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
             }
             backward_filters_algo = backward_filters_best_algo;
-
+#endif
 
             // Save this algorithm selection in the cache
             config_to_algo_cache[cache_key] = std::make_tuple(forward_algo, backward_data_algo, backward_filters_algo);


### PR DESCRIPTION
**Problem**: `Error while calling cudnnGetConvolutionBackwardFilterWorkspaceSize( context(), descriptor(data), descriptor(dest_desc), (const cudnnConvolutionDescriptor_t)conv_handle, (const cudnnFilterDescriptor_t)filter_handle, (cudnnConvolutionBwdFilterAlgo_t)backward_filters_algo, &backward_filters_workspace_size_in_bytes) in file C:\a\1\s\3rdparty\dlib\dlib\cuda\cudnn_dlibapi.cpp:1048. code: 9, reason: CUDNN_STATUS_NOT_SUPPORTED`

**Solution**: Do not apply the cuDNN 5.1 workaround if we have cuDNN version greater than or equal to 7

---

Apparently `cudnnFindConvolutionBackwardFilterAlgorithm` isn't deterministic (which is understandable), so the issue may not be easy to reproduce.