### PR TITLE
fix wrong union calculation in box_overlap_testing.h

### DIFF
--- a/dlib/image_processing/box_overlap_testing.h
+++ b/dlib/image_processing/box_overlap_testing.h
@@ -20,8 +20,8 @@ namespace dlib
         const double inner = a.intersect(b).area();
         if (inner == 0)
             return 0;
-        const double outer = (a+b).area();
-        return inner/outer;
+        const double outer = a.area() + b.area() - inner;
+        return inner / outer;
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
As explained in [this article](https://medium.com/analytics-vidhya/iou-intersection-over-union-705a39e7acef) the union for calculating the IoU of two rectangles must be the unified area of both rectangles. Currently the outer rectangle in that both rectangles fit is used, which is wrong, as this area is larger than the one that has to be used.