### PR TITLE
Add multiclass SVM trainer to svm/auto.h

### DIFF
--- a/dlib/svm/auto.cpp
+++ b/dlib/svm/auto.cpp
@@ -104,9 +104,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<double,0,1>>, unsigned long>>
     auto_train_multiclass_svm_linear_classifier (
-        std::vector<matrix<float,0,1>> x,
+        std::vector<matrix<double,0,1>> x,
         std::vector<unsigned long> y,
         const std::chrono::nanoseconds max_runtime,
         bool be_verbose
@@ -125,14 +125,14 @@ namespace dlib
 
         randomize_samples(x, y);
 
-        vector_normalizer<matrix<float,0,1>> normalizer;
+        vector_normalizer<matrix<double,0,1>> normalizer;
         // let the normalizer learn the mean and standard deviation of the samples
         normalizer.train(x);
         for (auto& samp : x)
             samp = normalizer(samp);
 
 
-        typedef linear_kernel<matrix<float,0,1>> kernel_type;
+        typedef linear_kernel<matrix<double,0,1>> kernel_type;
         normalized_function<multiclass_linear_decision_function<kernel_type, unsigned long>> df;
         df.normalizer = normalizer;
 
@@ -177,6 +177,27 @@ namespace dlib
         df.function = trainer.train(x, y);
 
         return df;
+    }
+
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    auto_train_multiclass_svm_linear_classifier (
+        const std::vector<matrix<float,0,1>>& x,
+        std::vector<unsigned long> y,
+        const std::chrono::nanoseconds max_runtime,
+        bool be_verbose
+    )
+    {
+        std::vector<matrix<double,0,1>> samples;
+        for (const auto& samp : x)
+            samples.push_back(matrix_cast<double>(samp));
+
+        auto df = auto_train_multiclass_svm_linear_classifier(samples, y, max_runtime, be_verbose);
+        normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>> dfloat;
+        dfloat.normalizer.train(x);;
+        dfloat.function.labels = df.function.labels;
+        dfloat.function.weights = matrix_cast<float>(df.function.weights);
+        dfloat.function.b = matrix_cast<float>(df.function.b);
+        return dfloat;
     }
 }
 

--- a/dlib/svm/auto.cpp
+++ b/dlib/svm/auto.cpp
@@ -186,7 +186,7 @@ namespace dlib
 
         auto df = auto_train_multiclass_svm_linear_classifier(samples, y, max_runtime, be_verbose);
         normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>> dfloat;
-        dfloat.normalizer.train(x);;
+        dfloat.normalizer.train(x);
         dfloat.function.labels = df.function.labels;
         dfloat.function.weights = matrix_cast<float>(df.function.weights);
         dfloat.function.b = matrix_cast<float>(df.function.b);

--- a/dlib/svm/auto.cpp
+++ b/dlib/svm/auto.cpp
@@ -36,16 +36,12 @@ namespace dlib
 
         randomize_samples(x,y);
 
-        vector_normalizer<matrix<double,0,1>> normalizer;
-        // let the normalizer learn the mean and standard deviation of the samples
-        normalizer.train(x);
-        for (auto& samp : x)
-            samp = normalizer(samp);
-
-
-        typedef radial_basis_kernel<matrix<double,0,1>> kernel_type;
+        using kernel_type = radial_basis_kernel<matrix<double,0,1>>;
         normalized_function<decision_function<kernel_type>> df;
-        df.normalizer = normalizer;
+        // let the normalizer learn the mean and standard deviation of the samples
+        df.normalizer.train(x);
+        for (auto& samp : x)
+            samp = df.normalizer(samp);
 
 
         std::mutex m;
@@ -125,16 +121,13 @@ namespace dlib
 
         randomize_samples(x, y);
 
