### PR TITLE
Add insert_image_chip

### DIFF
--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -2015,17 +2015,16 @@ namespace dlib
         const interpolation_type& interp
     )
     {
-        image_view<image_type1> img(image);
-        const_image_view<image_type2> chp(chip);
-        DLIB_CASSERT(chp.nr() == location.rows && chp.nc() == location.cols,
+        image_view<image_type1> vimg(image);
+        const_image_view<image_type2> vchip(chip);
+        DLIB_CASSERT(vchip.nr() == location.rows && vchip.nc() == location.cols,
                      "The chip and the location do not have the same size.")
-        // Figure out which rectangle contains the rotated rectangle
         const auto tf = get_mapping_to_chip(location);
-        for (long r = 0; r < img.nr(); ++r)
+        for (long r = 0; r < vimg.nr(); ++r)
         {
-            for (long c = 0; c < img.nc(); ++c)
+            for (long c = 0; c < vimg.nc(); ++c)
             {
-                interp(chip, tf(dlib::vector<double, 2>(c, r)), img[r][c]);
+                interp(vchip, tf(dlib::vector<double, 2>(c, r)), vimg[r][c]);
             }
         }
     }

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -2017,7 +2017,8 @@ namespace dlib
     {
         image_view<image_type1> vimg(image);
         const_image_view<image_type2> vchip(chip);
-        DLIB_CASSERT(vchip.nr() == location.rows && vchip.nc() == location.cols,
+        DLIB_CASSERT(static_cast<unsigned long>(vchip.nr()) == location.rows &&
+                     static_cast<unsigned long>(vchip.nc()) == location.cols,
                      "The chip and the location do not have the same size.")
         const auto tf = get_mapping_to_chip(location);
         for (long r = 0; r < vimg.nr(); ++r)

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -2003,6 +2003,50 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <
+        typename image_type1,
+        typename image_type2,
+        typename interpolation_type
+    >
+    void insert_image_chip (
+        image_type1& image,
+        const image_type2& chip,
+        const chip_details& location,
+        const interpolation_type& interp
+    )
+    {
+        image_view<image_type1> img(image);
+        const_image_view<image_type2> chp(chip);
+        DLIB_CASSERT(chp.nr() == location.rows && chp.nc() == location.cols,
+                     "The chip and the location do not have the same size.")
+        // Figure out which rectangle contains the rotated rectangle
+        const auto tf = get_mapping_to_chip(location);
+        for (long r = 0; r < img.nr(); ++r)
+        {
+            for (long c = 0; c < img.nc(); ++c)
+            {
+                interp(chip, tf(dlib::vector<double, 2>(c, r)), img[r][c]);
+            }
+        }
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    template <
+        typename image_type1,
+        typename image_type2
+    >
+    void insert_image_chip (
+        image_type1& image,
+        const image_type2& chip,
+        const chip_details& location
+    )
+    {
+        insert_image_chip(image, chip, location, interpolate_bilinear());
+    }
+
+// ----------------------------------------------------------------------------------------
+
     inline chip_details get_face_chip_details (
         const full_object_detection& det,
         const unsigned long size = 200,

--- a/dlib/image_transforms/interpolation_abstract.h
+++ b/dlib/image_transforms/interpolation_abstract.h
@@ -1345,6 +1345,50 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <
+        typename image_type1,
+        typename image_type2,
+        typename interpolation_type
+    >
+    void insert_image_chip (
+        image_type1& image,
+        const image_type2& chip,
+        const chip_details& location,
+        const interpolation_type& interp
+    );
+    /*!
+        requires
+            - image_type1 == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - image_type2 == an image object that implements the interface defined in
+              dlib/image_processing/generic_image.h
+            - pixel_traits<typename image_traits<image_type1>::pixel_type>::has_alpha == false
+            - num_rows(chip) == location.rows && num_columns(chip) == location.cols
+            - interpolation_type == interpolate_nearest_neighbor, interpolate_bilinear, 
+              interpolate_quadratic, or a type with a compatible interface.
+        ensures
+            - This function inserts chip into the image according to the location and the
+              interpolation method supplied as a parameter.
+    !*/
+
+    template <
+        typename image_type1,
+        typename image_type2
+    >
+    void insert_image_chip (
+        image_type1& image,
+        const image_type2& chip,
+        const chip_details& location
+    );
+    /*!
+        ensures
+            - This function is a simple convenience / compatibility wrapper that calls the
+              above-defined insert_image_chip() function using bilinear interpolation.
+    !*/
+
+
+// ----------------------------------------------------------------------------------------
+
+    template <
         typename image_type
         >
     struct sub_image_proxy

--- a/tools/python/src/image2.cpp
+++ b/tools/python/src/image2.cpp
@@ -476,22 +476,7 @@ void py_insert_image_chip (
     const chip_details& chip_location
 )
 {
-    image_view<numpy_image<T>> vimg(img);
-    const_image_view<numpy_image<T>> vchip(chip);
-    DLIB_CASSERT(vchip.nr() == chip_location.rows && vchip.nc() == chip_location.cols,
-                 "The chip and the chip_location do not have the same size.")
-    // Figure out which rectangle contains the rotated rectangle
-    const rectangle rect = grow_rect(chip_location.rect, chip_location.cols * 0.5 * std::cos(chip_location.angle));
-    const auto tf = get_mapping_to_chip(chip_location);
-    interpolate_bilinear interp;
-    for (long r = 0; r < vimg.nr(); ++r)
-    {
-        for (long c = 0; c < vimg.nc(); ++c)
-        {
-            if (rect.contains(c, r))
-                interp(vchip, tf(dlib::vector<double, 2>(c, r)), vimg[r][c]);
-        }
-    }
+    insert_image_chip(img, chip, chip_location);
 }
 
 // ----------------------------------------------------------------------------------------

--- a/tools/python/src/image2.cpp
+++ b/tools/python/src/image2.cpp
@@ -469,6 +469,30 @@ ensures \n\
 
 // ----------------------------------------------------------------------------------------
 
+template <typename T>
+void py_insert_image_chip (
+    numpy_image<T>& img,
+    const numpy_image<T>& chip,
+    const chip_details& chip_location
+)
+{
+    image_view<numpy_image<T>> vimg(img);
+    const_image_view<numpy_image<T>> vchip(chip);
+    DLIB_CASSERT(vchip.nr() == chip_location.rows && vchip.nc() == chip_location.cols,
+                 "The chip and the chip_location do not have the same size.")
+    const auto tf = inv(get_mapping_to_chip(chip_location));
+    for (long r = 0; r < vchip.nr(); ++r)
+    {
+        for (long c = 0; c < vchip.nc(); ++c)
+        {
+            const auto p = tf(dlib::vector<double, 2>(c, r));
+            assign_pixel(vimg[std::lround(p.y())][std::lround(p.x())], vchip[r][c]);
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------
+
 py::array py_tile_images (
     const py::list& images
 )
@@ -578,6 +602,36 @@ void bind_image_classes2(py::module& m)
         );
 
     register_extract_image_chip(m);
+    m.def("insert_image_chip", &py_insert_image_chip<uint8_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<uint16_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<uint32_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<uint64_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<int8_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<int16_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<int32_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<int64_t>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<float>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<double>, py::arg("img"), py::arg("chip"), py::arg("chip_location"));
+    m.def("insert_image_chip", &py_insert_image_chip<rgb_pixel>, py::arg("img"), py::arg("chip"), py::arg("chip_location"),
+        "Inserts chip into img applying the appropriate mapping using chip_location"
+"requires \n\
+    - img and chip numpy arrays that can be interpreted as images.  They \n\
+      must be the same type of image as well. \n\
+    - the number of rows and columns in chip match the ones in chip_location \n\
+ensures \n\
+    - This function takes the given chip and inserts it into img using an appropriate \n\
+      mapping, computed from chip_location."
+        /*!
+            requires
+                - img and chip numpy arrays that can be interpreted as images.  They
+                  must be the same type of image as well.
+                - the number of rows and columns in chip match the ones in chip_location.
+            ensures
+                - This function takes the given chip and inserts it into img using an appropriate
+                  mapping, computed from chip_location.
+        !*/
+        );
+
 
     m.def("sub_image", &py_sub_image, py::arg("img"), py::arg("rect"),
 "Returns a new numpy array that references the sub window in img defined by rect. \n\

--- a/tools/python/src/image2.cpp
+++ b/tools/python/src/image2.cpp
@@ -476,7 +476,6 @@ void py_insert_image_chip (
     const chip_details& chip_location
 )
 {
-    // numpy_image<T> out = img;
     image_view<numpy_image<T>> vimg(img);
     const_image_view<numpy_image<T>> vchip(chip);
     DLIB_CASSERT(vchip.nr() == chip_location.rows && vchip.nc() == chip_location.cols,


### PR DESCRIPTION
I think this function would be very convenient in the Python bindings to be able to revert the `extract_image_chip` without exposing the `transform` types in Python.

Exposing the `transform` tooling could be done at a latter time if there's a need for that, but I guess this function should cover most of the basic cases, such as #2595.