### PR TITLE
Add draw solid polygon

### DIFF
--- a/dlib/geometry/polygon.h
+++ b/dlib/geometry/polygon.h
@@ -22,6 +22,11 @@ namespace dlib
         const point& operator[](const size_type idx) const { return points[idx]; }
         const point& at(const size_type idx) const { return points.at(idx); }
 
+        std::vector<point>::iterator begin() { return points.begin(); }
+        std::vector<point>::iterator end() { return points.end(); }
+        const std::vector<point>::const_iterator begin() const { return points.begin(); }
+        const std::vector<point>::const_iterator end() const { return points.end(); }
+
         rectangle get_rect() const
         {
             rectangle rect;

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -585,7 +585,6 @@ namespace dlib
 
         valid_area = shrink_rect(valid_area.intersect(bounding_box), 1);
 
-        std::vector<double> prev_intersections;
         for (long y = valid_area.top(); y <= valid_area.bottom(); ++y)
         {
             // Compute the intersections with the scanline

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -291,7 +291,7 @@ namespace dlib
         typename pixel_type
     >
     void draw_string (
-        image_type& c,
+        image_type& image,
         const dlib::point& p,
         const std::basic_string<T,traits,alloc>& str,
         const pixel_type& color,
@@ -313,6 +313,7 @@ namespace dlib
 
         const rectangle rect(p, p);
         const font& f = *f_ptr;
+        image_view<image_type> img(image);
 
         long y_offset = rect.top() + f.ascender() - 1;
 
@@ -340,7 +341,7 @@ namespace dlib
             }
 
             // only look at letters in the intersection area
-            if (c.nr() + static_cast<long>(f.height()) < y_offset)
+            if (img.nr() + static_cast<long>(f.height()) < y_offset)
             {
                 // the string is now below our rectangle so we are done
                 return;
@@ -351,7 +352,7 @@ namespace dlib
                 pos += f[ch].width();
                 return;
             }
-            else if (c.nc() + static_cast<long>(f.right_overflow()) < pos)
+            else if (img.nc() + static_cast<long>(f.right_overflow()) < pos)
             {
                 // keep looking because there might be a '\n' in the string that
                 // will wrap us around and put us back into our rectangle.
@@ -368,9 +369,9 @@ namespace dlib
                 const long y = l[i].y + y_offset;
                 // draw each pixel of the letter if it is inside the intersection
                 // rectangle
-                if (x >= 0 && x < c.nc() && y >= 0 && y < c.nr())
+                if (x >= 0 && x < img.nc() && y >= 0 && y < img.nr())
                 {
-                    assign_pixel(c(y, x), color);
+                    assign_pixel(img[y][x], color);
                 }
             }
 
@@ -384,7 +385,7 @@ namespace dlib
         typename pixel_type
     >
     void draw_string (
-        image_type& c,
+        image_type& image,
         const dlib::point& p,
         const char* str,
         const pixel_type& color,
@@ -393,7 +394,7 @@ namespace dlib
         typename std::string::size_type last = std::string::npos
     )
     {
-        draw_string(c, p, std::string(str), color, f_ptr, first, last);
+        draw_string(image, p, std::string(str), color, f_ptr, first, last);
     }
 
 // ----------------------------------------------------------------------------------------
@@ -435,7 +436,6 @@ namespace dlib
         using std::max;
         using std::min;
         const rectangle valid_area(get_rect(image).intersect(area));
-
         const rectangle bounding_box = poly.get_rect();
 
         // Don't do anything if the polygon is totally outside the area we can draw in
@@ -443,6 +443,7 @@ namespace dlib
         if (bounding_box.intersect(valid_area).is_empty())
             return;
 
+        image_view<image_type> img(image);
         rgb_alpha_pixel alpha_pixel;
         assign_pixel(alpha_pixel, color);
         const unsigned char max_alpha = alpha_pixel.alpha;
@@ -481,7 +482,7 @@ namespace dlib
                 for (long x = left_x; x <= right_x; ++x)
                 {
                     const long y = i+top;
-                    assign_pixel(image(y, x), color);
+                    assign_pixel(img[y][x], color);
                 }
             }
 
@@ -500,7 +501,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = max_alpha-static_cast<unsigned char>((left_boundary[i]-p.x())*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()], temp);
                 }
             }
             else if (delta < 0)  // on the bottom side
