### PR TITLE
Miscellaneous cleanup and refresh

### DIFF
--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -384,29 +384,6 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_convertible
-
-        This is a template that can be used to determine if one type is convertible 
-        into another type.
-
-        For example:
-            is_convertible<int,float>::value == true    // because ints are convertible to floats
-            is_convertible<int*,float>::value == false  // because int pointers are NOT convertible to floats
-    !*/
-
-    template <typename from, typename to>
-    struct is_convertible
-    {
-        struct yes_type { char a; };
-        struct no_type { yes_type a[2]; };
-        static const from& from_helper();
-        static yes_type test(to);
-        static no_type test(...);
-        const static bool value = sizeof(test(from_helper())) == sizeof(yes_type);
-    };
-
-// ----------------------------------------------------------------------------------------
-
     struct general_ {};
     struct special_ : general_ {};
     template<typename> struct int_ { typedef int type; };

--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -10,11 +10,11 @@
 
 // this file contains miscellaneous stuff                      
 
-// Give people who forget the -std=c++11 option a reminder
-#if (defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))) || \
+// Give people who forget the -std=c++14 option a reminder
+#if (defined(__GNUC__) && ((__GNUC__ >= 5 && __GNUC_MINOR__ >= 0) || (__GNUC__ > 5))) || \
     (defined(__clang__) && ((__clang_major__ >= 3 && __clang_minor__ >= 4) || (__clang_major__ >= 3)))
-    #if __cplusplus < 201103
-        #error "Dlib requires C++11 support.  Give your compiler the -std=c++11 option to enable it."
+    #if __cplusplus < 201402L
+        #error "Dlib requires C++14 support.  Give your compiler the -std=c++14 option to enable it."
     #endif
 #endif
 
@@ -384,103 +384,23 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_pointer_type
-
-        This is a template where is_pointer_type<T>::value == true when T is a pointer 
-        type and false otherwise.
-    !*/
-
-    template <
-        typename T
-        >
-    class is_pointer_type
-    {
-    public:
-        enum { value = false };
-    private:
-        is_pointer_type();
-    };
-
-    template <
-        typename T
-        >
-    class is_pointer_type<T*>
-    {
-    public:
-        enum { value = true };
-    private:
-        is_pointer_type();
-    };
+    template <typename T>
+    using is_pointer_type = std::is_pointer<T>;
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_const_type
-
-        This is a template where is_const_type<T>::value == true when T is a const 
-        type and false otherwise.
-    !*/
-
     template <typename T>
-    struct is_const_type
-    {
-        static const bool value = false;
-    };
-    template <typename T>
-    struct is_const_type<const T>
-    {
-        static const bool value = true;
-    };
-    template <typename T>
-    struct is_const_type<const T&>
-    {
-        static const bool value = true;
-    };
+    using is_const_type = std::is_const<std::remove_reference_t<T>>;
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_reference_type 
-
-        This is a template where is_reference_type<T>::value == true when T is a reference 
-        type and false otherwise.
-    !*/
-
     template <typename T>
-    struct is_reference_type
-    {
-        static const bool value = false;
-    };
-
-    template <typename T> struct is_reference_type<const T&> { static const bool value = true; };
-    template <typename T> struct is_reference_type<T&> { static const bool value = true; };
+    using is_reference_type = std::is_reference<std::remove_const_t<T>>;
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_same_type 
-
-        This is a template where is_same_type<T,U>::value == true when T and U are the
-        same type and false otherwise.   
-    !*/
-
-    template <
-        typename T,
-        typename U
-        >
-    class is_same_type
-    {
-    public:
-        enum {value = false};
-    private:
-        is_same_type();
-    };
-
-    template <typename T>
-    class is_same_type<T,T>
-    {
-    public:
-        enum {value = true};
-    private:
-        is_same_type();
-    };
+    template <typename T, typename U>
+    using is_same_type = std::is_same<T,U>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -500,17 +420,9 @@ namespace dlib
     struct is_any<T,First,Rest...> : std::integral_constant<bool, std::is_same<T,First>::value || is_any<T,Rest...>::value> {};
 
 // ----------------------------------------------------------------------------------------
-    
-    /*!A is_float_type
 
-        This is a template that can be used to determine if a type is one of the built
-        int floating point types (i.e. float, double, or long double).
-    !*/
-
-    template < typename T > struct is_float_type  { const static bool value = false; };
-    template <> struct is_float_type<float>       { const static bool value = true; };
-    template <> struct is_float_type<double>      { const static bool value = true; };
-    template <> struct is_float_type<long double> { const static bool value = true; };
+    template<typename T>
+    using is_float_type = std::is_floating_point<T>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -579,36 +491,13 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_unsigned_type 
-
-        This is a template where is_unsigned_type<T>::value == true when T is an unsigned
-        scalar type and false when T is a signed scalar type.
-    !*/
-    template <
-        typename T
-        >
-    struct is_unsigned_type
-    {
-        static const bool value = static_cast<T>((static_cast<T>(0)-static_cast<T>(1))) > 0;
-    };
-    template <> struct is_unsigned_type<long double> { static const bool value = false; };
-    template <> struct is_unsigned_type<double>      { static const bool value = false; };
-    template <> struct is_unsigned_type<float>       { static const bool value = false; };
+    template <typename T>
+    using is_unsigned_type = std::is_unsigned<T>;
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_signed_type 
-
-        This is a template where is_signed_type<T>::value == true when T is a signed
-        scalar type and false when T is an unsigned scalar type.
-    !*/
-    template <
-        typename T
-        >
-    struct is_signed_type
-    {
-        static const bool value = !is_unsigned_type<T>::value;
-    };
+    template <typename T>
+    using is_signed_type = std::is_signed<T>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -905,45 +794,8 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    /*!A is_function 
-        
-        This is a template that allows you to determine if the given type is a function.
-
-        For example,
-            void funct();
-
-            is_built_in_scalar_type<funct>::value == true
-            is_built_in_scalar_type<int>::value == false 
-    !*/
-
-    template <typename T> struct is_function { static const bool value = false; };
-    template <typename T> 
-    struct is_function<T (void)> { static const bool value = true; };
-    template <typename T, typename A0> 
-    struct is_function<T (A0)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1> 
-    struct is_function<T (A0, A1)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2> 
-    struct is_function<T (A0, A1, A2)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3> 
-    struct is_function<T (A0, A1, A2, A3)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4> 
-    struct is_function<T (A0, A1, A2, A3, A4)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4,
-                          typename A5> 
-    struct is_function<T (A0,A1,A2,A3,A4,A5)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4,
-                          typename A5, typename A6> 
-    struct is_function<T (A0,A1,A2,A3,A4,A5,A6)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4,
-                          typename A5, typename A6, typename A7> 
-    struct is_function<T (A0,A1,A2,A3,A4,A5,A6,A7)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4,
-                          typename A5, typename A6, typename A7, typename A8> 
-    struct is_function<T (A0,A1,A2,A3,A4,A5,A6,A7,A8)> { static const bool value = true; };
-    template <typename T, typename A0, typename A1, typename A2, typename A3, typename A4,
-                          typename A5, typename A6, typename A7, typename A8, typename A9> 
-    struct is_function<T (A0,A1,A2,A3,A4,A5,A6,A7,A8,A9)> { static const bool value = true; };
+    template<typename T>
+    using is_function = std::is_function<T>;
 
 
     template <typename T> class funct_wrap0
