### PR TITLE
Add WebP support to imglab

### DIFF
--- a/tools/imglab/src/cluster.cpp
+++ b/tools/imglab/src/cluster.cpp
@@ -302,9 +302,19 @@ int cluster_dataset(
                 temp.push_back(images[assignments[i].idx]);
         }
 
-        string outfile = "cluster_"+pad_int_with_zeros(c+1, 3) + ".jpg";
-        cout << "Saving " << outfile << endl;
-        save_jpeg(tile_images(temp), outfile);
+        if (parser.option("webp"))
+        {
+            string outfile = "cluster_"+pad_int_with_zeros(c+1, 3) + ".webp";
+            cout << "Saving " << outfile << endl;
+            const float webp_quality = std::stof(parser.option("webp").argument());
+            save_webp(tile_images(temp), outfile, webp_quality);
+        }
+        else
+        {
+            string outfile = "cluster_"+pad_int_with_zeros(c+1, 3) + ".jpg";
+            cout << "Saving " << outfile << endl;
+            save_jpeg(tile_images(temp), outfile);
+        }
     }
 
 

--- a/tools/imglab/src/common.cpp
+++ b/tools/imglab/src/common.cpp
@@ -58,3 +58,13 @@ std::string to_jpg_name (const std::string& filename)
 
 // ----------------------------------------------------------------------------------------
 
+std::string to_webp_name (const std::string& filename)
+{
+    std::string::size_type pos = filename.find_last_of(".");
+    if (pos == std::string::npos)
+        throw dlib::error("invalid filename: " + filename);
+    return filename.substr(0,pos) + ".webp";
+}
+
+// ----------------------------------------------------------------------------------------
+

--- a/tools/imglab/src/common.h
+++ b/tools/imglab/src/common.h
@@ -34,6 +34,7 @@ void make_empty_file (
 
 std::string to_png_name (const std::string& filename);
 std::string to_jpg_name (const std::string& filename);
+std::string to_webp_name (const std::string& filename);
 
 // ----------------------------------------------------------------------------------------
 

--- a/tools/imglab/src/flip_dataset.cpp
+++ b/tools/imglab/src/flip_dataset.cpp
@@ -220,6 +220,12 @@ void flip_dataset(const command_line_parser& parser)
             filename = to_jpg_name(filename);
             save_jpeg(temp, filename,JPEG_QUALITY);
         }
