### PR TITLE
YOLO improvements: Smoothed L1 loss, Focal Loss, Weighted Loss

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3544,7 +3544,7 @@ namespace dlib
     {
         int version = 0;
         deserialize(version, in);
-        if (version != 1 && version != 2)
+        if (!(1 <= version && version <= 2))
             throw serialization_error("Unexpected version found while deserializing dlib::yolo_options.");
         deserialize(item.anchors, in);
         deserialize(item.labels, in);
@@ -3555,7 +3555,7 @@ namespace dlib
         deserialize(item.lambda_obj, in);
         deserialize(item.lambda_box, in);
         deserialize(item.lambda_cls, in);
-        if (version == 2)
+        if (version >= 2)
         {
             deserialize(item.gamma_obj, in);
             deserialize(item.gamma_cls, in);

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3518,12 +3518,13 @@ namespace dlib
         double lambda_obj = 1.0;
         double lambda_box = 1.0;
         double lambda_cls = 1.0;
+        double gamma_cls = 0.0;
 
     };
 
     inline void serialize(const yolo_options& item, std::ostream& out)
     {
-        int version = 1;
+        int version = 2;
         serialize(version, out);
         serialize(item.anchors, out);
         serialize(item.labels, out);
@@ -3534,13 +3535,14 @@ namespace dlib
         serialize(item.lambda_obj, out);
         serialize(item.lambda_box, out);
         serialize(item.lambda_cls, out);
+        serialize(item.gamma_cls, out);
     }
 
     inline void deserialize(yolo_options& item, std::istream& in)
     {
         int version = 0;
         deserialize(version, in);
-        if (version != 1)
+        if (version != 1 && version != 2)
             throw serialization_error("Unexpected version found while deserializing dlib::yolo_options.");
         deserialize(item.anchors, in);
         deserialize(item.labels, in);
@@ -3551,6 +3553,8 @@ namespace dlib
         deserialize(item.lambda_obj, in);
         deserialize(item.lambda_box, in);
         deserialize(item.lambda_cls, in);
+        if (version == 2)
+            deserialize(item.gamma_cls, in);
     }
 
     inline std::ostream& operator<<(std::ostream& out, const std::map<int, std::vector<yolo_options::anchor_box_details>>& anchors)
@@ -3755,6 +3759,7 @@ namespace dlib
                     double best_iou = 0;
                     size_t best_a = 0;
                     size_t best_tag_id = 0;
+                    running_stats<double> ious;
                     for (const auto& item : options.anchors)
                     {
                         const auto tag_id = item.first;
@@ -3768,14 +3773,20 @@ namespace dlib
                                 best_iou = iou;
                                 best_a = a;
                                 best_tag_id = tag_id;
+                                ious.add(iou);
                             }
                         }
                     }
 