@@ -1173,6 +1025,27 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    namespace detail
+    {
+        template <class Tuple, class F, std::size_t... I>
+        constexpr void for_each_impl(Tuple&& t, F&& f, std::index_sequence<I...>)
+        {
+#ifdef __cpp_fold_expressions
+            (std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))),...);
+#else
+            (void)std::initializer_list<int>{(std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))),0)...};
+#endif
+        }
+    }
+
+    template <class Tuple, class F>
+    constexpr void for_each_in_tuple(Tuple&& t, F&& f)
+    {
+        detail::for_each_impl(std::forward<Tuple>(t), std::forward<F>(f),
+                              std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tuple>>::value>{});
+    }
+
+// ----------------------------------------------------------------------------------------
 }
 
 #endif // DLIB_ALGs_

--- a/dlib/algs.h
+++ b/dlib/algs.h
@@ -400,7 +400,7 @@ namespace dlib
 
     // handle the case where T and U are unrelated types.
     template < typename T, typename U >
-    typename disable_if_c<is_convertible<T*, U*>::value || is_convertible<U*,T*>::value, bool>::type
+    std::enable_if_t<!std::is_convertible<T*, U*>::value && !std::is_convertible<U*,T*>::value, bool>
     is_same_object (
         const T& a, 
         const U& b
@@ -415,7 +415,7 @@ namespace dlib
     // valid way to convert between these two pointer types then we will take that route rather
     // than the void* approach used otherwise.
     template < typename T, typename U >
-    typename enable_if_c<is_convertible<T*, U*>::value || is_convertible<U*,T*>::value, bool>::type
+    std::enable_if_t<std::is_convertible<T*, U*>::value || std::is_convertible<U*,T*>::value, bool>
     is_same_object (
         const T& a, 
         const U& b

--- a/dlib/any/any.h
+++ b/dlib/any/any.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <typeinfo>
+#include <type_traits>
 
 namespace dlib
 {
@@ -49,7 +50,7 @@ namespace dlib
             const T& item
         )
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             data.reset(new derived<U>(item));
         }
 
@@ -63,7 +64,7 @@ namespace dlib
         bool contains (
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             return dynamic_cast<derived<U>*>(data.get()) != 0;
         }
 
@@ -77,7 +78,7 @@ namespace dlib
         T& cast_to(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -91,7 +92,7 @@ namespace dlib
         const T& cast_to(
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -105,7 +106,7 @@ namespace dlib
         T& get(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {

--- a/dlib/any/any_decision_function.h
+++ b/dlib/any/any_decision_function.h
@@ -44,7 +44,7 @@ namespace dlib
             const T& item
         )
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             data.reset(new derived<U>(item));
         }
 
@@ -58,7 +58,7 @@ namespace dlib
         bool contains (
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             return dynamic_cast<derived<U>*>(data.get()) != 0;
         }
 
@@ -86,7 +86,7 @@ namespace dlib
         T& cast_to(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -100,7 +100,7 @@ namespace dlib
         const T& cast_to(
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -114,7 +114,7 @@ namespace dlib
         T& get(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {

--- a/dlib/any/any_function_impl.h
+++ b/dlib/any/any_function_impl.h
@@ -300,17 +300,17 @@ typedef Tbase<function_type> base;
 template <typename T, typename enabled = void>
 struct funct_type { typedef T type; };
 template <typename T>
-struct funct_type<T, typename enable_if<is_function<T> >::type> { typedef T* type; };
+struct funct_type<T, typename enable_if<std::is_function<T> >::type> { typedef T* type; };
 
 template <typename T>
-static typename enable_if<is_function<T>,const T*>::type copy (const T& item) { return &item; }
+static typename enable_if<std::is_function<T>,const T*>::type copy (const T& item) { return &item; }
 template <typename T>
-static typename disable_if<is_function<T>,const T&>::type copy (const T& item) { return item; }
+static typename disable_if<std::is_function<T>,const T&>::type copy (const T& item) { return item; }
 
 template <typename T, typename U>
-static typename enable_if<is_function<T>,const T&>::type deref (const U& item) { return *item; }
+static typename enable_if<std::is_function<T>,const T&>::type deref (const U& item) { return *item; }
 template <typename T, typename U>
-static typename disable_if<is_function<T>,const T&>::type deref (const U& item) { return item; }
+static typename disable_if<std::is_function<T>,const T&>::type deref (const U& item) { return item; }
 
 // -----------------------------------------------
 

--- a/dlib/any/any_function_impl.h
+++ b/dlib/any/any_function_impl.h
@@ -51,7 +51,7 @@ any_function (
     const T& item
 )
 {
-    typedef typename basic_type<T>::type U;
+    using U = std::decay_t<T>;
     data.reset(new derived<U,function_type>(item));
 }
 
@@ -65,7 +65,7 @@ template <typename T>
 bool contains (
 ) const
 {
-    typedef typename basic_type<T>::type U;
+    using U = std::decay_t<T>;
     return dynamic_cast<derived<U,function_type>*>(data.get()) != 0;
 }
 
@@ -85,7 +85,7 @@ template <typename T>
 T& cast_to(
 ) 
 {
-    typedef typename basic_type<T>::type U;
+    using U = std::decay_t<T>;
     derived<U,function_type>* d = dynamic_cast<derived<U,function_type>*>(data.get());
     if (d == 0)
     {
@@ -99,7 +99,7 @@ template <typename T>
 const T& cast_to(
 ) const
 {
-    typedef typename basic_type<T>::type U;
+    using U = std::decay_t<T>;
     derived<U,function_type>* d = dynamic_cast<derived<U,function_type>*>(data.get());
     if (d == 0)
     {
@@ -113,7 +113,7 @@ template <typename T>
 T& get(
 ) 
 {
-    typedef typename basic_type<T>::type U;
+    using U = std::decay_t<T>;
     derived<U,function_type>* d = dynamic_cast<derived<U,function_type>*>(data.get());
     if (d == 0)
     {

--- a/dlib/any/any_trainer.h
+++ b/dlib/any/any_trainer.h
@@ -47,7 +47,7 @@ namespace dlib
             const T& item
         )
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             data.reset(new derived<U>(item));
         }
 
@@ -61,7 +61,7 @@ namespace dlib
         bool contains (
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             return dynamic_cast<derived<U>*>(data.get()) != 0;
         }
 
@@ -90,7 +90,7 @@ namespace dlib
         T& cast_to(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -104,7 +104,7 @@ namespace dlib
         const T& cast_to(
         ) const
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {
@@ -118,7 +118,7 @@ namespace dlib
         T& get(
         ) 
         {
-            typedef typename basic_type<T>::type U;
+            using U = std::decay_t<T>;
             derived<U>* d = dynamic_cast<derived<U>*>(data.get());
             if (d == 0)
             {

--- a/dlib/bound_function_pointer/bound_function_pointer_kernel_1.h
+++ b/dlib/bound_function_pointer/bound_function_pointer_kernel_1.h
@@ -304,8 +304,8 @@ namespace dlib
             F& function_object
         )
         {
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             using namespace bfp1_helpers;
             destroy_bf_memory();
@@ -323,8 +323,8 @@ namespace dlib
             A1& arg1
         )
         {
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             using namespace bfp1_helpers;
             destroy_bf_memory();
@@ -344,8 +344,8 @@ namespace dlib
             A2& arg2
         )
         {
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             using namespace bfp1_helpers;
             destroy_bf_memory();
@@ -367,8 +367,8 @@ namespace dlib
             A3& arg3
         )
         {
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             using namespace bfp1_helpers;
             destroy_bf_memory();
@@ -392,8 +392,8 @@ namespace dlib
             A4& arg4
         )
         {
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             using namespace bfp1_helpers;
             destroy_bf_memory();

--- a/dlib/bridge/bridge.h
+++ b/dlib/bridge/bridge.h
@@ -283,7 +283,7 @@ namespace dlib
 
 
             template <typename pipe_type>
-            typename enable_if<is_convertible<bridge_status, typename pipe_type::type> >::type  enqueue_bridge_status (
+            std::enable_if_t<std::is_convertible<bridge_status, typename pipe_type::type>::value>  enqueue_bridge_status (
                 pipe_type* p,
                 const bridge_status& status
             )
@@ -296,7 +296,7 @@ namespace dlib
             }
 
             template <typename pipe_type>
-            typename disable_if<is_convertible<bridge_status, typename pipe_type::type> >::type  enqueue_bridge_status (
+            std::enable_if_t<!std::is_convertible<bridge_status, typename pipe_type::type>::value>  enqueue_bridge_status (
                 pipe_type* ,
                 const bridge_status& 
             )

--- a/dlib/constexpr_if.h
+++ b/dlib/constexpr_if.h
@@ -31,16 +31,16 @@ namespace dlib
         WHAT THIS OBJECT REPRESENTS
             This is a type list. Use this to pass types to the switch_() function as
             compile-time initial conditions.
-   !*/
+    !*/
 
 // ----------------------------------------------------------------------------------------
 
     template<bool... v>
-    auto bools(std::integral_constant<bool, v>...)
+    constexpr auto bools(std::integral_constant<bool, v>...)
     /*!
         ensures
             - returns a type list of compile time booleans.
-   !*/
+    !*/
     {
         return types_<std::integral_constant<bool,v>...>{};
     }
@@ -130,7 +130,7 @@ namespace dlib
     /*!
         ensures
             - This is exactly the same as std::experimental::is_detected from library fundamentals v
-   !*/
+    !*/
 
 // ----------------------------------------------------------------------------------------
 }

--- a/dlib/dnn/core.h
+++ b/dlib/dnn/core.h
@@ -261,7 +261,7 @@ namespace dlib
         auto tuple_subset(
             const Tuple& item, 
             compile_time_integer_list<indices...>
-        )
+        ) -> decltype(std::make_tuple(std::get<indices>(item)...))
         {
             return std::make_tuple(std::get<indices>(item)...);
         }
@@ -283,7 +283,7 @@ namespace dlib
         template <typename... T>
         auto tuple_flatten(
             const std::tuple<T...>& item
-        )
+        ) -> decltype(tuple_flatten(item, typename make_compile_time_integer_range<sizeof...(T)>::type()))
         {
             return tuple_flatten(item, typename make_compile_time_integer_range<sizeof...(T)>::type());
         }
@@ -292,7 +292,7 @@ namespace dlib
         auto tuple_flatten(
             const std::tuple<T...>& item, 
             compile_time_integer_list<indices...>
-        )
+        ) -> decltype(std::tuple_cat(tuple_flatten(std::get<indices-1>(item))...))
         {
             return std::tuple_cat(tuple_flatten(std::get<indices-1>(item))...);
         }

--- a/dlib/dnn/core.h
+++ b/dlib/dnn/core.h
@@ -3,22 +3,23 @@
 #ifndef DLIB_DNn_CORE_H_
 #define DLIB_DNn_CORE_H_
 
-#include "core_abstract.h"
-#include "../cuda/tensor.h"
 #include <iterator>
 #include <memory>
 #include <sstream>
-#include <type_traits>
-#include "../statistics.h"
-#include "../rand.h"
-#include "../algs.h"
 #include <utility>
 #include <tuple>
 #include <cmath>
 #include <vector>
-#include "../cuda/tensor_tools.h"
 #include <type_traits>
+
+#include "core_abstract.h"
+#include "../cuda/tensor.h"
+#include "../cuda/tensor_tools.h"
+#include "../statistics.h"
+#include "../rand.h"
+#include "../algs.h"
 #include "../metaprogramming.h"
+#include "../constexpr_if.h"
 
 #ifdef _MSC_VER
 // Tell Visual Studio not to recursively inline functions very much because otherwise it
@@ -35,30 +36,48 @@ namespace dlib
 
     namespace impl
     {
-        template <typename T, typename int_<decltype(&T::get_learning_rate_multiplier)>::type = 0>
-        double get_learning_rate_multiplier (
-            const T& obj,
-            special_
-        ) { return obj.get_learning_rate_multiplier(); }
+        template<typename T>
+        using has_get_learning_rate_multiplier = decltype(std::declval<T>().get_learning_rate_multiplier());
+    
+        template<typename T>
+        using has_set_learning_rate_multiplier = decltype(std::declval<T>().set_learning_rate_multiplier(double{}));
 
-        template <typename T>
-        double get_learning_rate_multiplier ( const T& , general_) { return 1; }
+        template<typename T>
+        using has_get_bias_learning_rate_multiplier = decltype(std::declval<T>().get_bias_learning_rate_multiplier());
+
+        template<typename T>
+        using has_set_bias_learning_rate_multiplier = decltype(std::declval<T>().set_bias_learning_rate_multiplier(double{}));
+    
+        template<typename T>
+        using has_get_weight_decay_multiplier = decltype(std::declval<T>().get_weight_decay_multiplier());
+
+        template<typename T>
+        using has_set_weight_decay_multiplier = decltype(std::declval<T>().set_weight_decay_multiplier(double{}));
+
+        template<typename T>
+        using has_get_bias_weight_decay_multiplier = decltype(std::declval<T>().get_bias_weight_decay_multiplier());
+
+        template<typename T>
+        using has_set_bias_weight_decay_multiplier = decltype(std::declval<T>().set_bias_weight_decay_multiplier(double{}));
+
+        template<typename T>
+        using has_disable_bias = decltype(std::declval<T>().disable_bias());
+
+        template<typename T>
+        using has_clean = decltype(std::declval<T>().clean());
     }
+
+// ----------------------------------------------------------------------------------------
+
     template <typename T>
-    double get_learning_rate_multiplier(const T& obj) { return impl::get_learning_rate_multiplier(obj, special_()); }
-
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::set_learning_rate_multiplier)>::type = 0>
-        void set_learning_rate_multiplier (
-            T& obj,
-            special_,
-            double learning_rate_multiplier
-        ) { obj.set_learning_rate_multiplier(learning_rate_multiplier); }
-
-        template <typename T>
-        void set_learning_rate_multiplier (T& , general_, double) { }
+    double get_learning_rate_multiplier(const T& obj) 
+    { 
+        return switch_(bools(is_detected<impl::has_get_learning_rate_multiplier, T>{}),
+            [&](true_t, auto _) { return _(obj).get_learning_rate_multiplier(); },
+            [](auto...)         { return 1.0; }
+        );
     }
+
     template <typename T>
     void set_learning_rate_multiplier(
         T& obj,
@@ -66,37 +85,23 @@ namespace dlib
     )
     {
         DLIB_CASSERT(learning_rate_multiplier >= 0);
-        impl::set_learning_rate_multiplier(obj, special_(), learning_rate_multiplier);
+        switch_(bools(is_detected<impl::has_set_learning_rate_multiplier, T>{}),
+            [&](true_t, auto _) { _(obj).set_learning_rate_multiplier(learning_rate_multiplier); },
+            [](auto...)         {/*no-op*/}
+        );
     }
 
 // ----------------------------------------------------------------------------------------
 
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::get_bias_learning_rate_multiplier)>::type = 0>
-        double get_bias_learning_rate_multiplier (
-            const T& obj,
-            special_
-        ) { return obj.get_bias_learning_rate_multiplier(); }
-
-        template <typename T>
-        double get_bias_learning_rate_multiplier ( const T& , general_) { return 1; }
-    }
     template <typename T>
-    double get_bias_learning_rate_multiplier(const T& obj) { return impl::get_bias_learning_rate_multiplier(obj, special_()); }
-
-    namespace impl
+    double get_bias_learning_rate_multiplier(const T& obj) 
     {
-        template <typename T, typename int_<decltype(&T::set_bias_learning_rate_multiplier)>::type = 0>
-        void set_bias_learning_rate_multiplier (
-            T& obj,
-            special_,
-            double bias_learning_rate_multiplier
-        ) { obj.set_bias_learning_rate_multiplier(bias_learning_rate_multiplier); }
-
-        template <typename T>
-        void set_bias_learning_rate_multiplier (T& , general_, double) { }
+        return switch_(bools(is_detected<impl::has_get_bias_learning_rate_multiplier, T>{}),
+            [&](true_t, auto _) { return _(obj).get_bias_learning_rate_multiplier(); },
+            [](auto...)         { return 1.0; }
+        );
     }
+
     template <typename T>
     void set_bias_learning_rate_multiplier(
         T& obj,
@@ -104,37 +109,23 @@ namespace dlib
     )
     {
         DLIB_CASSERT(bias_learning_rate_multiplier >= 0);
-        impl::set_bias_learning_rate_multiplier(obj, special_(), bias_learning_rate_multiplier);
+        switch_(bools(is_detected<impl::has_set_bias_learning_rate_multiplier, T>{}),
+            [&](true_t, auto _) { _(obj).set_bias_learning_rate_multiplier(bias_learning_rate_multiplier); },
+            [](auto...)         {/*no-op*/}
+        );
     }
 
 // ----------------------------------------------------------------------------------------
 
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::get_weight_decay_multiplier)>::type = 0>
-        double get_weight_decay_multiplier (
-            const T& obj,
-            special_
-        ) { return obj.get_weight_decay_multiplier(); }
-
-        template <typename T>
-        double get_weight_decay_multiplier ( const T& , general_) { return 1; }
-    }
     template <typename T>
-    double get_weight_decay_multiplier(const T& obj) { return impl::get_weight_decay_multiplier(obj, special_()); }
-
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::set_weight_decay_multiplier)>::type = 0>
-        void set_weight_decay_multiplier (
-            T& obj,
-            special_,
-            double weight_decay_multiplier
-        ) { obj.set_weight_decay_multiplier(weight_decay_multiplier); }
-
-        template <typename T>
-        void set_weight_decay_multiplier (T& , general_, double) { }
+    double get_weight_decay_multiplier(const T& obj) 
+    { 
+        return switch_(bools(is_detected<impl::has_get_weight_decay_multiplier, T>{}),
+            [&](true_t, auto _) { return _(obj).get_weight_decay_multiplier(); },
+            [](auto...)         { return 1.0; }
+        );
     }
+
     template <typename T>
     void set_weight_decay_multiplier(
         T& obj,
@@ -142,37 +133,23 @@ namespace dlib
     )
     {
         DLIB_CASSERT(weight_decay_multiplier >= 0);
-        impl::set_weight_decay_multiplier(obj, special_(), weight_decay_multiplier);
+        switch_(bools(is_detected<impl::has_set_weight_decay_multiplier, T>{}),
+            [&](true_t, auto _) { _(obj).set_weight_decay_multiplier(weight_decay_multiplier); },
+            [](auto...)         {/*no-op*/}
+        );
     }
 
 // ----------------------------------------------------------------------------------------
 
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::get_bias_weight_decay_multiplier)>::type = 0>
-        double get_bias_weight_decay_multiplier (
-            const T& obj,
-            special_
-        ) { return obj.get_bias_weight_decay_multiplier(); }
-
-        template <typename T>
-        double get_bias_weight_decay_multiplier ( const T& , general_) { return 1; }
-    }
     template <typename T>
-    double get_bias_weight_decay_multiplier(const T& obj) { return impl::get_bias_weight_decay_multiplier(obj, special_()); }
-
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::set_bias_weight_decay_multiplier)>::type = 0>
-        void set_bias_weight_decay_multiplier (
-            T& obj,
-            special_,
-            double bias_weight_decay_multiplier
-        ) { obj.set_bias_weight_decay_multiplier(bias_weight_decay_multiplier); }
-
-        template <typename T>
-        void set_bias_weight_decay_multiplier (T& , general_, double) { }
+    double get_bias_weight_decay_multiplier(const T& obj)
+    { 
+        return switch_(bools(is_detected<impl::has_get_bias_weight_decay_multiplier, T>{}),
+            [&](true_t, auto _) { return _(obj).get_bias_weight_decay_multiplier(); },
+            [](auto...)         { return 1.0; }
+        );
     }
+
     template <typename T>
     void set_bias_weight_decay_multiplier(
         T& obj,
@@ -180,51 +157,39 @@ namespace dlib
     )
     {
         DLIB_CASSERT(bias_weight_decay_multiplier >= 0);
-        impl::set_bias_weight_decay_multiplier(obj, special_(), bias_weight_decay_multiplier);
+        switch_(bools(is_detected<impl::has_set_bias_weight_decay_multiplier, T>{}),
+            [&](true_t, auto _) { _(obj).set_bias_weight_decay_multiplier(bias_weight_decay_multiplier); },
+            [](auto...)         {/*no-op*/}
+        );
     }
 
 // ----------------------------------------------------------------------------------------
-
-    namespace impl
-    {
-        template <typename T, typename int_<decltype(&T::disable_bias)>::type = 0>
-        void disable_bias(
-            T& obj,
-            special_
-        ) { obj.disable_bias(); }
-
-        template <typename T>
-        void disable_bias( const T& , general_) { }
-    }
 
     template <typename T>
     void disable_bias(
         T& obj
     )
     {
-        impl::disable_bias(obj, special_());
+        switch_(bools(is_detected<impl::has_disable_bias, T>{}),
+            [&](true_t, auto _) { _(obj).disable_bias(); },
+            [](auto...)         { /*no-op*/ }
+        );
     }
 
 // ----------------------------------------------------------------------------------------
 
-    namespace impl
-    {
-        // The reason we return an int for this version rather than doing the more straight forward thing (like we do above) is to avoid a bug in visual studio 2015.
-        template <typename T>
-        auto call_clean_method_if_exists (
-            T& obj,
-            special_
-        ) -> typename int_<decltype(&T::clean)>::type { obj.clean();  return 0;  }
-
-        template <typename T>
-        void call_clean_method_if_exists (T& , general_) {}
-    }
     template <typename T>
-    void call_clean_method_if_exists(T& obj) { impl::call_clean_method_if_exists(obj, special_()); }
+    void call_clean_method_if_exists(T& obj) 
     /*!
         ensures
             - calls obj.clean() if obj has a .clean() method.
     !*/
+    { 
+        switch_(bools(is_detected<impl::has_clean, T>{}),
+            [&](true_t, auto _) { _(obj).clean(); },
+            [](auto...)         { /*no-op*/ }
+        );
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -296,7 +261,7 @@ namespace dlib
         auto tuple_subset(
             const Tuple& item, 
             compile_time_integer_list<indices...>
-        ) -> decltype(std::make_tuple(std::get<indices>(item)...))
+        )
         {
             return std::make_tuple(std::get<indices>(item)...);
         }
@@ -318,7 +283,7 @@ namespace dlib
         template <typename... T>
         auto tuple_flatten(
             const std::tuple<T...>& item
-        ) -> decltype(tuple_flatten(item, typename make_compile_time_integer_range<sizeof...(T)>::type()))
+        )
         {
             return tuple_flatten(item, typename make_compile_time_integer_range<sizeof...(T)>::type());
         }
@@ -327,7 +292,7 @@ namespace dlib
         auto tuple_flatten(
             const std::tuple<T...>& item, 
             compile_time_integer_list<indices...>
-        ) -> decltype(std::tuple_cat(tuple_flatten(std::get<indices-1>(item))...))
+        )
         {
             return std::tuple_cat(tuple_flatten(std::get<indices-1>(item))...);
         }

--- a/dlib/global_optimization/find_max_global.h
+++ b/dlib/global_optimization/find_max_global.h
@@ -35,14 +35,14 @@ namespace dlib
         auto _cwv (
             T&& f, 
             const matrix<double,0,1>& a, 
-            compile_time_integer_list<indices...>
-        ) -> decltype(f(a(indices-1)...)) 
+            std::index_sequence<indices...>
+        ) -> decltype(f(a(indices)...)) 
         {
             DLIB_CASSERT(a.size() == sizeof...(indices), 
                 "You invoked dlib::call_function_and_expand_args(f,a) but the number of arguments expected by f() doesn't match the size of 'a'. "
                 << "Expected " << sizeof...(indices) << " arguments but got " << a.size() << "."
             );  
-            return f(a(indices-1)...); 
+            return f(a(indices)...); 
         }
 
         // Visual studio, as of November 2017, doesn't support C++11 and can't compile this code.  
