### PR TITLE
powerpc/altivec: use __vector instead of vector

### DIFF
--- a/dlib/simd/simd4f.h
+++ b/dlib/simd/simd4f.h
@@ -89,7 +89,7 @@ namespace dlib
     class simd4f
     {    
         typedef union {
-            vector float v;
+            __vector float v;
             float x[4];
         } v4f;
         
@@ -98,7 +98,7 @@ namespace dlib
     public:
         inline simd4f() : x{0,0,0,0} {}
         inline simd4f(const simd4f& v) : x(v.x) { }
-        inline simd4f(const vector float& v) : x{v} { }
+        inline simd4f(const __vector float& v) : x{v} { }
 
         inline simd4f(const simd4i& v) {
             x.x[0]=v[0]; x.x[1]=v[1]; x.x[2]=v[2]; x.x[3]=v[3];
@@ -112,7 +112,7 @@ namespace dlib
         inline simd4f& operator=(const simd4f& v) { x = v.x; return *this; }
         inline simd4f& operator=(const float& v) { *this = simd4f(v); return *this; }
 
-        inline vector float operator() () const { return x.v; }
+        inline __vector float operator() () const { return x.v; }
         inline float operator[](unsigned int idx) const { return x.x[idx]; }
         
         inline void load_aligned(const float* ptr)  { x.v = vec_ld(0, ptr); }

--- a/dlib/simd/simd4i.h
+++ b/dlib/simd/simd4i.h
@@ -50,8 +50,8 @@ namespace dlib
     class simd4i
     {    
         typedef union {
-            vector signed int v;
-            vector bool int b;
+            __vector signed int v;
+            __vector __bool int b;
             signed int x[4];
         } v4i;
 
@@ -60,8 +60,8 @@ namespace dlib
     public:
         inline simd4i() : x{0,0,0,0} { }
         inline simd4i(const simd4i& v) : x(v.x) { }
-        inline simd4i(const vector int& v) : x{v} { }
-        inline simd4i(const vector bool int& b) { x.b=b; }
+        inline simd4i(const __vector int& v) : x{v} { }
+        inline simd4i(const __vector __bool int& b) { x.b=b; }
 
         inline simd4i(int32 f) : x{f,f,f,f} { }
         inline simd4i(int32 r0, int32 r1, int32 r2, int32 r3)
@@ -70,10 +70,10 @@ namespace dlib
         inline simd4i& operator=(const simd4i& v) { x = v.x; return *this; }
         inline simd4i& operator=(const int32& v) { *this = simd4i(v); return *this; }
 
-        inline vector signed int operator() () const { return x.v; }
+        inline __vector signed int operator() () const { return x.v; }
         inline int32 operator[](unsigned int idx) const { return x.x[idx]; }
         
-        inline vector bool int to_bool() const { return x.b; }
+        inline __vector __bool int to_bool() const { return x.b; }
         
         // intrinsics now seem to use xxpermdi automatically now
         inline void load_aligned(const int32* ptr)  { x.v = vec_ld(0, ptr); }
@@ -253,7 +253,7 @@ namespace dlib
                       _lhs[2]*_rhs[2],
                       _lhs[3]*_rhs[3]);
 #elif defined(DLIB_HAVE_VSX)
-        vector int a = lhs(), b = rhs();
+        __vector int a = lhs(), b = rhs();
         asm("vmuluwm %0, %0, %1\n\t" : "+&v" (a) : "v" (b) );
         return simd4i(a);
 #elif defined(DLIB_HAVE_NEON)

--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -83,6 +83,9 @@
 
 #ifdef DLIB_HAVE_ALTIVEC
 #include <altivec.h>
+#undef bool
+#undef vector
+#undef pixel
 #endif
 
 #ifdef DLIB_HAVE_SSE2
@@ -137,7 +140,8 @@
 
     inline std::array<unsigned int,4> cpuid(int) 
     {
-        return std::array<unsigned int,4>{};
+        std::array<unsigned int,4> info = { 0 };
+        return info;
     }
 
 #endif


### PR DESCRIPTION
The gcc altivec extension defines keywords for vector, bool, and pixel, both with underscores and without. However, unless another extension is used the keywords without underscores conflict with standard types.

To resolve the conflict use the keywords with underscores for the altivec vector types.

Fixes: #2711

Note: with this dlib can be compiled but crashes during tests. This crash is not specific to powerpc. There is probably something missing when neither the AMD nor the Arm vector implementation is available.