### PR TITLE
circular_buffer : 10X speedup

### DIFF
--- a/dlib/sliding_buffer/circular_buffer.h
+++ b/dlib/sliding_buffer/circular_buffer.h
@@ -49,7 +49,10 @@ namespace dlib
                 << "\n\t i:      " << i 
                 << "\n\t size(): " << size()
             );
-            return data[(i+offset)%data.size()]; 
+            auto index = i + offset;
+            if (index >= data.size())
+                index -= data.size();
+            return data[index]; 
         }
 
         const T& operator[] ( unsigned long i) const 
@@ -61,7 +64,10 @@ namespace dlib
                 << "\n\t i:      " << i 
                 << "\n\t size(): " << size()
             );
-            return data[(i+offset)%data.size()]; 
+            auto index = i + offset;
+            if (index >= data.size())
+                index -= data.size();
+            return data[index];
         }
 
         void resize(unsigned long size) 


### PR DESCRIPTION
I don't know why, maybe because of branch prediction, or maybe because the `%` operator is very slow, but this is almost a 10X speedup improvement.