### PR TITLE
Ubuntu 18.04 Actions runner image is deprecated, use newer image

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -105,8 +105,8 @@ jobs:
     - name: Test BLAS bindings
       run: build_blas_bindings/dtest --runall -q
 
-  ubuntu-18_04-gcc-7:
-    runs-on: 'ubuntu-18.04'
+  ubuntu-20_04-gcc-7:
+    runs-on: 'ubuntu-20.04'
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/