### PR TITLE
Fix cuDNN test project bug

### DIFF
--- a/dlib/cuda/cudnn_dlibapi.cpp
+++ b/dlib/cuda/cudnn_dlibapi.cpp
@@ -788,7 +788,7 @@ namespace dlib
         select_best_algorithms (
             const tensor& data,
             const tensor_descriptor& dest_desc,
-            allow_cache_use allow_cache_use
+            allow_cache_use allow_cache_use_
         ) 
         {
             // Calling the cuDNN "find the best algorithm" functions is really slow.  So we keep a
@@ -800,7 +800,7 @@ namespace dlib
             // the cache.
             const auto cache_key = std::make_tuple(stride_y, stride_x, padding_y, padding_x, filters_nr, filters_nc);
             const auto iter = config_to_algo_cache.find(cache_key);
-            if (iter != config_to_algo_cache.end() && allow_cache_use == allow_cache_use::yes)
+            if (iter != config_to_algo_cache.end() && allow_cache_use_ == allow_cache_use::yes)
             {
                 std::tie(forward_algo, backward_data_algo, backward_filters_algo) = iter->second;
                 return;


### PR DESCRIPTION
I was experienced an issue compiling Dlib with GPU and seeing the below error.

`-- Building a cuDNN test project to check if you have the right version of cuDNN installed...
-- *****************************************************************************************************
-- *** Found cuDNN, but we failed to compile the dlib/cmake_utils/test_for_cudnn project.
-- *** You either have an unsupported version of cuDNN or something is wrong with your cudDNN install.
-- *** Since a functional cuDNN is not found DLIB WILL NOT USE CUDA.
-- *** The output of the failed test_for_cudnn build is:`

`***   /home/dlib/dlib/cuda/cudnn_dlibapi.cpp:803:74: error: ‘allow_cache_use’ is not a class, namespace, or enumeration
   ***                if (iter != config_to_algo_cache.end() && allow_cache_use == allow_cache_use::yes)`

It appears the compilation issue in the test project was caused by a conflict between the name of the 'allow_cache_use' Enum Class and its instantiation as a parameter called 'allow_cache_use' in the select_best_algorithms method. 

The fix is to change the parameter name in the function definition and its associated usage inside the function to no longer conflict with the Enum Class name. I no longer have a compilation issue associated with the cuDNN test project after this fix.