### PR TITLE
Fix typo in the self-supervised learning example

### DIFF
--- a/examples/dnn_self_supervised_learning_ex.cpp
+++ b/examples/dnn_self_supervised_learning_ex.cpp
@@ -22,7 +22,7 @@
           representations as: C = trans(ZA) * ZB.
         - make C as close as possible to the identity matrix.
 
-    This removes the redundancy of the feature representations, by maximizing the
+    This removes the redundancy of the feature representations by maximizing the
     encoded information about the images themselves, while minimizing the information
     about the transforms and data augmentations used to obtain the representations.
 


### PR DESCRIPTION
A small typo fix to trigger the CI.