### PR TITLE
Fix error calling `cudnnGetConvolutionForwardWorkspaceSize`

### DIFF
--- a/dlib/cuda/cudnn_dlibapi.cpp
+++ b/dlib/cuda/cudnn_dlibapi.cpp
@@ -792,12 +792,14 @@ namespace dlib
         {
             // Calling the cuDNN "find the best algorithm" functions are really slow.  So we keep a
             // cache that tells us what method was best for a particular configuration.
-            thread_local std::map<std::tuple<int,int,int,int,long,long>,
+            thread_local std::map<std::tuple<int,int,int,int,long,long,long,long,long,long,long,long>,
                                   std::tuple<int,int,int>> config_to_algo_cache;
 
             // If we have already found good algorithms for this setting then just pull them from
             // the cache.
-            const auto cache_key = std::make_tuple(stride_y, stride_x, padding_y, padding_x, filters_nr, filters_nc);
+            const auto cache_key = std::make_tuple(stride_y, stride_x, padding_y, padding_x,
+                                                   filters_nr, filters_nc, filters_num_samples, filters_k,
+                                                   data_nr, data_nc, data_num_samples, data_k);
             const auto iter = config_to_algo_cache.find(cache_key);
             if (iter != config_to_algo_cache.end())
             {


### PR DESCRIPTION
**Problem**: `Error while calling cudnnGetConvolutionForwardWorkspaceSize( context(), descriptor(data), (const cudnnFilterDescriptor_t)filter_handle, (const cudnnConvolutionDescriptor_t)conv_handle, descriptor(dest_desc), (cudnnConvolutionFwdAlgo_t)forward_algo, &forward_workspace_size_in_bytes) in file C:\a\2\s\3rdparty\dlib\dlib\cuda\cudnn_dlibapi.cpp:1029. code: 9, reason: CUDNN_STATUS_NOT_SUPPORTED`

**Solution**: Add remaining dimensions of `filters`, and all dimensions of `data` to cache key

---

Not sure, but it looks like otherwise the chosen algorithm may be unsupported for some input combinations (e.g., larger input?).

Also not sure if all those key components are really needed. But reproducing the problem is not very straightforward, so figuring that out would take some time. So personally would be fine to just err on the side of caution. The present solution at least seems to fix the problem. Yes, I am painfully aware that the cache would be more useful, if the key did not include data dimensions. Possibly the data dimensions could be rounded up a bit when constructing the cache key, or something like that, in order to promote more cache hits (without risking errors that is – but at the moment I'm not sure a smaller input is always safe for a particular "supported" combination).

An alternative, I guess, could have been to try out `cudnnGetConvolutionForwardWorkspaceSize`, and in the event of failure, just clean the related cache item and try again.