### PR TITLE
Use chrono in console progress indicator and add finish method

### DIFF
--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -93,7 +93,7 @@ namespace dlib
         ) const;
         /*!
             ensures
-                - This objects prints the completed progress and the ellapsed time to out.
+                - This objects prints the completed progress and the elapsed time to out.
                   It is meant to be called after the loop we are training the progress of.
         !*/
 
@@ -236,7 +236,7 @@ namespace dlib
             const auto hours = std::chrono::duration_cast<std::chrono::hours>(delta_t);
             const auto minutes = std::chrono::duration_cast<std::chrono::minutes>(delta_t) - hours;
             const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(delta_t) - hours - minutes;
-            out << "Time ellapsed: ";
+            out << "Time elapsed: ";
             if (delta_t >= std::chrono::hours(1))
                 out << hours.count() << "h ";
             if (delta_t >= std::chrono::minutes(1))

--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -220,32 +220,32 @@ namespace dlib
         std::ostream& out
     ) const
     {
-            const auto oldflags = out.flags();
-            out.setf(std::ios::fixed,std::ios::floatfield);
-            std::streamsize ss;
+        const auto oldflags = out.flags();
+        out.setf(std::ios::fixed,std::ios::floatfield);
+        std::streamsize ss;
 
-            // adapt the precision based on whether the target val is an integer
-            if (std::trunc(target_val) == target_val)
-                ss = out.precision(0);
-            else
-                ss = out.precision(2);
+        // adapt the precision based on whether the target val is an integer
+        if (std::trunc(target_val) == target_val)
+            ss = out.precision(0);
+        else
+            ss = out.precision(2);
 
-            out << "Progress: " << target_val << "/" << target_val;
-            out << " (100.00%). ";
-            const auto delta_t = std::chrono::steady_clock::now() - start_time;
-            const auto hours = std::chrono::duration_cast<std::chrono::hours>(delta_t);
-            const auto minutes = std::chrono::duration_cast<std::chrono::minutes>(delta_t) - hours;
-            const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(delta_t) - hours - minutes;
-            out << "Time elapsed: ";
-            if (delta_t >= std::chrono::hours(1))
-                out << hours.count() << "h ";
-            if (delta_t >= std::chrono::minutes(1))
-                out << minutes.count() << "min ";
-            out << seconds.count() << "s.                " << std::endl;
+        out << "Progress: " << target_val << "/" << target_val;
+        out << " (100.00%). ";
+        const auto delta_t = std::chrono::steady_clock::now() - start_time;
+        const auto hours = std::chrono::duration_cast<std::chrono::hours>(delta_t);
+        const auto minutes = std::chrono::duration_cast<std::chrono::minutes>(delta_t) - hours;
+        const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(delta_t) - hours - minutes;
+        out << "Time elapsed: ";
+        if (delta_t >= std::chrono::hours(1))
+            out << hours.count() << "h ";
+        if (delta_t >= std::chrono::minutes(1))
+            out << minutes.count() << "min ";
+        out << seconds.count() << "s.                " << std::endl;
 
-            // restore previous output flags and precision settings
-            out.flags(oldflags);
-            out.precision(ss);
+        // restore previous output flags and precision settings
+        out.flags(oldflags);
+        out.precision(ss);
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -68,7 +68,7 @@ namespace dlib
         inline bool print_status (
             double cur,
             bool always_print = false,
-            std::ostream& out = std::cout
+            std::ostream& out = std::clog
         );
         /*!
             ensures

--- a/dlib/console_progress_indicator.h
+++ b/dlib/console_progress_indicator.h
@@ -93,8 +93,8 @@ namespace dlib
         ) const;
         /*!
             ensures
-                - This objects prints the completed progress and the elapsed time to out.
-                  It is meant to be called after the loop we are training the progress of.
+                - This object prints the completed progress and the elapsed time to out.
+                  It is meant to be called after the loop we are tracking the progress of.
         !*/
 
     private:

--- a/dlib/threads/parallel_for_extension.h
+++ b/dlib/threads/parallel_for_extension.h
@@ -449,6 +449,7 @@ namespace dlib
 
         impl::parfor_verbose_helper<T> helper(obj, funct, begin, end);
         parallel_for(tp, begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -474,6 +475,7 @@ namespace dlib
 
         impl::parfor_verbose_helper<T> helper(obj, funct, begin, end);
         parallel_for(num_threads, begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -498,6 +500,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for(tp, begin, end,  helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -522,6 +525,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for(num_threads, begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -545,6 +549,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for(begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -595,6 +600,7 @@ namespace dlib
 
         impl::parfor_verbose_helper3<T> helper(obj, funct, begin, end);
         parallel_for_blocked(num_threads, begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -619,6 +625,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for_blocked(tp, begin, end,  helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -643,6 +650,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for_blocked(num_threads, begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------
@@ -666,6 +674,7 @@ namespace dlib
 
         impl::parfor_verbose_helper2<T> helper(funct, begin, end);
         parallel_for_blocked(begin, end, helper, chunks_per_thread);
+        helper.pbar.finish();
     }
 
 // ----------------------------------------------------------------------------------------

--- a/docs/docs/release_notes.xml
+++ b/docs/docs/release_notes.xml
@@ -12,6 +12,8 @@
 
 <current>
 New Features and Improvements:
+   - Use std::chrono in console_progress_indicator to display mixed time units.
+   - Add a finish method to console_progress_indicator that will display the elapsed time.
 
 Non-Backwards Compatible Changes:
 


### PR DESCRIPTION
Hi, I've updated a little bit the `console_progress_indicator`.

Since C++11 is a minimal requirement for dlib, it now uses `std::chrono` for all time manipulations (I really like `std::chrono`).
I've also added a `finish` method that will print the completed progress and the ellapsed time.

While running (subsequent calls to `print_status`):
```
Progress: 51/1000 (5.10%). Time remaining: 1min 34s.
```

After calling `finish`:
```
Progress: 1000/1000 (100.00%). Time elapsed: 1min 39s.
```
This `finish` method is meant to be called after a loop so that you don't need to remember the estimated time the first call to `print_progress` printed.

I hope you like it :)