### PR TITLE
Fix visitor when tag layer is followed by skip layer

### DIFF
--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -608,6 +608,15 @@ namespace dlib
                 // update(i);
             }
 
+            // Handle the special case when the tag layer is followed by a skip layer
+            template <unsigned long ID, template <typename> class TAG, typename U, typename E>
+            void operator()(size_t i, const add_tag_layer<ID, add_skip_layer<TAG, U>, E>&)
+            {
+                tagged_layers.push_back(i);
+                const auto t = tag_id<TAG>::id;
+                tag_to_layer.at(t) = from;
+            }
+
             template <template <typename> class TAG, typename U>
             void operator()(size_t, const add_skip_layer<TAG, U>&)
             {

--- a/docs/docs/release_notes.xml
+++ b/docs/docs/release_notes.xml
@@ -21,6 +21,7 @@ Non-Backwards Compatible Changes:
 
 Bug fixes:
    - Fix saving grayscale WebP images (PR #2591)
+   - Fix dnn dot visitor when a tag layer is followed by a skip layer (PR #2662)
 </current>
 
 <!-- **************************************************************************************  -->


### PR DESCRIPTION
I noticed this while plotting the YOLOv7 architecture.
After this change, it works :)

[yolov7.pdf](https://github.com/davisking/dlib/files/9483227/yolov7.pdf)