+        else if (parser.option("webp"))
+        {
+            filename = to_webp_name(filename);
+            const float webp_quality = std::stof(parser.option("webp").argument());
+            save_webp(temp, filename, webp_quality);
+        }
         else
         {
             save_png(temp, filename);

--- a/tools/imglab/src/main.cpp
+++ b/tools/imglab/src/main.cpp
@@ -567,15 +567,15 @@ int tile_dataset(const command_line_parser& parser)
     {
         save_png(tile_images(images), out_image);
     }
-    else if (ext == "jpg")
-    {
-        save_jpeg(tile_images(images), out_image, JPEG_QUALITY);
-    }
-    else
+    else if (ext == "webp")
     {
         // Lossless by default
         const float webp_quality = get_option(parser, "webp", 101.f);
         save_webp(tile_images(images), out_image, webp_quality);
+    }
+    else
+    {
+        save_jpeg(tile_images(images), out_image, JPEG_QUALITY);
     }
 
     return EXIT_SUCCESS;

--- a/tools/imglab/src/main.cpp
+++ b/tools/imglab/src/main.cpp
@@ -21,7 +21,7 @@
 #include <dlib/dir_nav.h>
 
 
-const char* VERSION = "1.18";
+const char* VERSION = "1.19";
 
 
 
@@ -60,8 +60,8 @@ void create_new_dataset (
         {
             // then parser[i] should be a directory
 
-            std::vector<file> files = get_files_in_directory_tree(parser[i], 
-                                                                  match_endings(".png .PNG .jpeg .JPEG .jpg .JPG .bmp .BMP .dng .DNG .gif .GIF"),
+            std::vector<file> files = get_files_in_directory_tree(parser[i],
+                                                                  match_endings(".png .PNG .jpeg .JPEG .jpg .JPG .bmp .BMP .dng .DNG .gif .GIF .webp .WEBP"),
                                                                   depth);
             sort(files.begin(), files.end());
 
@@ -339,6 +339,12 @@ void rotate_dataset(const command_line_parser& parser)
             filename = to_jpg_name(filename);
             save_jpeg(temp, filename,JPEG_QUALITY);
         }
+        else if (parser.option("webp"))
+        {
+            filename = to_webp_name(filename);
+            const float webp_quality = std::stof(parser.option("webp").argument());
+            save_webp(temp, filename, webp_quality);
+        }
         else
         {
             save_png(temp, filename);
@@ -483,6 +489,12 @@ int resample_dataset(const command_line_parser& parser)
                 dimg.filename = to_jpg_name(dimg.filename);
                 save_jpeg(chip,dimg.filename, JPEG_QUALITY);
             }
+            else if (parser.option("webp"))
+            {
+                dimg.filename = to_webp_name(dimg.filename);
+                const float webp_quality = std::stof(parser.option("webp").argument());
+                save_webp(chip, dimg.filename, webp_quality);
+            }
             else
             {
                 save_png(chip,dimg.filename);
@@ -508,9 +520,9 @@ int tile_dataset(const command_line_parser& parser)
 
     string out_image = parser.option("tile").argument();
     string ext = right_substr(out_image,".");
-    if (ext != "png" && ext != "jpg")
+    if (ext != "png" && ext != "jpg" && ext != "webp")
     {
-        cerr << "The output image file must have either .png or .jpg extension." << endl;
+        cerr << "The output image file must have either .png, .jpg or .webp extension." << endl;
         return EXIT_FAILURE;
     }
 
@@ -552,9 +564,19 @@ int tile_dataset(const command_line_parser& parser)
     chdir.revert();
 
     if (ext == "png")
+    {
         save_png(tile_images(images), out_image);
+    }
+    else if (ext == "jpg")
+    {
+        save_jpeg(tile_images(images), out_image, JPEG_QUALITY);
+    }
     else
-        save_jpeg(tile_images(images), out_image);
+    {
+        // Lossless by default
+        const float webp_quality = get_option(parser, "webp", 101.f);
+        save_webp(tile_images(images), out_image, webp_quality);
+    }
 
     return EXIT_SUCCESS;
 }
@@ -628,6 +650,7 @@ int main(int argc, char** argv)
         parser.add_option("rmignore","Remove all boxes marked ignore and save the results to a new XML file.");
         parser.add_option("rm-if-overlaps","Remove all boxes labeled <arg> if they overlap any box not labeled <arg> and save the results to a new XML file.",1);
         parser.add_option("jpg", "When saving images to disk, write them as jpg files instead of png.");
+        parser.add_option("webp", "When saving images to disk, write them as webp files instead of png or jpg, using <arg> as the quality factor.", 1);
 
         parser.set_group_name("Cropping sub images");
         parser.add_option("resample", "Crop out images that are centered on each object in the dataset. "
@@ -741,6 +764,7 @@ int main(int argc, char** argv)
         parser.check_incompatible_options("rmtrunc", "ignore");
         parser.check_incompatible_options("box-images", "rename");
         parser.check_incompatible_options("box-images", "ignore");
+        parser.check_incompatible_options("jpg", "webp");
         const char* convert_args[] = {"pascal-xml","pascal-v1","idl"};
         parser.check_option_arg_range("convert", convert_args);
         parser.check_option_arg_range("cluster", 0, 999);
@@ -750,6 +774,7 @@ int main(int argc, char** argv)
         parser.check_option_arg_range("cropped-object-size", 4, 10000*10000);
         parser.check_option_arg_range("crop-size", 1.0, 100.0);
         parser.check_option_arg_range("split-train-test", 0.0, 1.0);
+        parser.check_option_arg_range("webp", 0.f, std::numeric_limits<float>::max());
 
         if (parser.option("h"))
         {


### PR DESCRIPTION
It should have been included in #2565.
I just noticed imglab couldn't find a dataset with WebP images.