### PR TITLE
Fix newton segfault on ppc64/mips64

### DIFF
--- a/dlib/matrix/lapack/fortran_id.h
+++ b/dlib/matrix/lapack/fortran_id.h
@@ -47,7 +47,7 @@ namespace dlib
     namespace lapack
     {
             // stuff from f2c used to define what exactly is an integer in fortran
-#if (defined(__alpha__) || defined(__sparc64__) || defined(__x86_64__) || defined(__ia64__) || defined(__aarch64__)) && !defined(MATLAB_MEX_FILE) && !defined(USE_64BIT_LAPACK_INTEGERS)
+#if (defined(__alpha__) || defined(__sparc64__) || defined(__x86_64__) || defined(__ia64__) || defined(__aarch64__) || defined(__powerpc64__) || defined(__mips64)) && !defined(MATLAB_MEX_FILE) && !defined(USE_64BIT_LAPACK_INTEGERS)
             typedef int integer;
             typedef unsigned int uinteger;
 #else


### PR DESCRIPTION
This fixes a segfault in the newton search on ppc & mips 64 bits:
```
Program received signal SIGSEGV, Segmentation fault.
0x000000550000679c in dlib::lu_decomposition<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> >::lu_decomposition<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> > (this=0x550181aa50, A=...) at /usr/aarch64-linux-gnu/include/dlib/matrix/matrix_lu.h:130
130             if (piv(piv_temp(i)-1) != piv(i))
#0  0x000000550000679c in dlib::lu_decomposition<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> >::lu_decomposition<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> > (this=0x550181aa50, A=...) at /usr/aarch64-linux-gnu/include/dlib/matrix/matrix_lu.h:130
#1  0x0000005500002890 in dlib::inv_helper<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, 0l>::inv (m=...) at /usr/aarch64-linux-gnu/include/dlib/matrix/matrix_la.h:845
#2  dlib::inv<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> > (m=...) at /usr/aarch64-linux-gnu/include/dlib/matrix/matrix_la.h:1018
#3  dlib::newton_search_strategy_obj<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> (*)(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&)>::get_next_direction<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> > (this=<synthetic pointer>, this=<synthetic pointer>, funct_derivative=..., x=...) at /usr/aarch64-linux-gnu/include/dlib/optimization/optimization_search_strategies.h:307
#4  dlib::find_min<dlib::newton_search_strategy_obj<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> (*)(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&)>, dlib::objective_delta_stop_strategy, double (dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&), dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const (dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&), dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> >(dlib::newton_search_strategy_obj<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> (*)(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&)>, dlib::objective_delta_stop_strategy, double ( const&)(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&), dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const ( const&)(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&), dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, double) (min_f=-1, x=..., der=<optimized out>, f=<optimized out>, stop_strategy=..., search_strategy=...) at /usr/aarch64-linux-gnu/include/dlib/optimization/optimization.h:186
#5  main () at optimization_ex.cpp:218
```

I wonder if we could use `__LP64__` here instead of all these macros