### PR TITLE
removed extra '<' in fc, added '\n' in layers/inputs/losses XML strings

### DIFF
--- a/dlib/dnn/input.h
+++ b/dlib/dnn/input.h
@@ -156,7 +156,7 @@ namespace dlib
 
         friend void to_xml(const input_rgb_image& item, std::ostream& out)
         {
-            out << "<input_rgb_image r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"'/>";
+            out << "<input_rgb_image r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"'/>\n";
         }
 
     private:
@@ -289,7 +289,7 @@ namespace dlib
 
         friend void to_xml(const input_rgb_image_sized& item, std::ostream& out)
         {
-            out << "<input_rgb_image_sized r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"' nr='"<<NR<<"' nc='"<<NC<<"'/>";
+            out << "<input_rgb_image_sized r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"' nr='"<<NR<<"' nc='"<<NC<<"'/>\n";
         }
 
     private:
@@ -448,7 +448,7 @@ namespace dlib
 
         friend void to_xml(const input_rgb_image_pair& item, std::ostream& out)
         {
-            out << "<input_rgb_image_pair r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"'/>";
+            out << "<input_rgb_image_pair r='"<<item.avg_red<<"' g='"<<item.avg_green<<"' b='"<<item.avg_blue<<"'/>\n";
         }
 
     private:
@@ -559,7 +559,7 @@ namespace dlib
 
         friend void to_xml(const input& /*item*/, std::ostream& out)
         {
-            out << "<input/>";
+            out << "<input/>\n";
         }
     };
 
@@ -652,7 +652,7 @@ namespace dlib
 
         friend void to_xml(const input& /*item*/, std::ostream& out)
         {
-            out << "<input/>";
+            out << "<input/>\n";
         }
     };
 
@@ -747,7 +747,7 @@ namespace dlib
 
         friend void to_xml(const input&, std::ostream& out)
         {
-            out << "<input/>";
+            out << "<input/>\n";
         }
     };
 
@@ -943,7 +943,7 @@ namespace dlib
             out << "<input_grayscale_image_pyramid"
                 <<"' pyramid_padding='"<<item.pyramid_padding
                 <<"' pyramid_outer_padding='"<<item.pyramid_outer_padding
-                <<"'/>";
+                <<"'/>\n";
         }
     };
 
@@ -1073,7 +1073,7 @@ namespace dlib
                 <<"' b='"<<item.avg_blue
                 <<"' pyramid_padding='"<<item.pyramid_padding
                 <<"' pyramid_outer_padding='"<<item.pyramid_outer_padding
-                <<"'/>";
+                <<"'/>\n";
         }
 
     private:

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -369,7 +369,7 @@ namespace dlib
                 << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'"
                 << " use_bias='"<<(item.use_bias?"true":"false")<<"'>\n";
             out << mat(item.params);
-            out << "</con>";
+            out << "</con>\n";
         }
 
     private:
@@ -693,7 +693,7 @@ namespace dlib
                 << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'"
                 << " use_bias='"<<(item.use_bias?"true":"false")<<"'>\n";
             out << mat(item.params);
-            out << "</cont>";
+            out << "</cont>\n";
         }
 
     private:
@@ -1445,7 +1445,7 @@ namespace dlib
 
         friend void to_xml(const layer_norm_& item, std::ostream& out)
         {
-            out << "layer_norm";
+            out << "<layer_norm";
             out << " eps='"<<item.eps<<"'";
             out << " learning_rate_mult='"<<item.learning_rate_multiplier<<"'";
             out << " weight_decay_mult='"<<item.weight_decay_multiplier<<"'";
@@ -1943,7 +1943,6 @@ namespace dlib
                     << " bias_learning_rate_mult='"<<item.bias_learning_rate_multiplier<<"'"
                     << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'"
                     << " use_bias='"<<(item.use_bias?"true":"false")<<"'>\n";
-                out << ">\n";
                 out << mat(item.params);
                 out << "</fc>\n";
             }

--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -119,7 +119,7 @@ namespace dlib
 
         friend void to_xml(const loss_binary_hinge_& /*item*/, std::ostream& out)
         {
-            out << "<loss_binary_hinge/>";
+            out << "<loss_binary_hinge/>\n";
         }
 
     };
@@ -236,7 +236,7 @@ namespace dlib
 
         friend void to_xml(const loss_binary_log_& /*item*/, std::ostream& out)
         {
-            out << "<loss_binary_log/>";
+            out << "<loss_binary_log/>\n";
         }
 
     };
@@ -353,7 +353,7 @@ namespace dlib
 
         friend void to_xml(const loss_multiclass_log_& /*item*/, std::ostream& out)
         {
-            out << "<loss_multiclass_log/>";
+            out << "<loss_multiclass_log/>\n";
         }
 
     };
@@ -472,7 +472,7 @@ namespace dlib
 
         friend void to_xml(const loss_multiclass_log_weighted_& /*item*/, std::ostream& out)
         {
-            out << "<loss_multiclass_log_weighted/>";
+            out << "<loss_multiclass_log_weighted/>\n";
         }
 
     };
@@ -735,7 +735,7 @@ namespace dlib
         {
             out << "<loss_multimulticlass_log>\n";
             out << item;
-            out << "\n</loss_multimulticlass_log>";
+            out << "\n</loss_multimulticlass_log>\n";
         }
 
     private:
