### PR TITLE
Modernize random_color_transform

### DIFF
--- a/dlib/image_transforms/random_color_transform.h
+++ b/dlib/image_transforms/random_color_transform.h
@@ -23,44 +23,44 @@ namespace dlib
             const double color_magnitude = 0.2
         )
         {
-            // pick a random gamma correction factor.  
-            double gamma = std::max(0.0, 1 + gamma_magnitude*(rnd.get_random_double()-0.5));
+            // pick a random gamma correction factor.
+            const double gamma = std::max(0.0, 1 + gamma_magnitude*(rnd.get_random_double() - 0.5));
 
             // pick a random color balancing scheme.
-            double red_scale = 1-rnd.get_random_double()*color_magnitude;
-            double green_scale = 1-rnd.get_random_double()*color_magnitude;
-            double blue_scale = 1-rnd.get_random_double()*color_magnitude;
-            const double m = 255*std::max(std::max(red_scale,green_scale),blue_scale);
+            double red_scale = 1 - rnd.get_random_double() * color_magnitude;
+            double green_scale = 1 - rnd.get_random_double() * color_magnitude;
+            double blue_scale = 1 - rnd.get_random_double() * color_magnitude;
+            const double m = 255 * std::max({red_scale, green_scale, blue_scale});
             red_scale /= m;
             green_scale /= m;
             blue_scale /= m;
 
             // Now compute a lookup table for all the color channels.  The table tells us
             // what the transform does.
-            table.resize(256*3);
+            table.resize(256 * 3);
             unsigned long i = 0;
             for (int k = 0; k < 256; ++k)
             {
-                double v = 255*std::pow(k*red_scale, gamma);
-                table[i++] = (unsigned char)(v + 0.5);
+                const double v = 255*std::pow(k * red_scale, gamma);
+                table[i++] = static_cast<unsigned char>(v + 0.5);
             }
             for (int k = 0; k < 256; ++k)
             {
-                double v = 255*std::pow(k*green_scale, gamma);
-                table[i++] = (unsigned char)(v + 0.5);
+                const double v = 255 * std::pow(k * green_scale, gamma);
+                table[i++] = static_cast<unsigned char>(v + 0.5);
             }
             for (int k = 0; k < 256; ++k)
             {
-                double v = 255*std::pow(k*blue_scale, gamma);
-                table[i++] = (unsigned char)(v + 0.5);
+                const double v = 255 * std::pow(k * blue_scale, gamma);
+                table[i++] = static_cast<unsigned char>(v + 0.5);
             }
         }
 
         rgb_pixel operator()(rgb_pixel p) const
         {
-            p.red = table[(unsigned int)p.red];
-            p.green = table[(unsigned int)p.green+256];
-            p.blue = table[(unsigned int)p.blue+512];
+            p.red = table[static_cast<unsigned int>(p.red)];
+            p.green = table[static_cast<unsigned int>(p.green + 256)];
+            p.blue = table[static_cast<unsigned int>(p.blue + 512)];
             return p;
         }
 

--- a/dlib/image_transforms/random_color_transform.h
+++ b/dlib/image_transforms/random_color_transform.h
@@ -41,18 +41,15 @@ namespace dlib
             unsigned long i = 0;
             for (int k = 0; k < 256; ++k)
             {
-                const double v = 255*std::pow(k * red_scale, gamma);
-                table[i++] = static_cast<unsigned char>(v + 0.5);
+                table[i++] = static_cast<unsigned char>(255*std::pow(k * red_scale, gamma) + 0.5);
             }
             for (int k = 0; k < 256; ++k)
             {
-                const double v = 255 * std::pow(k * green_scale, gamma);
-                table[i++] = static_cast<unsigned char>(v + 0.5);
+                table[i++] = static_cast<unsigned char>(255 * std::pow(k * green_scale, gamma) + 0.5);
             }
             for (int k = 0; k < 256; ++k)
             {
-                const double v = 255 * std::pow(k * blue_scale, gamma);
-                table[i++] = static_cast<unsigned char>(v + 0.5);
+                table[i++] = static_cast<unsigned char>(255 * std::pow(k * blue_scale, gamma) + 0.5);
             }
         }
 

--- a/dlib/image_transforms/random_color_transform.h
+++ b/dlib/image_transforms/random_color_transform.h
@@ -41,7 +41,7 @@ namespace dlib
             unsigned long i = 0;
             for (int k = 0; k < 256; ++k)
             {
-                table[i++] = static_cast<unsigned char>(255*std::pow(k * red_scale, gamma) + 0.5);
+                table[i++] = static_cast<unsigned char>(255 * std::pow(k * red_scale, gamma) + 0.5);
             }
             for (int k = 0; k < 256; ++k)
             {


### PR DESCRIPTION
Just a small PR to modernize `random_color_transform` a bit:
- use `initializer_list` for `std::max`: I really like this.
- use `const` where possible
- use `static_cast` instead of C-style cast

I have run a small benchmark, but I couldn't find any speed difference, both implementations take about 0.0128127±0.00387623 ms to create a `random_color_transform`.