### PR TITLE
Modernize rounding and cast statements

### DIFF
--- a/dlib/bigint/bigint_kernel_2.cpp
+++ b/dlib/bigint/bigint_kernel_2.cpp
@@ -1528,7 +1528,7 @@ namespace dlib
             const uint32 len = lhs->digits_used + rhs->digits_used;
             for (unsigned long i = 0; i < len; ++i)
             {
-                uint64 num1 = static_cast<uint64>(std::floor(a[i*2].real()+0.5));
+                uint64 num1 = static_cast<uint64>(std::round(a[i*2].real()));
                 num1 += carry;
                 carry = 0;
                 if (num1 > 255)
@@ -1537,7 +1537,7 @@ namespace dlib
                     num1 = (num1&0xFF);
                 }
 
-                uint64 num2 = static_cast<uint64>(std::floor(a[i*2+1].real()+0.5));
+                uint64 num2 = static_cast<uint64>(std::round(a[i*2+1].real()));
                 num2 += carry;
                 carry = 0;
                 if (num2 > 255)

--- a/dlib/geometry/drectangle.h
+++ b/dlib/geometry/drectangle.h
@@ -64,10 +64,10 @@ namespace dlib
         operator rectangle (
         ) const
         {
-            return rectangle((long)std::floor(l+0.5), 
-                             (long)std::floor(t+0.5),
-                             (long)std::floor(r+0.5),
-                             (long)std::floor(b+0.5));
+            return rectangle(std::lround(l),
+                             std::lround(t),
+                             std::lround(r),
+                             std::lround(b));
         }
 
         double left()   const { return l; }

--- a/dlib/geometry/rectangle.h
+++ b/dlib/geometry/rectangle.h
@@ -650,10 +650,10 @@ namespace dlib
     {
         DLIB_ASSERT(scale > 0, "scale factor must be > 0");
 
-        long l = (long)std::round(rect.left()*scale);
-        long t = (long)std::round(rect.top()*scale);
-        long r = (long)std::round(rect.right()*scale);
-        long b = (long)std::round(rect.bottom()*scale);
+        const long l = std::lround(rect.left()*scale);
+        const long t = std::lround(rect.top()*scale);
+        const long r = std::lround(rect.right()*scale);
+        const long b = std::lround(rect.bottom()*scale);
         return rectangle(l, t, r, b);
     }
 
@@ -770,8 +770,8 @@ namespace dlib
         }
         else
         {
-            double scale = std::sqrt(area/(double)rect.area());
-            return centered_rect(rect, (long)std::round(rect.width()*scale), (long)std::round(rect.height()*scale));
+            const double scale = std::sqrt(area/static_cast<double>(rect.area()));
+            return centered_rect(rect, std::lround(rect.width()*scale), std::lround(rect.height()*scale));
         }
     }
 #if defined (_MSC_VER)

--- a/dlib/gui_widgets/canvas_drawing.h
+++ b/dlib/gui_widgets/canvas_drawing.h
@@ -258,8 +258,8 @@ namespace dlib
         const long y = center_point.y();
         if (radius > 1)
         {
-            long first_x = static_cast<long>(x - radius + 0.5);
-            long last_x = static_cast<long>(x + radius + 0.5);
+            long first_x = std::lround(x - radius);
+            long last_x = std::lround(x + radius);
             const double rs = radius*radius;
 
             // ensure that we only loop over the part of the x dimension that this
@@ -271,7 +271,7 @@ namespace dlib
 
             long top, bottom;
 
-            top = static_cast<long>(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0)));
             top += y;
             long last = top;
 
@@ -281,7 +281,7 @@ namespace dlib
             {
                 double a = i - x + 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 
@@ -304,7 +304,7 @@ namespace dlib
             }
 
             middle = std::max(x,first_x);
-            top = static_cast<long>(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0)));
             top += y;
             last = top;
             // draw the right half of the circle
@@ -312,7 +312,7 @@ namespace dlib
             {
                 double a = i - x - 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 
@@ -365,8 +365,8 @@ namespace dlib
         const long y = center_point.y();
         if (radius > 1)
         {
-            long first_x = static_cast<long>(x - radius + 0.5);
-            long last_x = static_cast<long>(x + radius + 0.5);
+            long first_x = std::lround(x - radius);
+            long last_x = std::lround(x + radius);
             const double rs = radius*radius;
 
             // ensure that we only loop over the part of the x dimension that this
@@ -378,7 +378,7 @@ namespace dlib
 
             long top, bottom;
 
-            top = static_cast<long>(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0)));
             top += y;
             long last = top;
 
@@ -388,7 +388,7 @@ namespace dlib
             {
                 double a = i - x + 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 
@@ -403,7 +403,7 @@ namespace dlib
             }
 
             middle = std::max(x,first_x);