+                    // ATSS: Adaptive Training Sample Selection
+                    double iou_anchor_threshold = options.iou_anchor_threshold;
+                    if (iou_anchor_threshold == 0)
+                        iou_anchor_threshold = ious.mean() + ious.stddev();
+
                     for (size_t a = 0; a < anchors.size(); ++a)
                     {
                         // Update best anchor if it's from the current stride, and optionally other anchors
-                        if ((best_tag_id == tag_id<TAG_TYPE>::id && best_a == a) || options.iou_anchor_threshold < 1)
+                        if ((best_tag_id == tag_id<TAG_TYPE>::id && best_a == a) || iou_anchor_threshold < 1)
                         {
 
                             // do not update other anchors if they have low IoU
@@ -3783,7 +3794,7 @@ namespace dlib
                             {
                                 const yolo_rect anchor(centered_drect(t_center, anchors[a].width, anchors[a].height));
                                 const double iou = box_intersection_over_union(truth_box.rect, anchor.rect);
-                                if (iou < options.iou_anchor_threshold)
+                                if (iou < iou_anchor_threshold)
                                     continue;
                             }
 
@@ -3800,28 +3811,37 @@ namespace dlib
                             // Scale regression error according to the truth size
                             const double scale_box = options.lambda_box * (2 - truth_box.rect.area() / input_rect.area());
 
-                            // Compute the gradient for the box coordinates
+                            // Compute the smoothed L1 gradient for the box coordinates
                             const auto x_idx = tensor_index(output_tensor, n, k + 0, r, c);
                             const auto y_idx = tensor_index(output_tensor, n, k + 1, r, c);
                             const auto w_idx = tensor_index(output_tensor, n, k + 2, r, c);
                             const auto h_idx = tensor_index(output_tensor, n, k + 3, r, c);
-                            g[x_idx] = scale_box * (out_data[x_idx] * 2.0 - 0.5 - tx);
-                            g[y_idx] = scale_box * (out_data[y_idx] * 2.0 - 0.5 - ty);
-                            g[w_idx] = scale_box * (out_data[w_idx] - tw);
-                            g[h_idx] = scale_box * (out_data[h_idx] - th);
+                            g[x_idx] = scale_box * put_in_range(-1, 1, (out_data[x_idx] * 2.0 - 0.5 - tx));
+                            g[y_idx] = scale_box * put_in_range(-1, 1, (out_data[y_idx] * 2.0 - 0.5 - ty));
+                            g[w_idx] = scale_box * put_in_range(-1, 1, (out_data[w_idx] - tw));
+                            g[h_idx] = scale_box * put_in_range(-1, 1, (out_data[h_idx] - th));
 
                             // This grid cell should detect an object
                             const auto o_idx = tensor_index(output_tensor, n, k + 4, r, c);
                             g[o_idx] = options.lambda_obj * (out_data[o_idx] - 1);
 
-                            // Compute the classification error
+                            // Compute the classification error using the truth weights and the focal loss
                             for (long i = 0; i < num_classes; ++i)
                             {
                                 const auto c_idx = tensor_index(output_tensor, n, k + 5 + i, r, c);
+                                const auto p = out_data[c_idx];
                                 if (truth_box.label == options.labels[i])
-                                    g[c_idx] = options.lambda_cls * (out_data[c_idx] - 1);
+                                {
+                                    const float focus = std::pow(1 - p, options.gamma_cls);
+                                    const float g_cls = focus * (options.gamma_cls * p * safe_log(p) + p - 1);
+                                    g[c_idx] = truth_box.detection_confidence * options.lambda_cls * g_cls;
+                                }
                                 else
-                                    g[c_idx] = options.lambda_cls * out_data[c_idx];
+                                {
+                                    const float focus = std::pow(p, options.gamma_cls);
+                                    const float g_cls = focus * (options.gamma_cls * (1 - p) * safe_log(1 - p) + p);
+                                    g[c_idx] = truth_box.detection_confidence * options.lambda_cls * g_cls;
+                                }
                             }
                         }
                     }

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3925,6 +3925,7 @@ namespace dlib
         }
 
         const yolo_options& get_options() const { return options; }
+        yolo_options& get_options() { return options; }
 
         void adjust_nms(double iou_thresh, double percent_covered_thresh = 1, bool classwise = true)
         {
@@ -3976,6 +3977,7 @@ namespace dlib
             out << ", lambda_obj:" << opts.lambda_obj;
             out << ", lambda_box:" << opts.lambda_box;
             out << ", lambda_cls:" << opts.lambda_cls;
+            out << ", gamma_cls:" << opts.gamma_cls;
             out << ", overlaps_nms:(" << opts.overlaps_nms.get_iou_thresh() << "," << opts.overlaps_nms.get_percent_covered_thresh() << ")";
             out << ", classwise_nms:" << std::boolalpha << opts.classwise_nms;
             out << ")";

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3940,7 +3940,6 @@ namespace dlib
         }
 
         const yolo_options& get_options() const { return options; }