@@ -511,7 +512,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = static_cast<unsigned char>((x-left_boundary[i-1])/std::abs(delta)*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()], temp);
                 }
             }
             else // on the top side
@@ -523,7 +524,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = static_cast<unsigned char>((x-left_boundary[i])/delta*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()],temp);
                 }
             }
 
@@ -538,7 +539,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = max_alpha-static_cast<unsigned char>((p.x()-right_boundary[i])*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()],temp);
                 }
             }
             else if (delta < 0) // on the top side
@@ -549,7 +550,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = static_cast<unsigned char>((right_boundary[i]-x)/std::abs(delta)*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()],temp);
                 }
             }
             else // on the bottom side
@@ -561,7 +562,7 @@ namespace dlib
                     rgb_alpha_pixel temp = alpha_pixel;
                     temp.alpha = static_cast<unsigned char>((right_boundary[i-1]-x)/delta*max_alpha);
                     if (valid_area.contains(p))
-                        assign_pixel(image(p.y(), p.x()),temp);
+                        assign_pixel(img[p.y()][p.x()],temp);
                 }
             }
         }
@@ -577,7 +578,7 @@ namespace dlib
 
     template <typename image_type, typename pixel_type>
     void draw_solid_polygon (
-        image_type& img,
+        image_type& image,
         const polygon& poly,
         const pixel_type& color,
         const bool antialias = true,
@@ -585,6 +586,7 @@ namespace dlib
                                           std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
     )
     {
+        image_view<image_type> img(image);
         long height = img.nr();
         long width = img.nc();
 

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -585,10 +585,11 @@ namespace dlib
 
         valid_area = shrink_rect(valid_area.intersect(bounding_box), 1);
 
+        std::vector<double> intersections;
         for (long y = valid_area.top(); y <= valid_area.bottom(); ++y)
         {
-            // Compute the intersections with the scanline
-            std::vector<double> intersections;
+            // Compute the intersections with the scanline.
+            intersections.clear();
             for (size_t i = 0; i < poly.size(); ++i)
             {
                 const auto& p1 = poly[i];

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -584,7 +584,6 @@ namespace dlib
         image_type& image,
         const polygon& poly,
         const pixel_type& color,
-        const bool antialias = true,
         const rectangle& area = rectangle(std::numeric_limits<long>::min(), std::numeric_limits<long>::min(),
                                           std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
     )

--- a/dlib/image_transforms/draw.h
+++ b/dlib/image_transforms/draw.h
@@ -618,8 +618,7 @@ namespace dlib
                 // Draw the main body of the polygon
                 for (long x = left_x; x <= right_x; ++x)
                 {
-                    if (valid_area.contains(x, y))
-                        assign_pixel(img[y][x], color);
+                    assign_pixel(img[y][x], color);
                 }
             }
         }

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -193,10 +193,10 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename image_type, typename pixel_type>
-    void fill_convex_polygon (
+    void draw_solid_convex_polygon (
         image_type& image,
         const polygon& poly,
-        const pixel_type& pixel,
+        const pixel_type& color,
         const bool antialias = true,
         const rectangle& area = rectangle(std::numeric_limits<long>::min(), std::numeric_limits<long>::min(),
                                           std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
@@ -217,6 +217,26 @@ namespace dlib
             - Uses the given pixel color to draw the polygon.
             - if (antialias == true) then we draw anti-aliased edges so they don't
               look all pixely by alpha-blending them with the image.
+    !*/
+
+    template <typename image_type>
+    inline void draw_solid_convex_polygon (
+        image_type& image,
+        const polygon& poly
+    );
+    /*!
+        requires
+            - image_type == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+        ensures
+            - Interprets the given polygon object as defining a convex polygon shape.
+              In particular, the polygon is given by taking the points and drawing
+              lines between them.  That is, imagine drawing a line connecting polygon[i]
+              and polygon[(i+1)%polygon.size()], for all valid i, and then filling in
+              the interior of the polygon.  That is what this function does.
+            - It fills the inside of the convex_polygon with black.
+            - We draw anti-aliased edges so they don't look all pixely by alpha-blending
+              them with the image.
     !*/
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -197,6 +197,7 @@ namespace dlib
         image_type& image,
         const polygon& poly,
         const pixel_type& color,
+        const bool antialias = true,
         const rectangle& area = rectangle(std::numeric_limits<long>::min(), std::numeric_limits<long>::min(),
                                           std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
     );
@@ -207,6 +208,34 @@ namespace dlib
             - pixel_traits<pixel_type> is defined
         ensures
             - Interprets the given polygon object as defining a convex polygon shape.
+              In particular, the polygon is given by taking the points and drawing
+              lines between them.  That is, imagine drawing a line connecting polygon[i]
+              and polygon[(i+1)%polygon.size()], for all valid i, and then filling in
+              the interior of the polygon.  That is what this function does.
+            - When drawing the polygon, only the part of the polygon which overlaps both
+              the given image and area rectangle is drawn.
+            - Uses the given pixel color to draw the polygon.
+            - if (antialias == true) then we draw anti-aliased edges so they don't
+              look all pixely by alpha-blending them with the image.
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename image_type, typename pixel_type>
+    void draw_solid_polygon (
+        image_type& image,
+        const polygon& poly,
+        const pixel_type& color,
+        const rectangle& area = rectangle(std::numeric_limits<long>::min(), std::numeric_limits<long>::min(),
+                                          std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
+    );
+    /*!
+        requires
+            - image_type == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - pixel_traits<pixel_type> is defined
+        ensures
+            - Interprets the given polygon object as defining a polygon shape.
               In particular, the polygon is given by taking the points and drawing
               lines between them.  That is, imagine drawing a line connecting polygon[i]
               and polygon[(i+1)%polygon.size()], for all valid i, and then filling in

--- a/dlib/image_transforms/draw_abstract.h
+++ b/dlib/image_transforms/draw_abstract.h
@@ -197,7 +197,6 @@ namespace dlib
         image_type& image,
         const polygon& poly,
         const pixel_type& color,
-        const bool antialias = true,
         const rectangle& area = rectangle(std::numeric_limits<long>::min(), std::numeric_limits<long>::min(),
                                           std::numeric_limits<long>::max(), std::numeric_limits<long>::max())
     );
@@ -215,28 +214,6 @@ namespace dlib
             - When drawing the polygon, only the part of the polygon which overlaps both
               the given image and area rectangle is drawn.
             - Uses the given pixel color to draw the polygon.
-            - if (antialias == true) then we draw anti-aliased edges so they don't
-              look all pixely by alpha-blending them with the image.
-    !*/
-
-    template <typename image_type>
-    inline void draw_solid_convex_polygon (
-        image_type& image,
-        const polygon& poly
-    );
-    /*!
-        requires
-            - image_type == an image object that implements the interface defined in
-              dlib/image_processing/generic_image.h
-        ensures
-            - Interprets the given polygon object as defining a convex polygon shape.
-              In particular, the polygon is given by taking the points and drawing
-              lines between them.  That is, imagine drawing a line connecting polygon[i]
-              and polygon[(i+1)%polygon.size()], for all valid i, and then filling in
-              the interior of the polygon.  That is what this function does.
-            - It fills the inside of the convex_polygon with black.
-            - We draw anti-aliased edges so they don't look all pixely by alpha-blending
-              them with the image.
     !*/
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This is my first attempt at filling an arbitrary polygon, not just a convex one, using the scanline algorithm. With my current implementation, it doesn't seem obvious to add antialiasing for the edges, though.
However, I use this for drawing a polygon in a mask image, and then blur the mask to alpha blend whatever I want using the polygon, so I get the nice antialiasing just by blurring the mask.

Simultaneously, I fixed some other stuff:
- since I copied the `draw_solid_convex_polygon` from the widgets, where the antialiasing was not optional, when it was disabled, we were painting an extra pixel on the borders.
- there were parts that assumed a `dlib::matrix` (my fault), so I fixed that too.
- I renamed `fill_convex_polygon` to `draw_solid_convex_polygon` (to match all the other `draw_solid_` functions).

Some examples, trying to draw a star:
`antialias = true`
![image](https://user-images.githubusercontent.com/1671644/232228999-51dffd7f-7252-49ce-b743-3d38f82fb7a4.png)

`antialias = false` (before and after this PR)
![image](https://user-images.githubusercontent.com/1671644/232229035-e2417afe-783f-4b06-96d8-8eeb0371a714.png) ![image](https://user-images.githubusercontent.com/1671644/232229153-538a07ef-1e21-448c-bc2f-21a72e3286aa.png)

The new `draw_solid_polygon` (note that I was drawing this shape in the previous examples, too)
![image](https://user-images.githubusercontent.com/1671644/232229337-c8af872e-9e12-45e4-80d4-a7ac3696e5c0.png)