-            top = static_cast<long>(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0)));
             top += y;
             last = top;
             // draw the right half of the circle
@@ -411,7 +411,7 @@ namespace dlib
             {
                 double a = i - x - 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 

--- a/dlib/image_keypoint/hessian_pyramid.h
+++ b/dlib/image_keypoint/hessian_pyramid.h
@@ -123,7 +123,7 @@ namespace dlib
                 for (long i = 0; i < num_intervals; ++i)
                 {
                     const long border_size = get_border_size(i)*step_size;
-                    const long lobe_size = static_cast<long>(std::pow(2.0, o+1.0)+0.5)*(i+1) + 1;
+                    const long lobe_size = std::lround(std::pow(2.0, o+1.0))*(i+1) + 1;
                     const double area_inv = 1.0/std::pow(3.0*lobe_size, 2.0);
 
                     const long lobe_offset = lobe_size/2+1;
@@ -206,7 +206,7 @@ namespace dlib
                 << "\n\t octave: " << octave 
             );
 
-            return initial_step_size*static_cast<long>(std::pow(2.0, (double)octave)+0.5);
+            return initial_step_size*std::lround(std::pow(2.0, (double)octave));
         }
 
         long nr (

--- a/dlib/image_keypoint/surf.h
+++ b/dlib/image_keypoint/surf.h
@@ -92,7 +92,7 @@ namespace dlib
         std::vector<double> ang;
         std::vector<dlib::vector<double,2> > samples;
 
-        const long sc = static_cast<long>(scale+0.5);
+        const long sc = std::lround(scale);
 
         // accumulate a bunch of angle and vector samples
         dlib::vector<double,2> vect;
@@ -176,7 +176,7 @@ namespace dlib
         point_rotator rot(angle);
         point_rotator inv_rot(-angle);
 
-        const long sc = static_cast<long>(scale+0.5);
+        const long sc = std::lround(scale);
         long count = 0;
 
         // loop over the 4x4 grid of histogram buckets 

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -481,7 +481,7 @@ namespace dlib
 
             long top, bottom;
 
-            top = static_cast<long>(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (first_x-x-0.5)*(first_x-x-0.5),0.0)));
             top += y;
             long last = top;
 
@@ -491,7 +491,7 @@ namespace dlib
             {
                 double a = i - x + 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 
@@ -506,7 +506,7 @@ namespace dlib
             }
 
             middle = std::max(cp.x(),first_x);
-            top = static_cast<long>(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0))+0.5);
+            top = std::lround(sqrt(std::max(rs - (last_x-x+0.5)*(last_x-x+0.5),0.0)));
             top += y;
             last = top;
             // draw the right half of the circle
