### PR TITLE
Small YOLO loss improvements

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3799,16 +3799,12 @@ namespace dlib
 
                     for (size_t a = 0; a < anchors.size(); ++a)
                     {
-                        // Check if the best anchor is from the current stride.
-                        const bool is_best_anchor = best_tag_id == tag_id<TAG_TYPE>::id && best_a == a;
-
-                        // Do nothing if it's not the best anchor and iou_ignore_threshold is disabled
-                        if (!is_best_anchor && iou_anchor_threshold == 1)
-                            continue;
-
-                        // Do not update other anchors if they have low IoU
-                        if (!is_best_anchor)
+                        // We will always backpropagate on the best anchor, regardless of its IOU.
+                        // For other anchors, only if they have an IOU >= iou_anchor_threshold.
+                        if (!(best_tag_id == tag_id<TAG_TYPE>::id && best_a == a))
                         {
+                            if (iou_anchor_threshold == 1)
+                                continue;
                             const auto anchor(centered_drect(t_center, anchors[a].width, anchors[a].height));
                             if (box_intersection_over_union(truth_box.rect, anchor) < iou_anchor_threshold)
                                 continue;

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -3803,7 +3803,7 @@ namespace dlib
                         // For other anchors, only if they have an IOU >= iou_anchor_threshold.
                         if (!(best_tag_id == tag_id<TAG_TYPE>::id && best_a == a))
                         {
-                            if (iou_anchor_threshold == 1)
+                            if (iou_anchor_threshold >= 1)
                                 continue;
                             const auto anchor(centered_drect(t_center, anchors[a].width, anchors[a].height));
                             if (box_intersection_over_union(truth_box.rect, anchor) < iou_anchor_threshold)


### PR DESCRIPTION
Small improvements:
- Compute the input area and the truth area only once.
- Improve logic legibility for the `iou_anchor_threshold`.
- Make sure the input_area is a `drectangle` to avoid unwanted rounding operations:
  - in particular when checking `input_area.contains(center(truth_box.rect))`
  - the `.contains` method expects a `point` instead of a `dpoint` if `input_area` is a `rectangle`.
  - I don't think it has much effect, but still.