### PR TITLE
Fix GitHub actions on Windows because of CMake 3.25.0

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -106,7 +106,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run: cmake . -B ${{ env.build_dir }}
+      run: |
+        # don't use CMake 3.25.0 https://gitlab.kitware.com/cmake/cmake/-/issues/23975
+        pip3 install cmake==3.24.0
+        cmake . -B ${{ env.build_dir }}
     - name: Build just tests
       run: cmake --build ${{ env.build_dir }} --config ${{ env.config }} --target dtest --parallel 4
     - name: Test
@@ -119,7 +122,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run: cmake . -B ${{ env.build_dir }}
+      run: |
+        # don't use CMake 3.25.0 https://gitlab.kitware.com/cmake/cmake/-/issues/23975
+        pip3 install cmake==3.24.0
+        cmake . -B ${{ env.build_dir }}
     - name: Build just tests
       run: cmake --build ${{ env.build_dir }} --config Debug --target dtest --parallel 4
     - name: Build ancillary tools

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -19,9 +19,13 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - name: Install python deps
-      run: pip install pytest numpy
+      run: |
+        pip install pytest numpy
+        # don't use CMake 3.25.0 https://gitlab.kitware.com/cmake/cmake/-/issues/23975
+        pip3 install cmake==3.24.0
     - name: Build
       run: |
+        pip3 install cmake==3.24.0
         python setup.py build
         python setup.py install --user
     - name: Test


### PR DESCRIPTION
I found this on Reddit: https://www.reddit.com/r/cpp/comments/z618kl/psa_cmake_325_might_break_your_github_actions/

_The Meson devs, in their infinite wisdom, decided that it was a good idea to ignore 30 years old platform conventions and produce static libraries with a filename that implies GNU ABI on Windows, even when targeting MSVC ABI._

_CMake, in an attempt to accomodate, added this name pattern to its normal MSVC ABI search patterns in 3.25: https://gitlab.kitware.com/cmake/cmake/-/issues/23975
Since GitHub Actions runners are very frequently updating tools, this update quickly made it into the virtual envs._