@@ -52,9 +52,9 @@ namespace dlib
         struct call_function_and_expand_args
         {
             template <typename T>
-            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(_cwv(std::forward<T>(f),a,typename make_compile_time_integer_range<max_unpack>::type()))
+            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(_cwv(std::forward<T>(f),a,std::make_index_sequence<max_unpack>{}))
             {
-                return _cwv(std::forward<T>(f),a,typename make_compile_time_integer_range<max_unpack>::type());
+                return _cwv(std::forward<T>(f),a, std::make_index_sequence<max_unpack>{});
             }
 
             template <typename T>

--- a/dlib/metaprogramming.h
+++ b/dlib/metaprogramming.h
@@ -3,7 +3,8 @@
 #ifndef DLIB_METApROGRAMMING_Hh_
 #define DLIB_METApROGRAMMING_Hh_
 
-#include "algs.h"
+#include "constexpr_if.h"
+#include "invoke.h"
 
 namespace dlib
 {
@@ -11,38 +12,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <size_t... n>
-    struct compile_time_integer_list 
-    {
-        /*!
-            WHAT THIS OBJECT REPRESENTS
-                The point of this type is to, as the name suggests, hold a compile time list of integers.
-                As an example, here is something simple you could do with it:
-
-                    template <size_t... ints>
-                    void print_compile_time_ints (
-                        compile_time_integer_list<ints...>
-                    )
-                    {
-                        print(ints...);
-                    }
-
-                    int main()
-                    {
-                        print_compile_time_ints(compile_time_integer_list<0,4,9>());
-                    }
-
-                Which just calls: print(0,4,9);
-
-                This is a simple example, but this kind of thing is useful in larger and
-                more complex template metaprogramming constructs.
-        !*/
-
-        template <size_t m>
-        struct push_back
-        {
-            typedef compile_time_integer_list<n..., m> type;
-        };
-    };
+    using compile_time_integer_list = std::index_sequence<n...>;
 
 // ----------------------------------------------------------------------------------------
 
@@ -58,38 +28,10 @@ namespace dlib
                     compile_time_integer_list<1,2,3,4>
         !*/
 
-        typedef typename make_compile_time_integer_range<max-1>::type::template push_back<max>::type type;
+        using type = std::make_index_sequence<max>;
     };
-    // base case
-    template <> struct make_compile_time_integer_range<0> { typedef compile_time_integer_list<> type; };
 
 // ----------------------------------------------------------------------------------------
-
-    namespace civ_impl
-    {
-        template <
-            typename Funct, 
-            typename... Args,
-            typename int_<decltype(std::declval<Funct>()(std::declval<Args>()...))>::type = 0
-            >
-        bool call_if_valid (
-            special_,
-            Funct&& f, Args&&... args
-        ) 
-        {  
-            f(std::forward<Args>(args)...);
-            return true;
-        }
-
-        template <
-            typename Funct, 
-            typename... Args
-            >
-        bool call_if_valid (
-            general_,
-            Funct&& /*f*/, Args&&... /*args*/
-        ) { return false; }
-    }
 
     template <typename Funct, typename... Args>
     bool call_if_valid(Funct&& f, Args&&... args) 
@@ -99,7 +41,15 @@ namespace dlib
               true.  Otherwise we do nothing and return false.
     !*/
     {
-        return civ_impl::call_if_valid(special_(), f, std::forward<Args>(args)...);
+        return switch_(bools(is_invocable<Funct, Args...>{}),
+            [&](true_t, auto _) {
+                _(std::forward<Funct>(f))(std::forward<Args>(args)...);
+                return true;
+            },
+            [](auto...) {
+                return false;
+            }
+        );
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/metaprogramming.h
+++ b/dlib/metaprogramming.h
@@ -8,6 +8,18 @@
 
 namespace dlib
 {
+// ----------------------------------------------------------------------------------------
+    namespace impl
+    {
+        template<typename List>
+        struct add_one {};
+
+        template<std::size_t... n>
+        struct add_one<std::index_sequence<n...>> { using type = std::index_sequence<(n+1)...>; };
+
+        template<typename List>
+        using add_one_t = typename add_one<List>::type;
+    }
 
 // ----------------------------------------------------------------------------------------
 
@@ -28,7 +40,7 @@ namespace dlib
                     compile_time_integer_list<1,2,3,4>
         !*/
 
-        using type = std::make_index_sequence<max>;
+        using type = impl::add_one_t<std::make_index_sequence<max>>;
     };
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/metaprogramming.h
+++ b/dlib/metaprogramming.h
@@ -9,22 +9,36 @@
 namespace dlib
 {
 // ----------------------------------------------------------------------------------------
-    namespace impl
-    {
-        template<typename List>
-        struct add_one {};
-
-        template<std::size_t... n>
-        struct add_one<std::index_sequence<n...>> { using type = std::index_sequence<(n+1)...>; };
-
-        template<typename List>
-        using add_one_t = typename add_one<List>::type;
-    }
-
-// ----------------------------------------------------------------------------------------
 
     template <size_t... n>
-    using compile_time_integer_list = std::index_sequence<n...>;
+    struct compile_time_integer_list 
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                The point of this type is to, as the name suggests, hold a compile time list of integers.
+                As an example, here is something simple you could do with it:
+                    template <size_t... ints>
+                    void print_compile_time_ints (
+                        compile_time_integer_list<ints...>
+                    )
+                    {
+                        print(ints...);
+                    }
+                    int main()
+                    {
+                        print_compile_time_ints(compile_time_integer_list<0,4,9>());
+                    }
+                Which just calls: print(0,4,9);
+                This is a simple example, but this kind of thing is useful in larger and
+                more complex template metaprogramming constructs.
+        !*/
+
+        template <size_t m>
+        struct push_back
+        {
+            typedef compile_time_integer_list<n..., m> type;
+        };
+    };
 
 // ----------------------------------------------------------------------------------------
 
@@ -40,8 +54,10 @@ namespace dlib
                     compile_time_integer_list<1,2,3,4>
         !*/
 
-        using type = impl::add_one_t<std::make_index_sequence<max>>;
+        typedef typename make_compile_time_integer_range<max-1>::type::template push_back<max>::type type;
     };
+    // base case
+    template <> struct make_compile_time_integer_range<0> { typedef compile_time_integer_list<> type; };
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/overloaded.h
+++ b/dlib/overloaded.h
@@ -51,7 +51,7 @@ namespace dlib
         an overload-able set. This can be used in visitor patterns like
             - dlib::type_safe_union::apply_to_contents()
             - dlib::visit()
-            - dlib::for_each()
+            - dlib::for_each_type()
             - dlib::switch_()
 
         A picture paints a thousand words:

--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -1144,58 +1144,6 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I == sizeof...(Tp), void>::type
-    for_each_in_tuple(std::tuple<Tp...>&, FuncT)
-    {}
-
-    template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I < sizeof...(Tp), void>::type
-    for_each_in_tuple(std::tuple<Tp...>& t, FuncT f)
-    {
-        f(std::get<I>(t));
-        for_each_in_tuple<I + 1, FuncT, Tp...>(t, f);
-    }
-    
-    template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I == sizeof...(Tp), void>::type
-    for_each_in_tuple(const std::tuple<Tp...>&, FuncT)
-    {}
-
-    template<std::size_t I = 0, typename FuncT, typename... Tp>
-    inline typename std::enable_if<I < sizeof...(Tp), void>::type
-    for_each_in_tuple(const std::tuple<Tp...>& t, FuncT f)
-    {
-        f(std::get<I>(t));
-        for_each_in_tuple<I + 1, FuncT, Tp...>(t, f);
-    }
-    
-    struct serialize_tuple_helper
-    {
-        serialize_tuple_helper(std::ostream& out_) : out(out_) {}
-        
-        template<typename T>
-        void operator()(const T& item)
-        {
-            serialize(item, out);
-        }
-                
-        std::ostream& out;
-    };
-    
-    struct deserialize_tuple_helper
-    {
-        deserialize_tuple_helper(std::istream& in_) : in(in_) {}
-        
-        template<typename T>
-        void operator()(T& item)
-        {
-            deserialize(item, in);
-        }
-                
-        std::istream& in;
-    };
-
     template <typename... Types>
     void serialize (
         const std::tuple<Types...>& item,
@@ -1204,7 +1152,9 @@ namespace dlib
     {
         try
         { 
-            for_each_in_tuple(item, serialize_tuple_helper(out));
+            for_each_in_tuple(item, [&](auto&& x) {
+                serialize(x, out);
+            });
         }
         catch (serialization_error& e)
         { throw serialization_error(e.info + "\n   while serializing object of type std::tuple"); }
@@ -1218,7 +1168,9 @@ namespace dlib
     {
         try
         { 
-            for_each_in_tuple(item, deserialize_tuple_helper(in));
+            for_each_in_tuple(item, [&](auto&& x) {
+                deserialize(x, in);
+            });
         }
         catch (serialization_error& e)
         { throw serialization_error(e.info + "\n   while deserializing object of type std::tuple"); }

--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -2600,33 +2600,27 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template<typename T>
-    inline void serialize_these(std::ostream& out, const T& x)
+    template<typename... T>
+    inline void serialize_these(std::ostream& out, const T& ...x)
     {
         using dlib::serialize;
-        serialize(x, out);
+#ifdef __cpp_fold_expressions
+        (serialize(out, x),...);
+#else
+        (void)std::initializer_list<int>{(serialize(out,x),0)...};
+#endif
     }
     
-    template<typename T, typename... Rest>
-    inline void serialize_these(std::ostream& out, const T& x, const Rest& ... rest)
-    {
-        serialize_these(out, x);
-        serialize_these(out, rest...);
-    }
-    
-    template<typename T>
-    inline void deserialize_these(std::istream& in, T& x)
+    template<typename... T>
+    inline void deserialize_these(std::istream& in, T& ...x)
     {
         using dlib::deserialize;
-        deserialize(x, in);
+#ifdef __cpp_fold_expressions
+        (deserialize(in, x),...);
+#else
+        (void)std::initializer_list<int>{(deserialize(in,x),0)...};
+#endif
     }
-    
-    template<typename T, typename... Rest>
-    inline void deserialize_these(std::istream& in, T& x, Rest& ... rest)
-    {
-        deserialize_these(in, x);
-        deserialize_these(in, rest...);
-    }  
     
     #define DLIB_DEFINE_DEFAULT_SERIALIZATION(Type, ...)                \
     void serialize_to(std::ostream& dlibDefaultSer$_out) const          \

--- a/dlib/serialize.h
+++ b/dlib/serialize.h
@@ -2605,9 +2605,9 @@ namespace dlib
     {
         using dlib::serialize;
 #ifdef __cpp_fold_expressions
-        (serialize(out, x),...);
+        (serialize(x, out),...);
 #else
-        (void)std::initializer_list<int>{(serialize(out,x),0)...};
+        (void)std::initializer_list<int>{(serialize(x, out),0)...};
 #endif
     }
     
@@ -2616,9 +2616,9 @@ namespace dlib
     {
         using dlib::deserialize;
 #ifdef __cpp_fold_expressions
-        (deserialize(in, x),...);
+        (deserialize(x, in),...);
 #else
-        (void)std::initializer_list<int>{(deserialize(in,x),0)...};
+        (void)std::initializer_list<int>{(deserialize(x, in),0)...};
 #endif
     }
     

--- a/dlib/threads/thread_pool_extension.h
+++ b/dlib/threads/thread_pool_extension.h
@@ -579,8 +579,8 @@ namespace dlib
             F& function_object
         ) 
         { 
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             bfp_type temp;
             temp.set(function_object);
@@ -672,8 +672,8 @@ namespace dlib
             future<A1>& arg1
         ) 
         { 
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             bfp_type temp;
             temp.set(function_object,arg1.get());
@@ -807,8 +807,8 @@ namespace dlib
             future<A2>& arg2
         ) 
         { 
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             bfp_type temp;
             temp.set(function_object, arg1.get(), arg2.get());
@@ -967,8 +967,8 @@ namespace dlib
             future<A3>& arg3
         ) 
         { 
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             bfp_type temp;
             temp.set(function_object, arg1.get(), arg2.get(), arg3.get());
@@ -1153,8 +1153,8 @@ namespace dlib
             future<A4>& arg4
         ) 
         { 
-            COMPILE_TIME_ASSERT(is_function<F>::value == false);
-            COMPILE_TIME_ASSERT(is_pointer_type<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_function<F>::value == false);
+            COMPILE_TIME_ASSERT(std::is_pointer<F>::value == false);
             
             bfp_type temp;
             temp.set(function_object, arg1.get(), arg2.get(), arg3.get(), arg4.get());

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -47,10 +47,6 @@ namespace dlib
 
     namespace detail
     {
-#if __has_builtin(__type_pack_element)
-        template <size_t I, typename... Ts>
-        struct nth_type { using type = __type_pack_element<I, Ts...>; };
-#else
         template<size_t I, typename... Ts>
         struct nth_type;
 
@@ -59,7 +55,6 @@ namespace dlib
 
         template<typename T0, typename... Ts>
         struct nth_type<0, T0, Ts...> { using type = T0; };
-#endif
     }
 
     template <size_t I, typename TSU>

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -125,11 +125,9 @@ namespace dlib
         }
 
     private:
-        template<typename T>
-        struct is_valid : is_any<T,Types...> {};
 
         template<typename T>
-        using is_valid_check = typename std::enable_if<is_valid<T>::value, bool>::type;
+        using is_valid_check = std::enable_if_t<is_any<T,Types...>::value, bool>;
 
         template <size_t I>
         using get_type_t = type_safe_union_alternative_t<I, type_safe_union>;

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -47,6 +47,10 @@ namespace dlib
 
     namespace detail
     {
+#if __has_builtin(__type_pack_element)
+        template <size_t I, typename... Ts>
+        struct nth_type { using type = __type_pack_element<I, Ts...>; };
+#else
         template<size_t I, typename... Ts>
         struct nth_type;
 
@@ -55,6 +59,7 @@ namespace dlib
 
         template<typename T0, typename... Ts>
         struct nth_type<0, T0, Ts...> { using type = T0; };
+#endif
     }
 
     template <size_t I, typename TSU>
@@ -522,6 +527,13 @@ namespace dlib
         )
         {
             using Tsu = std::decay_t<TSU>;
+
+#ifdef __cpp_fold_expressions
+            (std::forward<F>(f)(
+                in_place_tag<type_safe_union_alternative_t<I, Tsu>>{},
+                std::forward<TSU>(tsu)),
+            ...);
+#else
             (void)std::initializer_list<int>{
                 (std::forward<F>(f)(
                         in_place_tag<type_safe_union_alternative_t<I, Tsu>>{},
@@ -529,6 +541,7 @@ namespace dlib
                  0
                 )...
             };
+#endif            
         }
     }
 

--- a/dlib/type_safe_union/type_safe_union_kernel_abstract.h
+++ b/dlib/type_safe_union/type_safe_union_kernel_abstract.h
@@ -236,6 +236,19 @@ namespace dlib
         !*/
 
         template <typename T>
+        static constexpr int get_type_id (
+            in_place_tag<T>
+        );
+        /*!
+           ensures
+                - returns get_type_id<T>()
+                - This is useful when using for_each_type() with a generic lambda. For example:
+                  for_each_type([](auto tag, auto&& me) {
+                    printf("ID %i\n", me.get_type_id(tag));
+                  }, item);
+        !*/
+
+        template <typename T>
         bool contains (
         ) const;
         /*!

--- a/dlib/type_traits.h
+++ b/dlib/type_traits.h
@@ -114,7 +114,6 @@
 
  // ----------------------------------------------------------------------------------------
 
-    
     template <typename ...Types>
     struct are_nothrow_move_constructible : And<std::is_nothrow_move_constructible<Types>::value...> {};
 
@@ -175,6 +174,11 @@
 
     template<std::size_t I>
     using size_ = std::integral_constant<std::size_t, I>;
+
+ // ----------------------------------------------------------------------------------------
+
+    template <typename from, typename to>
+    using is_convertible = std::is_convertible<from, to>;
 
  // ----------------------------------------------------------------------------------------
 

--- a/dlib/type_traits.h
+++ b/dlib/type_traits.h
@@ -1,0 +1,171 @@
+// Copyright (C) 2016  Davis E. King (davis@dlib.net)
+// License: Boost Software License   See LICENSE.txt for the full license.
+#ifndef DLIB_TYPE_TRAITS_H_
+#define DLIB_TYPE_TRAITS_H_
+
+/*
+    This header contains back-ports of C++14/17 type traits
+    It also contains aliases for things found in <type_traits> which
+    deprecate old dlib type traits.
+*/
+
+#include <type_traits>
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T>
+    using is_pointer_type = std::is_pointer<T>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T>
+    using is_const_type = std::is_const<std::remove_reference_t<T>>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T>
+    using is_reference_type = std::is_reference<std::remove_const_t<T>>;
+
+// ----------------------------------------------------------------------------------------
+
+    template<typename T>
+    using is_function = std::is_function<T>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T, typename U>
+    using is_same_type = std::is_same<T,U>;
+
+// ----------------------------------------------------------------------------------------
+
+    template<bool First, bool... Rest>
+    struct And : std::integral_constant<bool, First && And<Rest...>::value> {};
+
+    template<bool Value>
+    struct And<Value> : std::integral_constant<bool, Value>{};
+
+// ----------------------------------------------------------------------------------------
+
+    template<bool First, bool... Rest>
+    struct Or : std::integral_constant<bool, First || And<Rest...>::value> {};
+
+    template<bool Value>
+    struct Or<Value> : std::integral_constant<bool, Value>{};
+
+// ----------------------------------------------------------------------------------------
+
+    /*!A is_any 
+
+        This is a template where is_any<T,Rest...>::value == true when T is 
+        the same type as any one of the types in Rest... 
+    !*/
+
+    template <typename T, typename... Types>
+    struct is_any : Or<std::is_same<T,Types>::value...> {};
+
+// ----------------------------------------------------------------------------------------
+
+    template<typename T>
+    using is_float_type = std::is_floating_point<T>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T>
+    using is_unsigned_type = std::is_unsigned<T>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T>
+    using is_signed_type = std::is_signed<T>;
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename T> 
+    using is_built_in_scalar_type = std::is_arithmetic<T>;
+
+ // ----------------------------------------------------------------------------------------
+
+    template< class T >
+    using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    template <typename T>
+    struct basic_type { using type = remove_cvref_t<T>; };
+
+ // ----------------------------------------------------------------------------------------
+
+    template<class...>
+    struct conjunction : std::true_type {};
+
+    template<class B1>
+    struct conjunction<B1> : B1 {};
+
+    template<class B1, class... Bn>
+    struct conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    
+    template <typename ...Types>
+    struct are_nothrow_move_constructible : And<std::is_nothrow_move_constructible<Types>::value...> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    template <typename ...Types>
+    struct are_nothrow_move_assignable : And<std::is_nothrow_move_assignable<Types>::value...> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    template <typename ...Types>
+    struct are_nothrow_copy_constructible : And<std::is_nothrow_copy_constructible<Types>::value...> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    template <typename ...Types>
+    struct are_nothrow_copy_assignable : And<std::is_nothrow_copy_assignable<Types>::value...> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    template< class... >
+    using void_t = void;
+
+ // ----------------------------------------------------------------------------------------
+
+    namespace swappable_details
+    {
+        using std::swap;
+
+        template<typename T, typename = void>
+        struct is_swappable : std::false_type {};
+
+        template<typename T>
+        struct is_swappable<T, void_t<decltype(swap(std::declval<T&>(), std::declval<T&>()))>> : std::true_type {};
+
+        template<typename T>
+        struct is_nothrow_swappable :
+            std::integral_constant<bool, is_swappable<T>::value &&
+                                         noexcept(swap(std::declval<T&>(), std::declval<T&>()))> {};
+    }
+
+ // ----------------------------------------------------------------------------------------
+
+    template<typename T>
+    struct is_swappable : swappable_details::is_swappable<T>{};
+
+ // ----------------------------------------------------------------------------------------
+
+    template<typename T>
+    struct is_nothrow_swappable : swappable_details::is_nothrow_swappable<T>{};
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename ...Types>
+    struct are_nothrow_swappable : And<is_nothrow_swappable<Types>::value...> {};
+
+ // ----------------------------------------------------------------------------------------
+
+    template<std::size_t I>
+    using size_ = std::integral_constant<std::size_t, I>;
+
+ // ----------------------------------------------------------------------------------------
+
+#endif //DLIB_TYPE_TRAITS_H_

--- a/dlib/type_traits.h
+++ b/dlib/type_traits.h
@@ -11,6 +11,8 @@
 
 #include <type_traits>
 
+namespace dlib
+{
 // ----------------------------------------------------------------------------------------
 
     template <typename T>
@@ -181,5 +183,6 @@
     using is_convertible = std::is_convertible<from, to>;
 
  // ----------------------------------------------------------------------------------------
+}
 
 #endif //DLIB_TYPE_TRAITS_H_

--- a/dlib/type_traits.h
+++ b/dlib/type_traits.h
@@ -38,19 +38,29 @@
 
 // ----------------------------------------------------------------------------------------
 
+#ifdef __cpp_fold_expressions
+    template<bool... v>
+    struct And : std::integral_constant<bool, (... && v)> {};
+#else
     template<bool First, bool... Rest>
     struct And : std::integral_constant<bool, First && And<Rest...>::value> {};
 
     template<bool Value>
     struct And<Value> : std::integral_constant<bool, Value>{};
+#endif
 
 // ----------------------------------------------------------------------------------------
 
+#ifdef __cpp_fold_expressions
+    template<bool... v>
+    struct Or : std::integral_constant<bool, (... || v)> {};
+#else
     template<bool First, bool... Rest>
-    struct Or : std::integral_constant<bool, First || And<Rest...>::value> {};
+    struct Or : std::integral_constant<bool, First || Or<Rest...>::value> {};
 
     template<bool Value>
     struct Or<Value> : std::integral_constant<bool, Value>{};
+#endif
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -9,7 +9,7 @@
 /*
     This header contains back-ports of C++14/17 functions and type traits
     found in <utility> header of the standard library.
- */
+*/
 
 namespace dlib
 {
@@ -51,90 +51,6 @@ namespace dlib
     using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
     // ---------------------------------------------------------------------
 #endif
-
-    // ---------------------------------------------------------------------
-
-    template<bool First, bool... Rest>
-    struct And : std::integral_constant<bool, First && And<Rest...>::value> {};
-
-    template<bool Value>
-    struct And<Value> : std::integral_constant<bool, Value>{};
-
-    // ---------------------------------------------------------------------
-
-    template<class...>
-    struct conjunction : std::true_type {};
-
-    template<class B1>
-    struct conjunction<B1> : B1 {};
-
-    template<class B1, class... Bn>
-    struct conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
-
-    // ---------------------------------------------------------------------
-
-    template <typename ...Types>
-    struct are_nothrow_move_constructible : And<std::is_nothrow_move_constructible<Types>::value...> {};
-
-    // ---------------------------------------------------------------------
-
-    template <typename ...Types>
-    struct are_nothrow_move_assignable : And<std::is_nothrow_move_assignable<Types>::value...> {};
-
-    // ---------------------------------------------------------------------
-
-    template <typename ...Types>
-    struct are_nothrow_copy_constructible : And<std::is_nothrow_copy_constructible<Types>::value...> {};
-
-    // ---------------------------------------------------------------------
-
-    template <typename ...Types>
-    struct are_nothrow_copy_assignable : And<std::is_nothrow_copy_assignable<Types>::value...> {};
-
-    // ---------------------------------------------------------------------
-
-    template< class... >
-    using void_t = void;
-
-    // ---------------------------------------------------------------------
-
-    namespace swappable_details
-    {
-        using std::swap;
-
-        template<typename T, typename = void>
-        struct is_swappable : std::false_type {};
-
-        template<typename T>
-        struct is_swappable<T, void_t<decltype(swap(std::declval<T&>(), std::declval<T&>()))>> : std::true_type {};
-
-        template<typename T>
-        struct is_nothrow_swappable :
-            std::integral_constant<bool, is_swappable<T>::value &&
-                                         noexcept(swap(std::declval<T&>(), std::declval<T&>()))> {};
-    }
-
-    // ---------------------------------------------------------------------
-
-    template<typename T>
-    struct is_swappable : swappable_details::is_swappable<T>{};
-
-    // ---------------------------------------------------------------------
-
-    template<typename T>
-    struct is_nothrow_swappable : swappable_details::is_nothrow_swappable<T>{};
-
-    // ---------------------------------------------------------------------
-
-    template <typename ...Types>
-    struct are_nothrow_swappable : And<is_nothrow_swappable<Types>::value...> {};
-
-    // ---------------------------------------------------------------------
-
-    template<std::size_t I>
-    using size_ = std::integral_constant<std::size_t, I>;
-
-    // ---------------------------------------------------------------------
 }
 
 #endif //DLIB_UTILITY_Hh_

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -51,6 +51,22 @@ namespace dlib
     using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
     // ---------------------------------------------------------------------
 #endif
+
+    // ---------------------------------------------------------------------
+
+    template<class Sequence>
+    struct pop_front {};
+
+    template<std::size_t I, std::size_t... Ints>
+    struct pop_front<index_sequence<I, Ints...>>
+    {
+        using type = index_sequence<Ints...>;
+    };
+
+    template<class Sequence>
+    using pop_front_t = typename pop_front<Sequence>::type;
+
+    // ---------------------------------------------------------------------
 }
 
 #endif //DLIB_UTILITY_Hh_

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -4,6 +4,7 @@
 #define DLIB_UTILITY_Hh_
 
 #include <cstddef>
+#include <type_traits>
 
 /*
     This header contains back-ports of C++14/17 functions and type traits
@@ -58,6 +59,17 @@ namespace dlib
 
     template<bool Value>
     struct And<Value> : std::integral_constant<bool, Value>{};
+
+    // ---------------------------------------------------------------------
+
+    template<class...>
+    struct conjunction : std::true_type {};
+
+    template<class B1>
+    struct conjunction<B1> : B1 {};
+
+    template<class B1, class... Bn>
+    struct conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
 
     // ---------------------------------------------------------------------
 

--- a/tools/python/src/global_optimization.cpp
+++ b/tools/python/src/global_optimization.cpp
@@ -62,7 +62,7 @@ double call_func(py::object f, const matrix<double,0,1>& args)
         "The function being optimized takes a number of arguments that doesn't agree with the size of the bounds lists you provided to find_max_global()");
     DLIB_CASSERT(0 < num && num <= 35, "Functions being optimized must take between 1 and 35 scalar arguments.");
 
-#define CALL_WITH_N_ARGS(N) case N: return dlib::gopt_impl::_cwv(f,args,typename make_compile_time_integer_range<N>::type()).cast<double>(); 
+#define CALL_WITH_N_ARGS(N) case N: return dlib::gopt_impl::_cwv(f,args,std::make_index_sequence<N>{}).cast<double>(); 
     switch (num)
     {
         CALL_WITH_N_ARGS(1)


### PR DESCRIPTION
I'm currently working on a dnn2 API. As I'm working on it, I'm spotting things in the code base that could do with a refresh.
This PR proposes some of these updates:

- old type traits are now just aliases for standard library type traits
- using `is_detected` and `switch_()` in dnn core. I think it makes things clearer and trivially update-able to `if constexpr` for when the time comes.
- added an improved `for_each_in_tuple()`. It uses fold expression if possible otherwise the parameter pack expansion trick into dummy initializer list. This improves compile time. 
- Use generic lambdas where possible instead of struct helpers
- auto deduced return types

