### PR TITLE
Suppress incorrect warning from gcc

### DIFF
--- a/dlib/matrix/matrix_data_layout.h
+++ b/dlib/matrix/matrix_data_layout.h
@@ -24,7 +24,7 @@
 // definitely heap allocated.
 #if defined(__GNUC__) && ((__GNUC__ == 11 && __GNUC_MINOR__ == 3))
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=free-nonheap-object"
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
 
 namespace dlib

--- a/dlib/matrix/matrix_data_layout.h
+++ b/dlib/matrix/matrix_data_layout.h
@@ -17,16 +17,6 @@
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
-// GCC 11.3 wrongly yields this warning:
-//  dlib::row_major_layout::layout<double, 0, 2, dlib::memory_manager_stateless_kernel_1<char> >::data’ with nonzero offset 8 [-Werror=free-nonheap-object]
-//   61 |                 delete [] item;
-// Which by inspection of the class below you can see is clearly incorrect, as `data` is most
-// definitely heap allocated.
-#if defined(__GNUC__) && ((__GNUC__ == 11 && __GNUC_MINOR__ == 3))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
-#endif
-
 namespace dlib
 {
 
@@ -1342,10 +1332,6 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
 }
-
-#if defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 #if defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop

--- a/dlib/matrix/matrix_data_layout.h
+++ b/dlib/matrix/matrix_data_layout.h
@@ -17,6 +17,16 @@
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
+// GCC 11.3 wrongly yields this warning:
+//  dlib::row_major_layout::layout<double, 0, 2, dlib::memory_manager_stateless_kernel_1<char> >::data’ with nonzero offset 8 [-Werror=free-nonheap-object]
+//   61 |                 delete [] item;
+// Which by inspection of the class below you can see is clearly incorrect, as `data` is most
+// definitely heap allocated.
+#if defined(__GNUC__) && ((__GNUC__ == 11 && __GNUC_MINOR__ == 3))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=free-nonheap-object"
+#endif
+
 namespace dlib
 {
 
@@ -1332,6 +1342,10 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
 }
+
+#if defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))
+#pragma GCC diagnostic pop
+#endif
 
 #if defined(__GNUC__) && ((__GNUC__ >= 4 && __GNUC_MINOR__ >= 8) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -178,6 +178,16 @@ if (CMAKE_COMPILER_IS_GNUCXX)
    add_compile_options(-Wno-unused-function)
    add_compile_options(-Wno-strict-overflow)
    add_compile_options(-Wno-maybe-uninitialized)
+
+   if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 11.3.0)
+      # GCC 11.3 wrongly yields this warning:
+      #  dlib::row_major_layout::layout<double, 0, 2, dlib::memory_manager_stateless_kernel_1<char> >::data’ with nonzero offset 8 [-Werror=free-nonheap-object]
+      #   61 |                 delete [] item;
+      # Which by inspection of the dlib::row_major_layout::layout class you can see is clearly incorrect, as `data` is most
+      # definitely heap allocated.
+      add_compile_options(-Wno-free-nonheap-object)
+   endif()
+
 elseif (MSVC)
    # Treat warnings as errors.
    add_compile_options(/WX)


### PR DESCRIPTION
Github actions is using a new version of GCC that has a bug in it.  As can be seen in the test results on #2690.  This change should fix it.