### PR TITLE
Fix memory leak when writing WebP throws

### DIFF
--- a/dlib/image_saver/save_webp.cpp
+++ b/dlib/image_saver/save_webp.cpp
@@ -74,7 +74,10 @@ namespace dlib {
             {
                 fout.write(reinterpret_cast<char*>(output), output_size);
                 if (!fout.good())
+                {
+                    WebPFree(output);
                     throw image_save_error("Error while writing WebP image to " + filename + ".");
+                }
             }
             else
             {


### PR DESCRIPTION
I just noticed that, if we successfully encode an image into WebP, but fail to write it to disk for some reason, we must free the encoded image in memory. Otherwise, we would leak memory.