### PR TITLE
if constexpr() for C++14

### DIFF
--- a/dlib/constexpr_if.h
+++ b/dlib/constexpr_if.h
@@ -1,0 +1,131 @@
+// Copyright (C) 2022  Davis E. King (davis@dlib.net)
+// License: Boost Software License   See LICENSE.txt for the full license.
+#ifndef DLIB_IF_CONSTEXPR_H
+#define DLIB_IF_CONSTEXPR_H
+
+#include <utility>
+
+namespace dlib
+{
+    namespace detail
+    {
+        const auto _ = [](auto&& arg) { return std::forward<decltype(arg)>(arg); }; // same as std::identity in C++20 but better
+
+        template <
+            bool     Force,
+            typename Type,
+            typename Case
+        >
+        struct case_type_and_lambda
+        {
+            static constexpr bool force = Force;
+            using type = Type;
+            Case case_;
+
+            template<typename... Args>
+            constexpr decltype(auto) operator()(Args&& ...args) { return case_(_, std::forward<Args>(args)...); }
+        };
+
+        template<
+            typename type,
+            typename Case
+        >
+        using valid_t = std::enable_if_t<std::decay_t<Case>::force || std::is_same<type, typename std::decay_t<Case>::type>::value, bool>;
+
+        template<
+            typename type,
+            typename Case
+        >
+        using not_valid_t = std::enable_if_t<!std::decay_t<Case>::force && !std::is_same<type, typename std::decay_t<Case>::type>::value, bool>;
+    }
+
+    template <
+        typename type,
+        typename Case
+    >
+    constexpr auto case_type_(
+        Case &&case_
+    )
+    {
+        return detail::case_type_and_lambda<false, type, std::decay_t<Case>>{std::forward<Case>(case_)};
+    }
+
+    template <
+        bool result,
+        typename Case
+    >
+    constexpr auto case_(
+        Case &&case_
+    )
+    {
+        using bool_t = std::integral_constant<bool,result>;
+        return case_type_<bool_t>(std::forward<Case>(case_));
+    }
+
+    template <typename Case>
+    constexpr auto default_(Case &&case_)
+    {
+        return detail::case_type_and_lambda<true, bool, std::decay_t<Case>>{std::forward<Case>(case_)};
+    }
+
+    template <
+        typename type,
+        typename Case1,
+        typename... CaseRest,
+        detail::valid_t<type, Case1> = true
+    >
+    constexpr decltype(auto) switch_type_(
+        Case1&& first,
+        CaseRest&&...
+    )
+    {
+        return first();
+    }
+
+    template <
+        typename type,
+        typename Case1,
+        typename... CaseRest,
+        detail::not_valid_t<type, Case1> = true
+    >
+    constexpr decltype(auto) switch_type_(
+        Case1&&,
+        CaseRest&&... cases
+    )
+    {
+        return switch_type_<type>(std::forward<CaseRest>(cases)...);
+    }
+
+    template <
+        typename type,
+        typename CaseLast,
+        detail::valid_t<type, CaseLast> = true
+    >
+    constexpr decltype(auto) switch_type_(
+        CaseLast&& last
+    )
+    {
+        return last();
+    }
+
+    template <
+        typename type,
+        typename CaseLast,
+        detail::not_valid_t<type, CaseLast> = true
+    >
+    constexpr void switch_type_(CaseLast&&)
+    {
+    }
+
+    template <
+        typename...Cases
+    >
+    constexpr decltype(auto) switch_(
+        Cases&&... cases
+    )
+    {
+        return switch_type_<std::true_type>(std::forward<Cases>(cases)...);
+    }
+}
+
+#endif //DLIB_IF_CONSTEXPR_H

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set (tests
    conditioning_class_c.cpp
    conditioning_class.cpp
    config_reader.cpp
+   constexpr_if.cpp
    correlation_tracker.cpp
    crc32.cpp
    create_iris_datafile.cpp

--- a/dlib/test/constexpr_if.cpp
+++ b/dlib/test/constexpr_if.cpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2022  Davis E. King (davis@dlib.net)
+// License: Boost Software License   See LICENSE.txt for the full license.
+
+#include <string>
+#include <dlib/constexpr_if.h>
+#include "tester.h"
+
+namespace
+{
+    using namespace test;
+    using namespace dlib;
+
+    logger dlog("test.constexpr_if");
+
+    struct A
+    {
+        int i;
+    };
+
+    struct B
+    {
+        float f;
+    };
+
+    struct C
+    {
+        std::string str;
+    };
+
+    template<typename T>
+    auto handle_type_and_return1(T obj)
+    {
+        return switch_type_<T>(
+            case_type_<A>([&](auto _) {
+                return _(obj).i;
+            }),
+            case_type_<B>([&](auto _) {
+                return _(obj).f;
+            }),
+            case_type_<C>([&](auto _) {
+                return _(obj).str;
+            }),
+            default_([&](auto _) {
+                printf("Don't know what this type is\n");
+            })
+        );
+    }
+
+    template<typename T>
+    auto handle_type_and_return2(T obj)
+    {
+        return switch_(
+            case_<std::is_same<T,A>::value>([&](auto _) {
+                return _(obj).i;
+            }),
+            case_<std::is_same<T,B>::value>([&](auto _) {
+                return _(obj).f;
+            }),
+            case_<std::is_same<T,C>::value>([&](auto _) {
+                return _(obj).str;
+            }),
+            default_([&](auto _) {
+                printf("Don't know what this type is\n");
+            })
+        );
+    }
+
+    void test_switch_type()
+    {
+        A a{1};
+        B b{2.5f};
+        C c{"hello there!"};
+
+        {
+            auto ret = handle_type_and_return1(a);
+            static_assert(std::is_same<decltype(ret), int>::value, "failed test");
+            DLIB_TEST(ret == a.i);
+        }
+
+        {
+            auto ret = handle_type_and_return2(a);
+            static_assert(std::is_same<decltype(ret), int>::value, "failed test");
+            DLIB_TEST(ret == a.i);
+        }
+
+        {
+            auto ret = handle_type_and_return1(b);
+            static_assert(std::is_same<decltype(ret), float>::value, "failed test");
+            DLIB_TEST(ret == b.f);
+        }
+
+        {
+            auto ret = handle_type_and_return2(b);
+            static_assert(std::is_same<decltype(ret), float>::value, "failed test");
+            DLIB_TEST(ret == b.f);
+        }
+
+        {
+            auto ret = handle_type_and_return1(c);
+            static_assert(std::is_same<decltype(ret), std::string>::value, "failed test");
+            DLIB_TEST(ret == c.str);
+        }
+
+        {
+            auto ret = handle_type_and_return2(c);
+            static_assert(std::is_same<decltype(ret), std::string>::value, "failed test");
+            DLIB_TEST(ret == c.str);
+        }
+    }
+
+    class constexpr_if_test : public tester
+    {
+    public:
+        constexpr_if_test (
+        ) : tester ("test_constexpr_if",
+                    "Runs tests on the C++14 approximation of C++17 if constexpr() statements but better.")
+        {}
+
+        void perform_test (
+        )
+        {
+            test_switch_type();
+        }
+    } a;
+
+}

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -12,8 +12,17 @@
 
 namespace dlib
 {
-    // ---------------------------------------------------------------------
+#ifdef __cpp_lib_integer_sequence
+    template<std::size_t... Ints>
+    using index_sequence = std::index_sequence<Ints...>;
 
+    template<std::size_t N>
+    using make_index_sequence = std::make_index_sequence<N>;
+
+    template<class... T>
+    using index_sequence_for = std::index_sequence_for<T...>;
+#else
+    // ---------------------------------------------------------------------
     template<std::size_t... Ints>
     struct index_sequence
     {
@@ -31,54 +40,44 @@ namespace dlib
 
     template<std::size_t N>
     struct make_index_sequence
-        : merge_and_renumber < typename make_index_sequence < N / 2 >::type,
-          typename make_index_sequence < N - N / 2 >::type > {};
+            : merge_and_renumber < typename make_index_sequence < N / 2 >::type,
+                    typename make_index_sequence < N - N / 2 >::type > {};
 
     template<> struct make_index_sequence<0> : index_sequence<> {};
     template<> struct make_index_sequence<1> : index_sequence<0> {};
 
     template<typename... Ts>
     using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+    // ---------------------------------------------------------------------
+#endif
 
     // ---------------------------------------------------------------------
 
-    template <typename First, typename... Rest>
-    struct are_nothrow_move_constructible
-        : std::integral_constant<bool, std::is_nothrow_move_constructible<First>::value &&
-                                       are_nothrow_move_constructible<Rest...>::value> {};
+    template<bool First, bool... Rest>
+    struct And : std::integral_constant<bool, First && And<Rest...>::value> {};
 
-    template <typename T>
-    struct are_nothrow_move_constructible<T> : std::is_nothrow_move_constructible<T> {};
+    template<bool Value>
+    struct And<Value> : std::integral_constant<bool, Value>{};
 
     // ---------------------------------------------------------------------
 
-    template <typename First, typename... Rest>
-    struct are_nothrow_move_assignable
-        : std::integral_constant<bool, std::is_nothrow_move_assignable<First>::value &&
-                                       are_nothrow_move_assignable<Rest...>::value> {};
-
-    template <typename T>
-    struct are_nothrow_move_assignable<T> : std::is_nothrow_move_assignable<T> {};
+    template <typename ...Types>
+    struct are_nothrow_move_constructible : And<std::is_nothrow_move_constructible<Types>::value...> {};
 
     // ---------------------------------------------------------------------
 
-    template <typename First, typename... Rest>
-    struct are_nothrow_copy_constructible
-        : std::integral_constant<bool, std::is_nothrow_copy_constructible<First>::value &&
-                                       are_nothrow_copy_constructible<Rest...>::value> {};
-
-    template <typename T>
-    struct are_nothrow_copy_constructible<T> : std::is_nothrow_copy_constructible<T> {};
+    template <typename ...Types>
+    struct are_nothrow_move_assignable : And<std::is_nothrow_move_assignable<Types>::value...> {};
 
     // ---------------------------------------------------------------------
 
-    template <typename First, typename... Rest>
-    struct are_nothrow_copy_assignable
-        : std::integral_constant<bool, std::is_nothrow_copy_assignable<First>::value &&
-                                       are_nothrow_copy_assignable<Rest...>::value> {};
+    template <typename ...Types>
+    struct are_nothrow_copy_constructible : And<std::is_nothrow_copy_constructible<Types>::value...> {};
 
-    template <typename T>
-    struct are_nothrow_copy_assignable<T> : std::is_nothrow_copy_assignable<T> {};
+    // ---------------------------------------------------------------------
+
+    template <typename ...Types>
+    struct are_nothrow_copy_assignable : And<std::is_nothrow_copy_assignable<Types>::value...> {};
 
     // ---------------------------------------------------------------------
 
@@ -115,21 +114,8 @@ namespace dlib
 
     // ---------------------------------------------------------------------
 
-    template <typename First, typename... Rest>
-    struct are_nothrow_swappable
-        : std::integral_constant<bool, is_nothrow_swappable<First>::value &&
-                                       are_nothrow_swappable<Rest...>::value> {};
-
-    template <typename T>
-    struct are_nothrow_swappable<T> : is_nothrow_swappable<T> {};
-
-    // ---------------------------------------------------------------------
-
-    template<bool First, bool... Rest>
-    struct And : std::integral_constant<bool, First && And<Rest...>::value> {};
-
-    template<bool Value>
-    struct And<Value> : std::integral_constant<bool, Value>{};
+    template <typename ...Types>
+    struct are_nothrow_swappable : And<is_nothrow_swappable<Types>::value...> {};
 
     // ---------------------------------------------------------------------
 


### PR DESCRIPTION
It's actually more like "switch constexpr" and it's awesome.
It's inspired by hana::if_.
I've inserted it in a couple places where Davis mentioned that C++17's if constexpr would have been great.