@@ -900,7 +900,7 @@ namespace dlib
 
         friend void to_xml(const loss_multibinary_log_& item, std::ostream& out)
         {
-            out << "<loss_multibinary_log gamma='" << item.gamma << "'/>";
+            out << "<loss_multibinary_log gamma='" << item.gamma << "'/>\n";
         }
 
     private:
@@ -1715,7 +1715,7 @@ namespace dlib
         friend void to_xml(const loss_mmod_& /*item*/, std::ostream& out)
         {
             // TODO, add options fields
-            out << "<loss_mmod/>";
+            out << "<loss_mmod/>\n";
         }
 
     private:
@@ -2236,7 +2236,7 @@ namespace dlib
 
         friend void to_xml(const loss_metric_& item, std::ostream& out)
         {
-            out << "<loss_metric margin='"<<item.margin<<"' distance_threshold='"<<item.dist_thresh<<"'/>";
+            out << "<loss_metric margin='"<<item.margin<<"' distance_threshold='"<<item.dist_thresh<<"'/>\n";
         }
 
     private:
@@ -2386,7 +2386,7 @@ namespace dlib
 
         friend void to_xml(const loss_ranking_& /*item*/, std::ostream& out)
         {
-            out << "<loss_ranking/>";
+            out << "<loss_ranking/>\n";
         }
 
     };
@@ -2493,7 +2493,7 @@ namespace dlib
 
         friend void to_xml(const loss_mean_squared_& /*item*/, std::ostream& out)
         {
-            out << "<loss_mean_squared/>";
+            out << "<loss_mean_squared/>\n";
         }
 
     };
@@ -2621,7 +2621,7 @@ namespace dlib
 
         friend void to_xml(const loss_epsilon_insensitive_& item, std::ostream& out)
         {
-            out << "<loss_epsilon_insensitive_ epsilon='" << item.eps << "'/>";
+            out << "<loss_epsilon_insensitive_ epsilon='" << item.eps << "'/>\n";
         }
 
     private:
@@ -2743,7 +2743,7 @@ namespace dlib
 
         friend void to_xml(const loss_mean_squared_multioutput_& /*item*/, std::ostream& out)
         {
-            out << "<loss_mean_squared_multioutput/>";
+            out << "<loss_mean_squared_multioutput/>\n";
         }
 
     };
@@ -2853,7 +2853,7 @@ namespace dlib
 
         friend void to_xml(const loss_binary_log_per_pixel_& /*item*/, std::ostream& out)
         {
-            out << "<loss_binary_log_per_pixel/>";
+            out << "<loss_binary_log_per_pixel/>\n";
         }
 
     private:
@@ -2998,7 +2998,7 @@ namespace dlib
 
         friend void to_xml(const loss_multiclass_log_per_pixel_& /*item*/, std::ostream& out)
         {
-            out << "<loss_multiclass_log_per_pixel/>";
+            out << "<loss_multiclass_log_per_pixel/>\n";
         }
 
     private:
@@ -3098,7 +3098,7 @@ namespace dlib
 
         friend void to_xml(const loss_multiclass_log_per_pixel_weighted_& /*item*/, std::ostream& out)
         {
-            out << "<loss_multiclass_log_per_pixel_weighted/>";
+            out << "<loss_multiclass_log_per_pixel_weighted/>\n";
         }
 
     private:
@@ -3231,7 +3231,7 @@ namespace dlib
 
         friend void to_xml(const loss_mean_squared_per_pixel_& /*item*/, std::ostream& out)
         {
-            out << "<loss_mean_squared_per_pixel/>";
+            out << "<loss_mean_squared_per_pixel/>\n";
         }
 
     };
@@ -3349,7 +3349,7 @@ namespace dlib
 
         friend void to_xml(const loss_mean_squared_per_channel_and_pixel_& /*item*/, std::ostream& out)
         {
-            out << "<loss_mean_squared_per_channel_and_pixel/>";
+            out << "<loss_mean_squared_per_channel_and_pixel/>\n";
         }
 
     private:
@@ -3462,7 +3462,7 @@ namespace dlib
 
         friend void to_xml(const loss_dot_& /*item*/, std::ostream& out)
         {
-            out << "<loss_dot/>";
+            out << "<loss_dot/>\n";
         }
 
     };
@@ -4002,7 +4002,7 @@ namespace dlib
 
         friend void to_xml(const loss_yolo_& /*item*/, std::ostream& out)
         {
-            out << "<loss_yolo/>";
+            out << "<loss_yolo/>\n";
         }
 
     private:
@@ -4182,7 +4182,7 @@ namespace dlib
 
         friend void to_xml(const loss_barlow_twins_& item, std::ostream& out)
         {
-            out << "<loss_barlow_twins lambda='" << item.lambda << "'/>";
+            out << "<loss_barlow_twins lambda='" << item.lambda << "'/>\n";
         }
 
     private:


### PR DESCRIPTION
There were errors in some XML strings returned by to_xml in dnn/layers.h (fc, layer_norm). I also added newlines to various XML strings.
I noticed XML strings that may have errors in dnn/layers.h at lines 3181 (leaky_relu) and 3699 (smelu), i don't know if those should be changed as well