### PR TITLE
Fix saving grayscale WebP images

### DIFF
--- a/dlib/image_saver/save_webp.h
+++ b/dlib/image_saver/save_webp.h
@@ -76,7 +76,7 @@ namespace dlib
         auto data = reinterpret_cast<const uint8_t*>(image_data(img));
         const int width = img.nc();
         const int height = img.nr();
-        const int stride = width_step(img);
+        int stride = width_step(img);
         if (pixel_traits<pixel_type>::rgb_alpha)
         {
             if (pixel_traits<pixel_type>::bgr_layout)
@@ -94,8 +94,10 @@ namespace dlib
         else
         {
             // This is some other kind of color image so just save it as an RGB image.
+            // We also need to recompute the stride in case we were given a grayscale image.
             array2d<rgb_pixel> temp;
             assign_image(temp, img);
+            stride = width_step(temp);
             auto data = reinterpret_cast<const uint8_t*>(image_data(temp));
             impl::impl_save_webp(filename, data, width, height, stride, quality, impl::webp_type::rgb);
         }

--- a/docs/docs/release_notes.xml
+++ b/docs/docs/release_notes.xml
@@ -16,6 +16,7 @@ New Features and Improvements:
 Non-Backwards Compatible Changes:
 
 Bug fixes:
+   - Fix saving grayscale WebP images (PR #2591)
 </current>
 
 <!-- **************************************************************************************  -->


### PR DESCRIPTION
I just noticed that there was a problem when saving grayscale images in WebP format.
WebP does not support single-channel images, so we need to save them as RGB, which we were doing.
However, the stride was wrong: I was using the stride as if it were a single-channel image, so we need to recompute it before saving.

This PR addresses this issue.

Fun fact: even though we save a lossless RGB image in WebP, it still takes less disk space than the grayscale PNG, at least for the images I tried.