### PR TITLE
Strip binaries in release mode

### DIFF
--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -14,9 +14,7 @@ set(DLIB_TEST_COMPILE_ALL_SOURCE_CPP ON)
 
 add_subdirectory(.. dlib_build)
 
-# This variable contains a list of all the tests we are building
-# into the regression test suite.
-set (tests
+add_executable(${target_name} main.cpp tester.cpp
    example.cpp
    active_learning.cpp
    any.cpp
@@ -163,15 +161,10 @@ set (tests
    elastic_net.cpp
    te.cpp
    ffmpeg.cpp
-   )
-
-
-# add all the cpp files we want to compile to this list.  This tells
-# cmake that they are part of our target (which is the executable named dtest)
-ADD_EXECUTABLE(${target_name} main.cpp tester.cpp ${tests})
+)
 
 get_filename_component(DLIB_FFMPEG_DATA ${CMAKE_SOURCE_DIR}/ffmpeg_data/details.cfg REALPATH)
-add_compile_definitions(DLIB_FFMPEG_DATA="${DLIB_FFMPEG_DATA}")
+target_compile_definitions(${target_name} PRIVATE DLIB_FFMPEG_DATA="${DLIB_FFMPEG_DATA}")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
    # Turn on all warnings, and treat them as errors.
@@ -191,6 +184,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
       # definitely heap allocated.
       add_compile_options(-Wno-free-nonheap-object)
    endif()
+   target_link_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:-s>)
 
 elseif (MSVC)
    # Treat warnings as errors.
@@ -200,10 +194,11 @@ else() # basically Clang
    add_compile_options(-W -Werror)
    # This is for the comment in face_detection_ex.cpp that says "faces/*.jpg"
    add_compile_options(-Wno-comment)
+   target_link_options(${target_name} PRIVATE $<$<CONFIG:RELEASE>:-s>)
 endif()
 
 
-TARGET_LINK_LIBRARIES(${target_name} dlib::dlib )
+target_link_libraries(${target_name} dlib::dlib )
 
 
 if (NOT DLIB_NO_GUI_SUPPORT)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(assignment_learning_ex dlib::dlib)
 macro(add_example name)
    add_executable(${name} ${name}.cpp)
    target_link_libraries(${name} dlib::dlib )
+   target_link_options(${name} PRIVATE $<$<CONFIG:RELEASE>:-s>)
 endmacro()
 
 # if an example requires GUI, call this macro to check DLIB_NO_GUI_SUPPORT to include or exclude

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(assignment_learning_ex dlib::dlib)
 macro(add_example name)
    add_executable(${name} ${name}.cpp)
    target_link_libraries(${name} dlib::dlib )
+   # And strip symbols to make your binary smaller if you like.  Certainly not required though.
    target_link_options(${name} PRIVATE $<$<CONFIG:RELEASE>:-s>)
 endmacro()
 


### PR DESCRIPTION
I think this is a good idea.
I always compile libav* libraries as static libraries.
I noticed that `dtest` was then 100MB in size.
Stripping in release mode reduces that to 20MB on my machine. That's pretty typical given a fully enabled installation of ffmpeg.
I don't want users to get scared and think that all their computer vision applications will be > 100MB in size. That's pretty crazy and easily avoidable by adding in `-s` to your link options.