-        yolo_options& get_options() { return options; }
 
         void adjust_nms(double iou_thresh, double percent_covered_thresh = 1, bool classwise = true)
         {

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -2012,6 +2012,12 @@ namespace dlib
             ensures
                 - returns the options object that defines the general behavior of this loss layer.
         !*/
+        yolo_options& get_options (
+        );
+        /*!
+            ensures
+                - returns the options object that defines the general behavior of this loss layer.
+        !*/
 
         template <
             typename SUB_TYPE,

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -1928,21 +1928,33 @@ namespace dlib
         // When computing the YOLO loss (objectness + bounding box regression + classification),
         // the best match between a truth and an anchor is always used, regardless of the IoU.
         // However, if other anchors have an IoU with a truth box above iou_anchor_threshold, they
-        // will also experience loss against that truth box as well.  Setting iou_anchor_threshold to 1 will
-        // make the model use only the best anchor for each ground truth, so other anchors can be
-        // used for other ground truth boxes in the same cell (useful for detecting objects in crowds).
-        // This setting is meant to be used with "high capacity" models, not small ones.
+        // will also experience loss against that truth box as well.  Setting iou_anchor_threshold
+        // to 1 will make the model use only the best anchor for each ground truth, so other
+        // anchors can be used for other ground truth boxes in the same cell (useful for detecting
+        // objects in crowds).  This setting is meant to be used with "high capacity" models, not
+        // small ones.  Additionaly, when this value is set to 0, it will adaptively compute the
+        // IOU threshold based on the statistics of the IOUS from all anchors with the current
+        // target truth box. In particular, it follows the adaptive training sample selection
+        // (ATSS) from the paper: "Bridging the Gap Between Anchor-based and Anchor-free Detection
+        // via Adaptive Training Sample Selection" by Shifeng Zhang, et al.
+        // (https://arxiv.org/abs/1912.02424)
         double iou_anchor_threshold = 1.0;
         // When doing non-max suppression, we use overlaps_nms to decide if a box overlaps
         // an already output detection and should therefore be thrown out.
         test_box_overlap overlaps_nms = test_box_overlap(0.45, 1.0);
         // When set to true, NMS will only be applied between objects with the same class label.
         bool classwise_nms = true;
-        // These parameters control how we penalize different kinds of mistakes: notably the objectness loss,
-        // the box (bounding box regression) loss, and the classification loss.
+        // These parameters control how we penalize different kinds of mistakes: notably the
+        // objectness loss, the box (bounding box regression) loss, and the classification loss.
         double lambda_obj = 1.0;
         double lambda_box = 1.0;
         double lambda_cls = 1.0;
+        // This parameter makes the classifier behave like the Focal loss, presented in the paper:
+        // "Focal Loss for Dense Object Detection", by Tsung-Yi Lin, et al.
+        // (https://arxiv.org/abs/1708.02002)
+        // This gamma acts as a modulating factor to the cross-entropy layer by reducing the
+        // relative loss for well-classified examples, and focusing on the difficult ones.
+        double gamma_cls = 0.0;
 
     };
 

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -1949,11 +1949,13 @@ namespace dlib
         double lambda_obj = 1.0;
         double lambda_box = 1.0;
         double lambda_cls = 1.0;
-        // This parameter makes the classifier behave like the Focal loss, presented in the paper:
+        // This parameter makes YOLO behave like the Focal loss, presented in the paper:
         // "Focal Loss for Dense Object Detection", by Tsung-Yi Lin, et al.
         // (https://arxiv.org/abs/1708.02002)
-        // This gamma acts as a modulating factor to the cross-entropy layer by reducing the
-        // relative loss for well-classified examples, and focusing on the difficult ones.
+        // The gamma_obj and gamma_cls act as a modulating factor to the cross-entropy layers of
+        // objectness and classification by reducing the relative loss for well-classified
+        // examples, and focusing on the difficult ones.
+        double gamma_obj = 0.0;
         double gamma_cls = 0.0;
 
     };

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -2014,12 +2014,6 @@ namespace dlib
             ensures
                 - returns the options object that defines the general behavior of this loss layer.
         !*/
-        yolo_options& get_options (
-        );
-        /*!
-            ensures
-                - returns the options object that defines the general behavior of this loss layer.
-        !*/
 
         template <
             typename SUB_TYPE,


### PR DESCRIPTION
Here there are some (backwards-compatible) for the YOLO layer:

- use the Smoothed L1 norm in the bounding box regression to stabilize the training.
- optional focal losses for the objectness and classifier.
- use the `truth.detection_confidence` as the positive weight for the classification loss.  This could be used to handle imbalance in the classifier.

By doing so, on an internal dataset, I was able to gain 1 mAP point.

I also added [Adaptive Training Sample Selection (ATSS)](https://arxiv.org/abs/1912.02424): when `iou_anchor_threshold` is set to 0, the threshold will be adjusted adaptively for each ground truth, according to how it matches the anchors. The motivation is:

- if an anchor matches really well (high IoU), the threshold will be high and other anchors won't be used. 
- if no anchor has a high IoU, then the threshold will be low, and more anchors will be used.

You are welcome to reject, of course… At least the code is now visible, in case people want to use it.