### PR TITLE
Add HSV support

### DIFF
--- a/dlib/matrix/matrix_utilities.h
+++ b/dlib/matrix/matrix_utilities.h
@@ -3004,6 +3004,7 @@ namespace dlib
             pixel_traits<P>::grayscale,
             pixel_traits<P>::rgb,
             pixel_traits<P>::hsi,
+            pixel_traits<P>::hsv,
             pixel_traits<P>::rgb_alpha,
             pixel_traits<P>::lab
             >::value
@@ -3062,6 +3063,21 @@ namespace dlib
             const P& pixel
         )
         {
+            m(0) = static_cast<typename M::type>(pixel.h);
+            m(1) = static_cast<typename M::type>(pixel.s);
+            m(2) = static_cast<typename M::type>(pixel.v);
+        }
+    };
+
+    template <typename P>
+    struct pixel_to_vector_helper<P,5>
+    {
+        template <typename M>
+        static void assign (
+            M& m,
+            const P& pixel
+        )
+        {
             m(0) = static_cast<typename M::type>(pixel.red);
             m(1) = static_cast<typename M::type>(pixel.green);
             m(2) = static_cast<typename M::type>(pixel.blue);
@@ -3070,7 +3086,7 @@ namespace dlib
     };
 
     template <typename P>
-    struct pixel_to_vector_helper<P,5>
+    struct pixel_to_vector_helper<P,6>
     {
         template <typename M>
         static void assign (
@@ -3107,6 +3123,7 @@ namespace dlib
             pixel_traits<P>::grayscale,
             pixel_traits<P>::rgb,
             pixel_traits<P>::hsi,
+            pixel_traits<P>::hsv,
             pixel_traits<P>::rgb_alpha,
             pixel_traits<P>::lab
             >::value
@@ -3165,6 +3182,21 @@ namespace dlib
             const M& m
         )
         {
+            pixel.h = static_cast<unsigned char>(m(0));
+            pixel.s = static_cast<unsigned char>(m(1));
+            pixel.v = static_cast<unsigned char>(m(2));
+        }
+    };
+
+    template <typename P>
+    struct vector_to_pixel_helper<P,5>
+    {
+        template <typename M>
+        static void assign (
+            P& pixel,
+            const M& m
+        )
+        {
             pixel.red = static_cast<unsigned char>(m(0));
             pixel.green = static_cast<unsigned char>(m(1));
             pixel.blue = static_cast<unsigned char>(m(2));
@@ -3173,7 +3205,7 @@ namespace dlib
     };
 
     template <typename P>
-    struct vector_to_pixel_helper<P,5>
+    struct vector_to_pixel_helper<P,6>
     {
         template <typename M>
         static void assign (

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -86,6 +86,16 @@ namespace dlib
                 - min() == 0 
                 - max() == 255
                 - is_unsigned == true
+            - else if (hsv == true) then
+                - The type T will be a struct with 3 public members of type
+                  unsigned char named "h" "s" and "v".
+                - This type of pixel represents the HSV color space.
+                - num == 3
+                - has_alpha == false
+                - basic_pixel_type == unsigned char
+                - min() == 0
+                - max() == 255
+                - is_unsigned == true
              - else if (lab == true) then
                 - The type T will be a struct with 3 public members of type
                   unsigned char named "l" "a" and "b".
@@ -322,6 +332,41 @@ namespace dlib
             return !(*this == that);
         }
 
+    };
+
+// ----------------------------------------------------------------------------------------
+
+    struct hsv_pixel
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This is a simple struct that represents an HSV colored graphical pixel.
+        !*/
+
+        hsv_pixel (
+        ) {}
+
+        hsv_pixel (
+            unsigned char h_,
+            unsigned char s_,
+            unsigned char v_
+        ) : h(h_), s(s_), v(v_) {}
+
+        unsigned char h;
+        unsigned char s;
+        unsigned char v;
+
+        bool operator == (const hsv_pixel& that) const
+        {
+            return this->h == that.h
+                && this->s == that.s
+                && this->v == that.v;
+        }
+
+        bool operator != (const hsv_pixel& that) const
+        {
+            return !(*this == that);
+        }
     };
 
     // ----------------------------------------------------------------------------------------
@@ -566,6 +611,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         constexpr static long num = 3;
         typedef unsigned char basic_pixel_type;
@@ -585,6 +631,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = true;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         constexpr static long num = 4;
         typedef unsigned char basic_pixel_type;
@@ -604,6 +651,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = true;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         constexpr static long num = 4;
         typedef unsigned char basic_pixel_type;
@@ -624,6 +672,28 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = true;
+        constexpr static bool hsv = false;
+        constexpr static bool lab = false;
+        constexpr static long num = 3;
+        typedef unsigned char basic_pixel_type;
+        static basic_pixel_type min() { return 0;}
+        static basic_pixel_type max() { return 255;}
+        constexpr static bool is_unsigned = true;
+        constexpr static bool has_alpha = false;
+    };
+
+// ----------------------------------------------------------------------------------------
+
+
+    template <>
+    struct pixel_traits<hsv_pixel>
+    {
+        constexpr static bool rgb  = false;
+        constexpr static bool bgr_layout  = false;
+        constexpr static bool rgb_alpha  = false;
+        constexpr static bool grayscale = false;
+        constexpr static bool hsi = false;
+        constexpr static bool hsv = true;
         constexpr static bool lab = false;
         constexpr static long num = 3;
         typedef unsigned char basic_pixel_type;
@@ -644,6 +714,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = true;
         constexpr static long num = 3;
         typedef unsigned char basic_pixel_type;
@@ -663,6 +734,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = true;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         constexpr static long num = 1;
         constexpr static bool has_alpha = false;
@@ -696,6 +768,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = true;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         constexpr static long num = 1;
         constexpr static bool has_alpha = false;
@@ -942,11 +1015,12 @@ namespace dlib
 
     // -----------------------------
 
-        struct HSL
+        // Helper struct used for HSL and HSV
+        struct HSX
         {
             double h;
             double s;
-            double l;
+            double x;
         };
 
         struct COLOUR
@@ -966,19 +1040,19 @@ namespace dlib
             Lightness is between 0 and 1
             Saturation is between 0 and 1
         */
-        inline HSL RGB2HSL(COLOUR c1)
+        inline HSX RGB2HSL(COLOUR c1)
         {
             double themin,themax,delta;
-            HSL c2;
+            HSX c2;
             using namespace std;
 
             themin = std::min(c1.r,std::min(c1.g,c1.b));
             themax = std::max(c1.r,std::max(c1.g,c1.b));
             delta = themax - themin;
-            c2.l = (themin + themax) / 2;
+            c2.x = (themin + themax) / 2;
             c2.s = 0;
-            if (c2.l > 0 && c2.l < 1)
-                c2.s = delta / (c2.l < 0.5 ? (2*c2.l) : (2-2*c2.l));
+            if (c2.x > 0 && c2.x < 1)
+                c2.s = delta / (c2.x < 0.5 ? (2*c2.x) : (2-2*c2.x));
             c2.h = 0;
             if (delta > 0) {
                 if (themax == c1.r && themax != c1.g)
@@ -998,7 +1072,7 @@ namespace dlib
             Lightness is between 0 and 1
             Saturation is between 0 and 1
         */
-        inline COLOUR HSL2RGB(HSL c1)
+        inline COLOUR HSL2RGB(HSX c1)
         {
             COLOUR c2,sat,ctmp;
             using namespace std;
@@ -1024,17 +1098,140 @@ namespace dlib
             ctmp.g = 2 * c1.s * sat.g + (1 - c1.s);
             ctmp.b = 2 * c1.s * sat.b + (1 - c1.s);
 
-            if (c1.l < 0.5) {
-                c2.r = c1.l * ctmp.r;
-                c2.g = c1.l * ctmp.g;
-                c2.b = c1.l * ctmp.b;
+            if (c1.x < 0.5) {
+                c2.r = c1.x * ctmp.r;
+                c2.g = c1.x * ctmp.g;
+                c2.b = c1.x * ctmp.b;
             } else {
-                c2.r = (1 - c1.l) * ctmp.r + 2 * c1.l - 1;
-                c2.g = (1 - c1.l) * ctmp.g + 2 * c1.l - 1;
-                c2.b = (1 - c1.l) * ctmp.b + 2 * c1.l - 1;
+                c2.r = (1 - c1.x) * ctmp.r + 2 * c1.x - 1;
+                c2.g = (1 - c1.x) * ctmp.g + 2 * c1.x - 1;
+                c2.b = (1 - c1.x) * ctmp.b + 2 * c1.x - 1;
             }
 
             return(c2);
+        }
+
+        /*
+            Calculate HSV from RGB
+            Hue is in degrees
+            Saturation is between 0 and 1
+            Value is between 0 and 1
+        */
+        inline HSX RGB2HSV(COLOUR in)
+        {
+            HSX out;
+            double min, max, delta;
+
+            min = in.r < in.g ? in.r : in.g;
+            min = min < in.b ? min : in.b;
+
+            max = in.r > in.g ? in.r : in.g;
+            max = max > in.b ? max : in.b;
+
+            out.x = max;
+            delta = max - min;
+            if (delta < 0.00001)
+            {
+                out.s = 0;
+                out.h = 0;
+                return out;
+            }
+            if (max > 0.0)
+            {
+                out.s = (delta / max);
+            }
+            else
+            {
+                out.s = 0.0;
+                out.h = NAN;
+                return out;
+            }
+            if (in.r >= max)
+            {
+                out.h = (in.g - in.b) / delta;
+            }
+            else
+            {
+                if (in.g >= max)
+                    out.h = 2.0 + (in.b - in.r) / delta;
+                else
+                    out.h = 4.0 + (in.r - in.g) / delta;
+            }
+
+            out.h *= 60.0;
+
+            if (out.h < 0.0)
+                out.h += 360.0;
+
+            return out;
+        }
+
+        // -----------------------------
+
+        /*
+            Calculate RGB from HSV, reverse of RGB2HSV()
+            Hue is in degrees
+            Saturation is between 0 and 1
+            Value is between 0 and 1
+        */
+        inline COLOUR HSV2RGB(HSX in)
+        {
+            double hh, p, q, t, ff;
+            long i;
+            COLOUR out;
+
+            if (in.s <= 0.0)
+            {
+                out.r = in.x;
+                out.g = in.x;
+                out.b = in.x;
+                return out;
+            }
+            hh = in.h;
+            if (hh >= 360.0)
+                hh = 0.0;
+            hh /= 60.0;
+            i = static_cast<long>(hh);
+            ff = hh - i;
+            p = in.x * (1.0 - in.s);
+            q = in.x * (1.0 - (in.s * ff));
+            t = in.x * (1.0 - (in.s * (1.0 - ff)));
+
+            switch (i)
+            {
+            case 0:
+                out.r = in.x;
+                out.g = t;
+                out.b = p;
+                break;
+            case 1:
+                out.r = q;
+                out.g = in.x;
+                out.b = p;
+                break;
+            case 2:
+                out.r = p;
+                out.g = in.x;
+                out.b = t;
+                break;
+            case 3:
+                out.r = p;
+                out.g = q;
+                out.b = in.x;
+                break;
+            case 4:
+                out.r = t;
+                out.g = p;
+                out.b = in.x;
+                break;
+            case 5:
+            default:
+                out.r = in.x;
+                out.g = p;
+                out.b = q;
+                break;
+            }
+            return out;
         }
 
         // -----------------------------
@@ -1262,12 +1459,29 @@ namespace dlib
         assign(P1& dest, const P2& src) 
         { 
             COLOUR c;
-            HSL h;
+            HSX h;
             h.h = src.h;
             h.h = h.h/255.0*360;
             h.s = src.s/255.0;
-            h.l = src.i/255.0;
+            h.x = src.i/255.0;
             c = HSL2RGB(h);
+
+            dest.red = static_cast<unsigned char>(c.r*255.0 + 0.5);
+            dest.green = static_cast<unsigned char>(c.g*255.0 + 0.5);
+            dest.blue = static_cast<unsigned char>(c.b*255.0 + 0.5);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::rgb && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            COLOUR c;
+            HSX h;
+            h.h = src.h;
+            h.h = h.h/255.0*360;
+            h.s = src.s/255.0;
+            h.x = src.i/255.0;
+            c = HSV2RGB(h);
 
             dest.red = static_cast<unsigned char>(c.r*255.0 + 0.5);
             dest.green = static_cast<unsigned char>(c.g*255.0 + 0.5);
@@ -1333,12 +1547,30 @@ namespace dlib
         assign(P1& dest, const P2& src) 
         { 
             COLOUR c;
-            HSL h;
+            HSX h;
             h.h = src.h;
             h.h = h.h/255.0*360;
             h.s = src.s/255.0;
-            h.l = src.i/255.0;
+            h.x = src.i/255.0;
             c = HSL2RGB(h);
+
+            dest.red = static_cast<unsigned char>(c.r*255.0 + 0.5);
+            dest.green = static_cast<unsigned char>(c.g*255.0 + 0.5);
+            dest.blue = static_cast<unsigned char>(c.b*255.0 + 0.5);
+            dest.alpha = 255;
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::rgb_alpha && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            COLOUR c;
+            HSX h;
+            h.h = src.h;
+            h.h = h.h/255.0*360;
+            h.s = src.s/255.0;
+            h.x = src.v/255.0;
+            c = HSV2RGB(h);
 
             dest.red = static_cast<unsigned char>(c.r*255.0 + 0.5);
             dest.green = static_cast<unsigned char>(c.g*255.0 + 0.5);
@@ -1389,7 +1621,7 @@ namespace dlib
         assign(P1& dest, const P2& src) 
         { 
             COLOUR c1;
-            HSL c2;
+            HSX c2;
             c1.r = src.red/255.0;
             c1.g = src.green/255.0;
             c1.b = src.blue/255.0;
@@ -1397,7 +1629,7 @@ namespace dlib
 
             dest.h = static_cast<unsigned char>(c2.h/360.0*255.0 + 0.5);
             dest.s = static_cast<unsigned char>(c2.s*255.0 + 0.5);
-            dest.i = static_cast<unsigned char>(c2.l*255.0 + 0.5);
+            dest.i = static_cast<unsigned char>(c2.x*255.0 + 0.5);
         }
 
         template < typename P1, typename P2 >
@@ -1425,6 +1657,72 @@ namespace dlib
             assign_pixel_helpers::assign(temp,src);
             // now we can just go assign the new rgb value to the
             // hsi pixel
+            assign_pixel_helpers::assign(dest,temp);
+        }
+
+    // -----------------------------
+        // dest is an hsv pixel
+
+        template < typename P1>
+        typename enable_if_c<pixel_traits<P1>::hsv>::type
+        assign(P1& dest, const unsigned char& src) 
+        { 
+            dest.h = 0;
+            dest.s = 0;
+            dest.v = src;
+        }
+
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::grayscale>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            dest.h = 0;
+            dest.s = 0;
+            assign_pixel(dest.i, src);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::rgb>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            COLOUR c1;
+            HSX c2;
+            c1.r = src.red/255.0;
+            c1.g = src.green/255.0;
+            c1.b = src.blue/255.0;
+            c2 = RGB2HSV(c1);
+
+            dest.h = static_cast<unsigned char>(c2.h/360.0*255.0 + 0.5);
+            dest.s = static_cast<unsigned char>(c2.s*255.0 + 0.5);
+            dest.v = static_cast<unsigned char>(c2.x*255.0 + 0.5);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::rgb_alpha>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            rgb_pixel temp;
+            // convert target hsv pixel to rgb
+            assign_pixel_helpers::assign(temp,dest);
+
+            // now assign the rgb_alpha value to our temp rgb pixel
+            assign_pixel_helpers::assign(temp,src);
+
+            // now we can just go assign the new rgb value to the
+            // hsv pixel
+            assign_pixel_helpers::assign(dest,temp);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::lab>::type
+        assign(P1& dest, const P2& src)
+        {
+            rgb_pixel temp;
+            // convert lab value to our temp rgb pixel
+            assign_pixel_helpers::assign(temp,src);
+            // now we can just go assign the new rgb value to the
+            // hsv pixel
             assign_pixel_helpers::assign(dest,temp);
         }
 
@@ -1488,6 +1786,20 @@ namespace dlib
             rgb_pixel temp;
 
             // convert hsi value to our temp rgb pixel
+            assign_pixel_helpers::assign(temp,src);
+
+            // now we can just go assign the new rgb value to the
+            // lab pixel
+            assign_pixel_helpers::assign(dest,temp);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::lab && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src)
+        {
+            rgb_pixel temp;
+
+            // convert hsv value to our temp rgb pixel
             assign_pixel_helpers::assign(temp,src);
 
             // now we can just go assign the new rgb value to the
@@ -1772,6 +2084,44 @@ namespace dlib
         catch (serialization_error& e)
         {
             throw serialization_error(e.info + "\n   while deserializing object of type hsi_pixel"); 
+        }
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    inline void serialize (
+        const hsv_pixel& item, 
+        std::ostream& out 
+    )   
+    {
+        try
+        {
+            serialize(item.h,out);
+            serialize(item.s,out);
+            serialize(item.v,out);
+        }
+        catch (serialization_error& e)
+        {
+            throw serialization_error(e.info + "\n   while serializing object of type hsv_pixel"); 
+        }
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    inline void deserialize (
+        hsv_pixel& item, 
+        std::istream& in
+    )   
+    {
+        try
+        {
+            deserialize(item.h,in);
+            deserialize(item.s,in);
+            deserialize(item.v,in);
+        }
+        catch (serialization_error& e)
+        {
+            throw serialization_error(e.info + "\n   while deserializing object of type hsv_pixel"); 
         }
     }
 

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -1241,7 +1241,6 @@ namespace dlib
                 out.g = p;
                 out.b = in.x;
                 break;
-            case 5:
             default:
                 out.r = in.x;
                 out.g = p;

--- a/dlib/pixel.h
+++ b/dlib/pixel.h
@@ -592,6 +592,7 @@ namespace dlib
         constexpr static bool rgb_alpha  = false;
         constexpr static bool grayscale = false;
         constexpr static bool hsi = false;
+        constexpr static bool hsv = false;
         constexpr static bool lab = false;
         enum { num = 3};
         typedef unsigned char basic_pixel_type;
@@ -939,6 +940,15 @@ namespace dlib
         }
 
         template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            dest.h = src.h; 
+            dest.s = src.s; 
+            dest.v = src.v; 
+        }
+
+        template < typename P1, typename P2 >
         typename enable_if_c<pixel_traits<P1>::lab && pixel_traits<P2>::lab>::type
         assign(P1& dest, const P2& src)
         {
@@ -1003,6 +1013,13 @@ namespace dlib
         assign(P1& dest, const P2& src) 
         { 
             assign_pixel(dest, src.i);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::grayscale && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src) 
+        { 
+            assign_pixel(dest, src.v);
         }
 
         template < typename P1, typename P2 >
@@ -1480,7 +1497,7 @@ namespace dlib
             h.h = src.h;
             h.h = h.h/255.0*360;
             h.s = src.s/255.0;
-            h.x = src.i/255.0;
+            h.x = src.v/255.0;
             c = HSV2RGB(h);
 
             dest.red = static_cast<unsigned char>(c.r*255.0 + 0.5);
@@ -1649,6 +1666,18 @@ namespace dlib
         }
 
         template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsi && pixel_traits<P2>::hsv>::type
+        assign(P1& dest, const P2& src)
+        {
+            rgb_pixel temp;
+            // convert hsv value to our temp rgb pixel
+            assign_pixel_helpers::assign(temp,src);
+            // now we can just go assign the new rgb value to the
+            // hsi pixel
+            assign_pixel_helpers::assign(dest,temp);
+        }
+
+        template < typename P1, typename P2 >
         typename enable_if_c<pixel_traits<P1>::hsi && pixel_traits<P2>::lab>::type
         assign(P1& dest, const P2& src)
         {
@@ -1679,7 +1708,7 @@ namespace dlib
         { 
             dest.h = 0;
             dest.s = 0;
-            assign_pixel(dest.i, src);
+            assign_pixel(dest.v, src);
         }
 
         template < typename P1, typename P2 >
@@ -1709,6 +1738,18 @@ namespace dlib
             // now assign the rgb_alpha value to our temp rgb pixel
             assign_pixel_helpers::assign(temp,src);
 
+            // now we can just go assign the new rgb value to the
+            // hsv pixel
+            assign_pixel_helpers::assign(dest,temp);
+        }
+
+        template < typename P1, typename P2 >
+        typename enable_if_c<pixel_traits<P1>::hsv && pixel_traits<P2>::hsi>::type
+        assign(P1& dest, const P2& src)
+        {
+            rgb_pixel temp;
+            // convert hsi value to our temp rgb pixel
+            assign_pixel_helpers::assign(temp,src);
             // now we can just go assign the new rgb value to the
             // hsv pixel
             assign_pixel_helpers::assign(dest,temp);

--- a/dlib/test/pixel.cpp
+++ b/dlib/test/pixel.cpp
@@ -28,6 +28,7 @@ namespace
     static_assert(is_pixel_type<rgb_alpha_pixel>::value, "bad trait definition");
     static_assert(is_pixel_type<bgr_alpha_pixel>::value, "bad trait definition");
     static_assert(is_pixel_type<hsi_pixel>::value, "bad trait definition");
+    static_assert(is_pixel_type<hsv_pixel>::value, "bad trait definition");
     static_assert(is_pixel_type<lab_pixel>::value, "bad trait definition");
 
     static_assert(is_pixel_type<char>::value,           "bad trait definition");
@@ -68,6 +69,7 @@ namespace
         signed char p_schar;
         rgb_pixel p_rgb,p_rgb2;
         hsi_pixel p_hsi, p_hsi2;
+        hsv_pixel p_hsv, p_hsv2;
         rgb_alpha_pixel p_rgba;
         lab_pixel p_lab, p_lab2;
 
@@ -78,6 +80,7 @@ namespace
         assign_pixel(p_gray, -2);
         assign_pixel(p_rgb,0);
         assign_pixel(p_hsi, -4);
+        assign_pixel(p_hsv, -4);
         assign_pixel(p_rgba, p_int);
         assign_pixel(p_gray16,0);
         assign_pixel(p_lab,-400);
@@ -102,6 +105,10 @@ namespace
         DLIB_TEST(p_hsi.s == 0);
         DLIB_TEST(p_hsi.i == 0);
 
+        DLIB_TEST(p_hsv.h == 0);
+        DLIB_TEST(p_hsv.s == 0);
+        DLIB_TEST(p_hsv.v == 0);
+
         DLIB_TEST(p_lab.l == 0);
         DLIB_TEST(p_lab.a == 128);
         DLIB_TEST(p_lab.b == 128);
@@ -110,6 +117,7 @@ namespace
         assign_pixel(p_gray16,10);
         assign_pixel(p_rgb,10);
         assign_pixel(p_hsi,10);
+        assign_pixel(p_hsv,10);
         assign_pixel(p_rgba,10);
         assign_pixel(p_lab,10);
 
@@ -137,6 +145,10 @@ namespace
         DLIB_TEST(p_hsi.s == 0);
         DLIB_TEST(p_hsi.i == 10);
 
+        DLIB_TEST(p_hsv.h == 0);
+        DLIB_TEST(p_hsv.s == 0);
+        DLIB_TEST(p_hsv.v == 10);
+
         DLIB_TEST(p_lab.l == 10);
         DLIB_TEST(p_lab.a == 128);
         DLIB_TEST(p_lab.b == 128);
@@ -156,6 +168,7 @@ namespace
         assign_pixel(p_rgb,p_rgb);
         assign_pixel(p_rgba,p_rgb);
         assign_pixel(p_hsi,p_rgb);
+        assign_pixel(p_hsv,p_rgb);
         assign_pixel(p_lab,p_rgb);
 
         assign_pixel(p_float,p_rgb);
@@ -181,6 +194,10 @@ namespace
         DLIB_TEST(p_hsi.s > 0);
         DLIB_TEST(p_hsi.h > 0);
 
+        DLIB_TEST(p_hsv.v > 0);
+        DLIB_TEST(p_hsv.s > 0);
+        DLIB_TEST(p_hsv.h > 0);
+
         DLIB_TEST(p_lab.l > 0);
         DLIB_TEST(p_lab.a > 0);
         DLIB_TEST(p_lab.b > 0);
@@ -190,6 +207,16 @@ namespace
         DLIB_TEST(p_rgb.green == 0);
         DLIB_TEST(p_rgb.blue == 0);
         assign_pixel(p_rgb, p_hsi);
+
+        DLIB_TEST_MSG(p_rgb.red > 251 ,(int)p_rgb.green);
+        DLIB_TEST_MSG(p_rgb.green > 96 && p_rgb.green < 104,(int)p_rgb.green);
+        DLIB_TEST_MSG(p_rgb.blue > 47 && p_rgb.blue < 53,(int)p_rgb.green);
+
+        assign_pixel(p_rgb,0);
+        DLIB_TEST(p_rgb.red == 0);
+        DLIB_TEST(p_rgb.green == 0);
+        DLIB_TEST(p_rgb.blue == 0);
+        assign_pixel(p_rgb, p_hsv);
 
         DLIB_TEST_MSG(p_rgb.red > 251 ,(int)p_rgb.green);
         DLIB_TEST_MSG(p_rgb.green > 96 && p_rgb.green < 104,(int)p_rgb.green);
@@ -219,6 +246,20 @@ namespace
         DLIB_TEST(p_hsi.s == p_hsi2.s);
         DLIB_TEST(p_hsi.i == p_hsi2.i);
 
+        assign_pixel(p_hsv2, p_hsv);
+        DLIB_TEST(p_hsv.h == p_hsv2.h);
+        DLIB_TEST(p_hsv.s == p_hsv2.s);
+        DLIB_TEST(p_hsv.v == p_hsv2.v);
+        assign_pixel(p_hsv,0);
+        DLIB_TEST(p_hsv.h == 0);
+        DLIB_TEST(p_hsv.s == 0);
+        DLIB_TEST(p_hsv.v == 0);
+        assign_pixel(p_hsv, p_rgba);
+
+        DLIB_TEST(p_hsv.h == p_hsv2.h);
+        DLIB_TEST(p_hsv.s == p_hsv2.s);
+        DLIB_TEST(p_hsv.v == p_hsv2.v);
+
         assign_pixel(p_lab2, p_lab);
         DLIB_TEST(p_lab.l == p_lab2.l);
         DLIB_TEST(p_lab.a == p_lab2.a);
@@ -237,6 +278,7 @@ namespace
         assign_pixel(p_gray, 10);
         assign_pixel(p_rgb, 10);
         assign_pixel(p_hsi, 10);
+        assign_pixel(p_hsv, 10);
 
         assign_pixel(p_schar, 10);
         assign_pixel(p_float, 10);
@@ -261,6 +303,12 @@ namespace
         DLIB_TEST(p_hsi.h == 0);
         DLIB_TEST(p_hsi.s == 0);
         DLIB_TEST_MSG(p_hsi.i < p_hsi2.i+2 && p_hsi.i > p_hsi2.i -2,(int)p_hsi.i << "   " << (int)p_hsi2.i);
+
+        assign_pixel(p_hsv, p_rgba);
+        assign_pixel(p_hsv2, p_rgb);
+        DLIB_TEST(p_hsv.h == 0);
+        DLIB_TEST(p_hsv.s == 0);
+        DLIB_TEST_MSG(p_hsv.v < p_hsv2.v+2 && p_hsv.v > p_hsv2.v -2,(int)p_hsv.v << "   " << (int)p_hsv2.v);
 
         // this value corresponds to RGB(10,10,10)
         p_lab.l = 7;
@@ -485,6 +533,11 @@ namespace
         p_hsi.s = 10;
         p_hsi.i = 11;
 
+        p_hsv.h = 9;
+        p_hsv.s = 10;
+        p_hsv.v = 11;
+
+
         p_lab.l = 10;
         p_lab.a = 9;
         p_lab.b = 8;
@@ -497,6 +550,7 @@ namespace
         serialize(p_int,sout);
         serialize(p_float,sout);
         serialize(p_hsi,sout);
+        serialize(p_hsv,sout);
         serialize(p_lab,sout);
 
         assign_pixel(p_rgb,0);
@@ -506,6 +560,7 @@ namespace
         assign_pixel(p_int,0);
         assign_pixel(p_float,0);
         assign_pixel(p_hsi,0);
+        assign_pixel(p_hsv,0);
         assign_pixel(p_lab,0);
 
         istringstream sin(sout.str());
@@ -517,6 +572,7 @@ namespace
         deserialize(p_int,sin);
         deserialize(p_float,sin);
         deserialize(p_hsi,sin);
+        deserialize(p_hsv,sin);
         deserialize(p_lab,sin);
 
         DLIB_TEST(p_rgb.red == 1);
@@ -537,13 +593,17 @@ namespace
         DLIB_TEST(p_hsi.s == 10);
         DLIB_TEST(p_hsi.i == 11);
 
+        DLIB_TEST(p_hsv.h == 9);
+        DLIB_TEST(p_hsv.s == 10);
+        DLIB_TEST(p_hsv.v == 11);
+
         DLIB_TEST(p_lab.l == 10);
         DLIB_TEST(p_lab.a == 9);
         DLIB_TEST(p_lab.b == 8);
 
         {
             matrix<double,1,1> m_gray, m_schar, m_int, m_float;
-            matrix<double,3,1> m_rgb, m_hsi, m_lab;
+            matrix<double,3,1> m_rgb, m_hsi, m_hsv, m_lab;
 
             m_gray = pixel_to_vector<double>(p_gray);
             m_schar = pixel_to_vector<double>(p_schar);
@@ -551,6 +611,7 @@ namespace
             m_float = pixel_to_vector<double>(p_float);
 
             m_hsi = pixel_to_vector<double>(p_hsi);
+            m_hsv = pixel_to_vector<double>(p_hsv);
             m_rgb = pixel_to_vector<double>(p_rgb);
             m_lab = pixel_to_vector<double>(p_lab);
 
@@ -565,6 +626,9 @@ namespace
             DLIB_TEST(m_hsi(0) == p_hsi.h);
             DLIB_TEST(m_hsi(1) == p_hsi.s);
             DLIB_TEST(m_hsi(2) == p_hsi.i);
+            DLIB_TEST(m_hsv(0) == p_hsv.h);
+            DLIB_TEST(m_hsv(1) == p_hsv.s);
+            DLIB_TEST(m_hsv(2) == p_hsv.v);
             DLIB_TEST(m_lab(0) == p_lab.l);
             DLIB_TEST(m_lab(1) == p_lab.a);
             DLIB_TEST(m_lab(2) == p_lab.b);
@@ -587,18 +651,24 @@ namespace
             DLIB_TEST(p_hsi.s == 10);
             DLIB_TEST(p_hsi.i == 11);
 
+            DLIB_TEST(p_hsv.h == 9);
+            DLIB_TEST(p_hsv.s == 10);
+            DLIB_TEST(p_hsv.v == 11);
+
             DLIB_TEST(p_lab.l == 10);
             DLIB_TEST(p_lab.a == 9);
             DLIB_TEST(p_lab.b == 8);
 
             assign_pixel(p_gray,0);
             assign_pixel(p_hsi,0);
+            assign_pixel(p_hsv,0);
             assign_pixel(p_rgb,0);
             assign_pixel(p_lab,0);
 
             vector_to_pixel(p_float, m_float);
             vector_to_pixel(p_gray, m_gray);
             vector_to_pixel(p_hsi, m_hsi);
+            vector_to_pixel(p_hsv, m_hsv);
             vector_to_pixel(p_rgb, m_rgb);
             vector_to_pixel(p_lab, m_lab);
 
@@ -618,6 +688,10 @@ namespace
             DLIB_TEST(p_hsi.s == 10);
             DLIB_TEST(p_hsi.i == 11);
 
+            DLIB_TEST(p_hsv.h == 9);
+            DLIB_TEST(p_hsv.s == 10);
+            DLIB_TEST(p_hsv.v == 11);
+
             DLIB_TEST(p_lab.l == 10);
             DLIB_TEST(p_lab.a == 9);
             DLIB_TEST(p_lab.b == 8);
@@ -634,6 +708,7 @@ namespace
             signed char p_schar;
             rgb_pixel p_rgb;
             hsi_pixel p_hsi, p_hsi2;
+            hsv_pixel p_hsv, p_hsv2;
             rgb_alpha_pixel p_rgba;
             lab_pixel p_lab;
 
@@ -645,6 +720,7 @@ namespace
             assign_pixel(p_schar, 0);
             assign_pixel(p_rgb, 0);
             assign_pixel(p_hsi, 0);
+            assign_pixel(p_hsv, 0);
             assign_pixel(p_lab, 0);
 
 
@@ -718,6 +794,10 @@ namespace
             p_hsi.s = 100;
             p_hsi.i = 84;
             DLIB_TEST(get_pixel_intensity(p_hsi) == 84);
+            p_hsv.h = 123;
+            p_hsv.s = 100;
+            p_hsv.v = 84;
+            DLIB_TEST(get_pixel_intensity(p_hsv) == 84);
 
             p_lab.l = 123;
             p_lab.a = 100;


### PR DESCRIPTION
I needed to use HSV instead of HSI in dlib, so I added support for it.
Code adapted from [here](https://stackoverflow.com/questions/3018313/algorithm-to-convert-rgb-to-hsv-and-hsv-to-rgb-in-range-0-255-for-both).

I've compared it to the one provided by OpenCV and the results are identical.