@@ -514,7 +514,7 @@ namespace dlib
             {
                 double a = i - x - 0.5;
                 // find the top of the arc
-                top = static_cast<long>(sqrt(std::max(rs - a*a,0.0))+0.5);
+                top = std::lround(sqrt(std::max(rs - a*a,0.0)));
                 top += y;
                 long temp = top;
 

--- a/dlib/image_transforms/fhog.h
+++ b/dlib/image_transforms/fhog.h
@@ -814,14 +814,14 @@ namespace dlib
             const int padding_cols_offset = (filter_cols_padding-1)/2;
             init_hog(hog, hog_nr, hog_nc, filter_rows_padding, filter_cols_padding);
 
-            const int visible_nr = std::min((long)cells_nr*cell_size,img.nr())-1;
-            const int visible_nc = std::min((long)cells_nc*cell_size,img.nc())-1;
+            const int visible_nr = std::min(cells_nr*cell_size,static_cast<int>(img.nr()))-1;
+            const int visible_nc = std::min(cells_nc*cell_size,static_cast<int>(img.nc()))-1;
 
             // First populate the gradient histograms
             for (int y = 1; y < visible_nr; y++) 
             {
-                const float yp = ((float)y+0.5)/(float)cell_size - 0.5;
-                const int iyp = (int)std::floor(yp);
+                const float yp = (y + 0.5) / static_cast<float>(cell_size) - 0.5;
+                const int iyp = static_cast<int>(std::floor(yp));
                 const float vy0 = yp - iyp;
                 const float vy1 = 1.0 - vy0;
                 int x;
@@ -835,7 +835,7 @@ namespace dlib
                     // We will use bilinear interpolation to add into the histogram bins.
                     // So first we precompute the values needed to determine how much each
                     // pixel votes into each bin.
-                    simd8f xp = (xx + 0.5) / (float)cell_size + 0.5;
+                    simd8f xp = (xx + 0.5) / static_cast<float>(cell_size) + 0.5;
                     simd8i ixp = simd8i(xp);
                     simd8f vx0 = xp - ixp;
                     simd8f vx1 = 1.0f - vx0;
@@ -943,8 +943,8 @@ namespace dlib
 
                     v = std::sqrt(v);
                     // add to 4 histograms around pixel using bilinear interpolation
-                    const float xp = ((double)x + 0.5) / (double)cell_size - 0.5;
-                    const int ixp = (int)std::floor(xp);
+                    const float xp = (x + 0.5) / static_cast<double>(cell_size) - 0.5;
+                    const int ixp = static_cast<int>(std::floor(xp));
                     const float vx0 = xp - ixp;
                     const float vx1 = 1.0 - vx0;
 

--- a/dlib/image_transforms/image_pyramid.h
+++ b/dlib/image_transforms/image_pyramid.h
@@ -941,7 +941,7 @@ namespace dlib
             COMPILE_TIME_ASSERT( pixel_traits<out_pixel_type>::has_alpha == false );
 
 
-            set_image_size(down, (std::lround((N-1)*num_rows(original))/N), std::lround(((N-1)*num_columns(original))/N+0.5));
+            set_image_size(down, std::lround(((N-1)*num_rows(original))/N), std::lround(((N-1)*num_columns(original))/N));
             resize_image(original, down);
         }
 

--- a/dlib/image_transforms/image_pyramid.h
+++ b/dlib/image_transforms/image_pyramid.h
@@ -941,7 +941,7 @@ namespace dlib
             COMPILE_TIME_ASSERT( pixel_traits<out_pixel_type>::has_alpha == false );
 
 
-            set_image_size(down, (std::lround((N-1)*num_rows(original))/N), std::lround(((N-1)*num_columns(original))/N+0.5);
+            set_image_size(down, (std::lround((N-1)*num_rows(original))/N), std::lround(((N-1)*num_columns(original))/N+0.5));
             resize_image(original, down);
         }
 

--- a/dlib/image_transforms/image_pyramid.h
+++ b/dlib/image_transforms/image_pyramid.h
@@ -941,7 +941,7 @@ namespace dlib
             COMPILE_TIME_ASSERT( pixel_traits<out_pixel_type>::has_alpha == false );
 
 
-            set_image_size(down, ((N-1)*num_rows(original))/N+0.5, ((N-1)*num_columns(original))/N+0.5);
+            set_image_size(down, (std::lround((N-1)*num_rows(original))/N), std::lround(((N-1)*num_columns(original))/N+0.5);
             resize_image(original, down);
         }
 
@@ -1168,7 +1168,7 @@ namespace dlib
         DLIB_CASSERT(0 < scale && scale <= 1);
         pyramid_type pyr;
         // This scale factor maps this many levels down the pyramid
-        long pyramid_down_iter = static_cast<long>(std::log(scale)/std::log(pyramid_rate(pyr))+0.5);
+        long pyramid_down_iter = std::lround(std::log(scale)/std::log(pyramid_rate(pyr)));
         pyramid_down_iter = put_in_range(0, (long)rects.size()-1, pyramid_down_iter);
 
         return rects[pyramid_down_iter].tl_corner() + pyr.point_down(p, pyramid_down_iter);

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -1658,7 +1658,7 @@ namespace dlib
         chip_details() : angle(0), rows(0), cols(0) {}
         chip_details(const rectangle& rect_) : rect(rect_),angle(0), rows(rect_.height()), cols(rect_.width()) {}
         chip_details(const drectangle& rect_) : rect(rect_),angle(0), 
-          rows((unsigned long)(rect_.height()+0.5)), cols((unsigned long)(rect_.width()+0.5)) {}
+          rows(std::lround(rect_.height())), cols(std::lround(rect_.width())) {}
         chip_details(const drectangle& rect_, unsigned long size) : rect(rect_),angle(0) 
         { compute_dims_from_size(size); }
         chip_details(const drectangle& rect_, unsigned long size, double angle_) : rect(rect_),angle(angle_) 

--- a/dlib/matrix/matrix_math_functions.h
+++ b/dlib/matrix/matrix_math_functions.h
@@ -179,8 +179,8 @@ namespace dlib
         typedef typename M::type type;
         typedef const typename M::type const_ret_type;
         const_ret_type apply (long r, long c) const
-        { 
-            return static_cast<type>(std::floor(this->m(r,c)+0.5)); 
+        {
+            return static_cast<type>(std::round(this->m(r,c)));
         }
     };
 

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -168,20 +168,21 @@ ADD_EXECUTABLE(${target_name} main.cpp tester.cpp ${tests})
 
 if (CMAKE_COMPILER_IS_GNUCXX)
    # Turn on all warnings, and treat them as errors.
-   add_definitions("-W -Wall -Wextra -Werror")
+   add_compile_options(-W -Wall -Wextra -Wpedantic -Werror)
+   add_compile_options(-fdiagnostics-color=always)
    # I don't care about unused testing functions though.  I like to keep them
    # around.  Don't warn about it.
-   add_definitions("-Wno-unused-function")
-   add_definitions("-Wno-strict-overflow")
-   add_definitions("-Wno-maybe-uninitialized")
+   add_compile_options(-Wno-unused-function)
+   add_compile_options(-Wno-strict-overflow)
+   add_compile_options(-Wno-maybe-uninitialized)
 elseif (MSVC)
    # Treat warnings as errors.
-   add_definitions("/WX")
+   add_compile_options(/WX)
 else() # basically Clang
    # Treat warnings as errors, but do not turn on all warnings.
-   add_definitions("-W -Werror")
+   add_compile_options(-W -Werror)
    # This is for the comment in face_detection_ex.cpp that says "faces/*.jpg"
-   add_definitions("-Wno-comment")
+   add_compile_options(-Wno-comment)
 endif()
 
 

--- a/dlib/test/fhog.cpp
+++ b/dlib/test/fhog.cpp
@@ -61,9 +61,9 @@ namespace
             dlib::array<array2d<float> > hog;
             extract_fhog_features(img, hog, sbin);
             DLIB_TEST(hog.size() == 31);
-            DLIB_TEST_MSG(hog[0].nr() == max(static_cast<int>(img.nr()/(double)sbin+0.5)-2,0),
-                hog[0].nr() << "   " << max(static_cast<int>(img.nr()/(double)sbin+0.5)-2,0));
-            DLIB_TEST(hog[0].nc() == max(static_cast<int>(img.nc()/(double)sbin+0.5)-2,0));
+            DLIB_TEST_MSG(hog[0].nr() == max(lround(img.nr()/static_cast<double>(sbin))-2,0l),
+                hog[0].nr() << "   " << max(lround(img.nr()/static_cast<double>(sbin))-2,0l));
+            DLIB_TEST(hog[0].nc() == max(lround(img.nc()/static_cast<double>(sbin))-2,0l));
 
             DLIB_TEST(hog.size() == 31);
             for (long o = 0; o < (long)hog.size(); ++o)
@@ -94,8 +94,8 @@ namespace
                 extract_fhog_features(img, hog);
 
                 DLIB_TEST(hog.size() == 31);
-                DLIB_TEST(hog[0].nr() == max(static_cast<int>(img.nr()/8.0+0.5)-2,0));
-                DLIB_TEST(hog[0].nc() == max(static_cast<int>(img.nc()/8.0+0.5)-2,0));
+                DLIB_TEST(hog[0].nr() == max(lround(img.nr()/8.0)-2,0l));
+                DLIB_TEST(hog[0].nc() == max(lround(img.nc()/8.0)-2,0l));
             }
             for (int i = 1; i < 10; ++i)
             {
@@ -103,8 +103,8 @@ namespace
                 assign_all_pixels(img, i);
                 extract_fhog_features(img, hog);
                 DLIB_TEST(hog.size() == 31);
-                DLIB_TEST(hog[0].nr() == max(static_cast<int>(img.nr()/8.0+0.5)-2,0));
-                DLIB_TEST(hog[0].nc() == max(static_cast<int>(img.nc()/8.0+0.5)-2,0));
+                DLIB_TEST(hog[0].nr() == max(lround(img.nr()/8.0)-2,0l));
+                DLIB_TEST(hog[0].nc() == max(lround(img.nc()/8.0)-2,0l));
             }
             for (int i = 1; i < 10; ++i)
             {
@@ -112,8 +112,8 @@ namespace
                 assign_all_pixels(img, i);
                 extract_fhog_features(img, hog);
                 DLIB_TEST(hog.size() == 31);
-                DLIB_TEST(hog[0].nr() == max(static_cast<int>(img.nr()/8.0+0.5)-2,0));
-                DLIB_TEST(hog[0].nc() == max(static_cast<int>(img.nc()/8.0+0.5)-2,0));
+                DLIB_TEST(hog[0].nr() == max(lround(img.nr()/8.0)-2,0l));
+                DLIB_TEST(hog[0].nc() == max(lround(img.nc()/8.0)-2,0l));
             }
         }
 

--- a/examples/dnn_self_supervised_learning_ex.cpp
+++ b/examples/dnn_self_supervised_learning_ex.cpp
@@ -80,7 +80,7 @@ namespace resnet50
             repeat<2, res_64,  transition<64, 1,
             relu<BN<conv<64, 3, 1,INPUT>>>>>>>>>>>>;
     };
-};
+}
 
 // This model namespace contains the definitions for:
 // - SSL model using the Barlow Twins loss, a projector head and an input_rgb_image_pair.


### PR DESCRIPTION
I have some time to kill, and I want to modernize some rounding statements in dlib.

I think it won't break anything (I recently learned about `std::lround` and wanted to use it in dlib)