-        vector_normalizer<matrix<double,0,1>> normalizer;
-        // let the normalizer learn the mean and standard deviation of the samples
-        normalizer.train(x);
-        for (auto& samp : x)
-            samp = normalizer(samp);
-
-
-        typedef linear_kernel<matrix<double,0,1>> kernel_type;
+        using kernel_type = linear_kernel<matrix<double,0,1>>;
         normalized_function<multiclass_linear_decision_function<kernel_type, unsigned long>> df;
-        df.normalizer = normalizer;
+        // let the normalizer learn the mean and standard deviation of the samples
+        df.normalizer.train(x);
+        for (auto& samp : x)
+            samp = df.normalizer(samp);
+
 
         auto cross_validation_score = [&](const double c)
         {

--- a/dlib/svm/auto.cpp
+++ b/dlib/svm/auto.cpp
@@ -112,8 +112,8 @@ namespace dlib
         for (const auto label : labels)
         {
             const auto num_samples = sum(mat(y) == label);
-            DLIB_CASSERT(num_samples >= 6,
-                "You must provide at least 6 examples of each class to this training routine, however, label "
+            DLIB_CASSERT(num_samples >= 3,
+                "You must provide at least 3 examples of each class to this training routine, however, label "
                 << label << " has only " << num_samples << " examples.");
         }
         DLIB_ASSERT(is_learning_problem(x,y) == true);

--- a/dlib/svm/auto.cpp
+++ b/dlib/svm/auto.cpp
@@ -184,13 +184,13 @@ namespace dlib
         for (const auto& samp : x)
             samples.push_back(matrix_cast<double>(samp));
 
-        auto df = auto_train_multiclass_svm_linear_classifier(samples, y, max_runtime, be_verbose);
-        normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>> dfloat;
-        dfloat.normalizer.train(x);
-        dfloat.function.labels = df.function.labels;
-        dfloat.function.weights = matrix_cast<float>(df.function.weights);
-        dfloat.function.b = matrix_cast<float>(df.function.b);
-        return dfloat;
+        const auto temp = auto_train_multiclass_svm_linear_classifier(samples, y, max_runtime, be_verbose);
+        normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>> df;
+        df.normalizer.train(x);
+        df.function.labels = temp.function.labels;
+        df.function.weights = matrix_cast<float>(temp.function.weights);
+        df.function.b = matrix_cast<float>(temp.function.b);
+        return df;
     }
 }
 

