### PR TITLE
Add Focal Loss

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -1021,7 +1021,7 @@ namespace dlib
         }
 
     private:
-        float gamma = 0;
+        float gamma = 2.0;
     };
 
     template <typename SUBNET>

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -973,14 +973,14 @@ namespace dlib
                         const float temp = log1pexp(-out_data[idx]);
                         const float focus = std::pow(1 - g[idx], gamma);
                         loss += y * scale * temp * focus;
-                        g[idx] = y * scale * focus * (g[idx] * (1 - gamma * temp) - 1);
+                        g[idx] = y * scale * focus * (g[idx] * (gamma * temp + 1) - 1);
                     }
                     else
                     {
                         const float temp = -(-out_data[idx] - log1pexp(-out_data[idx]));
                         const float focus = std::pow(g[idx], gamma);
                         loss += -y * scale * temp * focus;
-                        g[idx] = -y * scale * focus * g[idx] * (1 - gamma * temp);
+                        g[idx] = -y * scale * focus * g[idx] * (gamma * temp + 1);
                     }
                 }
             }

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -968,7 +968,6 @@ namespace dlib
                     const float y = (*truth)[k];
                     DLIB_CASSERT(y != 0, "y: " << y);
                     const size_t idx = i * output_tensor.k() + k;
-                    const float focus = std::pow(1 - g[idx], gamma);
                     if (y > 0)
                     {
                         const float temp = log1pexp(-out_data[idx]);

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -815,6 +815,8 @@ namespace dlib
 
         loss_focal_(float gamma);
         /*!
+            requires
+                - gamma >= 0
             ensures
                 - #get_gamma() == gamma
         !*/
@@ -2182,6 +2184,8 @@ namespace dlib
 
         loss_barlow_twins_(float lambda);
         /*!
+            requires
+                - lambda > 0
             ensures
                 - #get_lambda() == lambda
         !*/

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -797,8 +797,9 @@ namespace dlib
                 parameter gamma which acts as a modulating factor to the cross-entropy
                 layer by reducing the relative loss for well-classified samples, and
                 focusing on the difficult ones.  As a result, this means that you might
-                want to use this loss layer when your dataset is very imbalanced.
-                Note that when gamma == 0, this loss is exactly the same as the
+                want to use this loss layer when your dataset has some kind of information
+                assymetry between classes, i.e. one class is easier to distinguish than
+                the rest.  Note that when gamma == 0, this loss is exactly the same as the
                 loss_multibinary_log_ defined above.
         !*/
 

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -813,7 +813,7 @@ namespace dlib
         );
         /*!
             ensures
-                - #get_gamma() == 0
+                - #get_gamma() == 2.0
         !*/
 
         loss_focal_(float gamma);

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -799,7 +799,9 @@ namespace dlib
                 focusing on the difficult ones.  As a result, this means that you might
                 want to use this loss layer when your dataset has some kind of information
                 assymetry between classes, i.e. one class is easier to distinguish than
-                the rest.  Note that when gamma == 0, this loss is exactly the same as the
+                the rest.  In the paper, the authors find that gamma == 2.0 works best in
+                their experiments.  However the optimal value will depend on the task.
+                Note that when gamma == 0, this loss is exactly the same as the
                 loss_multibinary_log_ defined above.
         !*/
 

--- a/docs/docs/ml.xml
+++ b/docs/docs/ml.xml
@@ -359,6 +359,10 @@ Davis E. King. <a href="http://jmlr.csail.mit.edu/papers/volume10/king09a/king09
                   <link>dlib/dnn/loss_abstract.h.html#loss_multibinary_log_</link>
                </item>
                <item>
+                  <name>loss_focal</name>
+                  <link>dlib/dnn/loss_abstract.h.html#loss_focal_</link>
+               </item>
+               <item>
                   <name>loss_barlow_twins</name>
                   <link>#loss_barlow_twins_</link>
                </item>

--- a/docs/docs/release_notes.xml
+++ b/docs/docs/release_notes.xml
@@ -15,6 +15,7 @@ New Features and Improvements:
    - Added Beta distribution to dlib::rand.
    - Deep learning tooling:
       - Added ReOrg layer.
+      - Added Focal loss layer.
       - Added visitor to draw network architectures using the DOT language.
       - Made Barlow Twins loss much faster for high dimensionality inputs.
 

--- a/docs/docs/term_index.xml
+++ b/docs/docs/term_index.xml
@@ -146,6 +146,7 @@
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_multiclass_log_per_pixel_weighted_" include="dlib/dnn.h"/>
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_mean_squared_per_channel_and_pixel_" include="dlib/dnn.h"/>
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_multibinary_log_" include="dlib/dnn.h"/>
+         <term file="dlib/dnn/loss_abstract.h.html" name="loss_focal_" include="dlib/dnn.h"/>
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_ranking_" include="dlib/dnn.h"/>
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_dot_" include="dlib/dnn.h"/>
          <term file="dlib/dnn/loss_abstract.h.html" name="loss_epsilon_insensitive_" include="dlib/dnn.h"/>


### PR DESCRIPTION
This PR adds the Focal Loss layer introduced in the paper: [Focal Loss for Dense Object Detection](https://arxiv.org/abs/1708.02002).

This layer can be seen as an improvement to the `loss_multibinary_log` from #2141.
I actually wonder whether I should remove the `loss_multibinary_log` and just define it as a particular case of the Focal Loss when `gamma == 0`. :sweat_smile: 

I consider this layer to be the ultimate layer for classification problems using neural networks in dlib. Here's my reasoning:

- It is based on the `loss_multibinary_log`, so:
  - It works on par with `loss_multiclass_log` on single label datasets (from my and other people's experiments).
  - It can output nothing when presented with a sample that it's not from the trained categories.
  - It can output multiple labels with high confidence if they appear in the same image (even when trained with single-label datasets).
  - It's straightforward to calibrate using dlib's `learn_platt_scaling`.
  - You can change the relative weights and make up for an imbalanced dataset: in particular, I tried [this paper](https://arxiv.org/abs/1901.05555) on a highly imbalanced dataset, and it works great.
- You can set `gamma > 0` and make the loss focus on classifying hard examples (penalizing predictions with low confidence).
- You can combine both points above.

As you can see, it is a very versatile layer, able to solve multi-label classification problems with dataset imbalance and with samples that can be hard to classify. Maybe at some point, I might add a `loss_focal_per_pixel_` for segmentation problems.

Anyway, for now, what do you think? Somehow, I never paid enough attention to the Focal loss…