### PR TITLE
Fix crash when libX11 is missing locale support

### DIFF
--- a/dlib/gui_core/gui_core_kernel_2.cpp
+++ b/dlib/gui_core/gui_core_kernel_2.cpp
@@ -1757,10 +1757,12 @@ namespace dlib
         // it isn't const anymore.
         wchar_t *title = const_cast<wchar_t *>(title_.c_str());
         XTextProperty property;
-        XwcTextListToTextProperty(x11_stuff.globals->disp,&title,1,XStdICCTextStyle, &property);
-        XSetWMName(x11_stuff.globals->disp,x11_stuff.hwnd,&property);
-        XFree(property.value);
-        XFlush(x11_stuff.globals->disp);
+        int rc = XwcTextListToTextProperty(x11_stuff.globals->disp,&title,1,XStdICCTextStyle, &property);
+        if (rc >= 0) {
+            XSetWMName(x11_stuff.globals->disp,x11_stuff.hwnd,&property);
+            XFree(property.value);
+            XFlush(x11_stuff.globals->disp);
+        }
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a crash I was running into trying the dnn_face_recognition_ex with XQuartz on a Apple Silicon Mac.

It seems that the prebuilt libX11.6.dylib bottle from Homebrew is missing full locale support, which causes the XwcTextListToTextProperty call to return -2 (XLocaleNotSupported), which caused this code to crash when calling XFree as the XTextProperty value was not initialised.

Window titles seemed generally low value here, so just avoiding the crash seemed like the easiest path forwards.