--- a/dlib/svm/auto.h
+++ b/dlib/svm/auto.h
@@ -24,9 +24,17 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<double,0,1>>, unsigned long>>
+    auto_train_multiclass_svm_linear_classifier (
+        std::vector<matrix<double,0,1>> x,
+        std::vector<unsigned long> y,
+        const std::chrono::nanoseconds max_runtime,
+        bool be_verbose = true
+    );
+
     normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
     auto_train_multiclass_svm_linear_classifier (
-        std::vector<matrix<float,0,1>> x,
+        const std::vector<matrix<float,0,1>>& x,
         std::vector<unsigned long> y,
         const std::chrono::nanoseconds max_runtime,
         bool be_verbose = true

--- a/dlib/svm/auto.h
+++ b/dlib/svm/auto.h
@@ -7,6 +7,8 @@
 #include "../algs.h"
 #include "function.h"
 #include "kernel.h"
+#include "svm_multiclass_linear_trainer.h"
+#include "cross_validate_multiclass_trainer.h"
 #include <chrono>
 #include <vector>
 
@@ -16,6 +18,16 @@ namespace dlib
     normalized_function<decision_function<radial_basis_kernel<matrix<double,0,1>>>> auto_train_rbf_classifier (
         std::vector<matrix<double,0,1>> x,
         std::vector<double> y,
+        const std::chrono::nanoseconds max_runtime,
+        bool be_verbose = true
+    );
+
+// ----------------------------------------------------------------------------------------
+
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    auto_train_multiclass_svm_linear_classifier (
+        std::vector<matrix<float,0,1>> x,
+        std::vector<unsigned long> y,
         const std::chrono::nanoseconds max_runtime,
         bool be_verbose = true
     );

--- a/dlib/svm/auto_abstract.h
+++ b/dlib/svm/auto_abstract.h
@@ -62,7 +62,7 @@ namespace dlib
     /*!
         requires
             - is_learning_problem(x,y) == true
-            - y contains at least 6 examples of each class.
+            - y contains at least 3 examples of each class.
         ensures
             - This function is just an overload of the one defined immediately above.  It casts the
               input data from float to double, calls the above function, and casts the results back

--- a/dlib/svm/auto_abstract.h
+++ b/dlib/svm/auto_abstract.h
@@ -42,7 +42,7 @@ namespace dlib
     /*!
         requires
             - is_learning_problem(x,y) == true
-            - y contains at least 6 examples of each class.
+            - y contains at least 3 examples of each class.
         ensures
             - This routine trains a linear multiclass SVM on the given classification training data.
               It uses the svm_multiclass_linear_trainer to do this.  It also

--- a/dlib/svm/auto_abstract.h
+++ b/dlib/svm/auto_abstract.h
@@ -29,6 +29,28 @@ namespace dlib
             - The hyperparameter search will run for about max_runtime and will print
               messages to the screen as it runs if be_verbose==true.
     !*/
+
+// ----------------------------------------------------------------------------------------
+
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    auto_train_multiclass_svm_linear_classifier (
+        std::vector<matrix<float,0,1>> x,
+        std::vector<unsigned long> y,
+        const std::chrono::nanoseconds max_runtime,
+        bool be_verbose = true
+    );
+    /*!
+        requires
+            - is_learning_problem(x,y) == true
+            - y contains at least 6 examples of each class.
+        ensures
+            - This routine trains a linear multiclass SVM on the given classification training data.
+              It uses the svm_multiclass_linear_trainer to do this.  It also
+              uses find_max_global() and 3-fold cross-validation to automatically determine
+              the best setting of the SVM's hyper parameter C.
+            - The hyperparameter search will run for about max_runtime and will print
+              messages to the screen as it runs if be_verbose==true.
+    !*/
 }
 
 #endif // DLIB_AUTO_LEARnING_ABSTRACT_Hh_

--- a/dlib/svm/auto_abstract.h
+++ b/dlib/svm/auto_abstract.h
@@ -25,16 +25,16 @@ namespace dlib
             - This routine trains a radial basis function SVM on the given binary
               classification training data.  It uses the svm_c_trainer to do this.  It also
               uses find_max_global() and 6-fold cross-validation to automatically determine
-              the best settings of the SVM's hyper parameters.
+              the best settings of the SVM's hyperparameters.
             - The hyperparameter search will run for about max_runtime and will print
               messages to the screen as it runs if be_verbose==true.
     !*/
 
 // ----------------------------------------------------------------------------------------
 
