### PR TITLE
Add optional Python version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -32,6 +32,14 @@ body:
     validations:
       required: true
   - type: input
+    id: python
+    attributes:
+      label: Python version
+      description: "The version of Python you are using"
+      placeholder: "3.8"
+    validations:
+      required: false
+  - type: input
     id: compiler
     attributes:
       label: Compiler


### PR DESCRIPTION
I guess a lot of people are building dlib to use it from Python, so add a field to allow them to report which version they're using.