-    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<double,0,1>>, unsigned long>>
     auto_train_multiclass_svm_linear_classifier (
-        std::vector<matrix<float,0,1>> x,
+        std::vector<matrix<double,0,1>> x,
         std::vector<unsigned long> y,
         const std::chrono::nanoseconds max_runtime,
         bool be_verbose = true
@@ -47,7 +47,30 @@ namespace dlib
             - This routine trains a linear multiclass SVM on the given classification training data.
               It uses the svm_multiclass_linear_trainer to do this.  It also
               uses find_max_global() and 3-fold cross-validation to automatically determine
-              the best setting of the SVM's hyper parameter C.
+              the best setting of the SVM's hyperparameter C.
+            - The hyperparameter search will run for about max_runtime and will print
+              messages to the screen as it runs if be_verbose==true.
+    !*/
+
+    normalized_function<multiclass_linear_decision_function<linear_kernel<matrix<float,0,1>>, unsigned long>>
+    auto_train_multiclass_svm_linear_classifier (
+        const std::vector<matrix<float,0,1>>& x,
+        std::vector<unsigned long> y,
+        const std::chrono::nanoseconds max_runtime,
+        bool be_verbose = true
+    );
+    /*!
+        requires
+            - is_learning_problem(x,y) == true
+            - y contains at least 6 examples of each class.
+        ensures
+            - This function is just an overload of the one defined immediately above.  It casts the
+              input data from double to float, calls the above function, and casts the results back
+              to float.
+            - This routine trains a linear multiclass SVM on the given classification training data.
+              It uses the svm_multiclass_linear_trainer to do this.  It also
+              uses find_max_global() and 3-fold cross-validation to automatically determine
+              the best setting of the SVM's hyperparameter C.
             - The hyperparameter search will run for about max_runtime and will print
               messages to the screen as it runs if be_verbose==true.
     !*/

--- a/dlib/svm/svm_multiclass_linear_trainer.h
+++ b/dlib/svm/svm_multiclass_linear_trainer.h
@@ -5,6 +5,7 @@
 
 #include "svm_multiclass_linear_trainer_abstract.h"
 #include "structural_svm_problem_threaded.h"
+#include "multiclass_tools.h"
 #include <vector>
 #include "../optimization/optimization_oca.h"
 #include "../matrix.h"

--- a/docs/docs/release_notes.xml
+++ b/docs/docs/release_notes.xml
@@ -14,6 +14,8 @@
 New Features and Improvements:
    - Use std::chrono in console_progress_indicator to display mixed time units.
    - Add a finish method to console_progress_indicator that will display the elapsed time.
+   - Added auto_train_multiclass_svm_linear_classifier(), a tool that trains a multiclass
+     SVM linear classifier without requiring the user to supply any hyperparameters.
 
 Non-Backwards Compatible Changes:
 

--- a/examples/dnn_self_supervised_learning_ex.cpp
+++ b/examples/dnn_self_supervised_learning_ex.cpp
@@ -326,7 +326,7 @@ try
     cout << "Extracting features for linear classifier from " << training_images.size() << " samples..." << endl;
     features = fnet(training_images, 4 * batch_size);
 
-    const auto df = auto_train_multiclass_svm_linear_classifier(features, training_labels, std::chrono::minutes(5));
+    const auto df = auto_train_multiclass_svm_linear_classifier(features, training_labels, std::chrono::minutes(1));
     serialize("multiclass_svm_cifar_10.dat") << df;
 
     // Finally, we can compute the accuracy of the model on the CIFAR-10 train and test images.

--- a/examples/dnn_self_supervised_learning_ex.cpp
+++ b/examples/dnn_self_supervised_learning_ex.cpp
@@ -329,7 +329,7 @@ try
 
     // Finally, we can compute the accuracy of the model on the CIFAR-10 train and
     // test images.
-    auto compute_accuracy = [&fnet, &df, batch_size](
+    auto compute_accuracy = [&df](
         const std::vector<matrix<float, 0, 1>>& samples,
         const std::vector<unsigned long>& labels
     )

--- a/examples/dnn_self_supervised_learning_ex.cpp
+++ b/examples/dnn_self_supervised_learning_ex.cpp
@@ -47,9 +47,8 @@
 #include <dlib/cmd_line_parser.h>
 #include <dlib/data_io.h>
 #include <dlib/dnn.h>
-#include <dlib/global_optimization.h>
 #include <dlib/gui_widgets.h>
-#include <dlib/svm_threaded.h>
+#include <dlib/svm.h>
 
 using namespace std;
 using namespace dlib;


### PR DESCRIPTION
As suggested in https://github.com/davisking/dlib/pull/2460#issuecomment-971569505, this PR adds the common following common use case for training multiclass SVM classifiers:

- normalize
- run cross validation to find the best setting
- train the final linear model

I am sure there is room for improvement, for instance, the type of the training samples `x`, which I set it to `matrix<float>` because that's what the neural networks return...
Maybe I could be generic in the type, or add an overload that converts `matrix<float>` to `matrix<double>` and just have that implementation?

As a side note, is there any reason why you prefer `typedef` over `using` syntax? I kind of like `using` more :P