### PR TITLE
[Meta] fixed callable_traits

### DIFF
--- a/dlib/constexpr_if.h
+++ b/dlib/constexpr_if.h
@@ -13,12 +13,6 @@ namespace dlib
     namespace detail
     {
         const auto _ = [](auto&& arg) -> decltype(auto) { return std::forward<decltype(arg)>(arg); };
-
-        template<typename Void, template <class...> class Op, class... Args>
-        struct is_detected : std::false_type{};
-
-        template<template <class...> class Op, class... Args>
-        struct is_detected<dlib::void_t<Op<Args...>>, Op, Args...> : std::true_type {};
     }
 
 // ----------------------------------------------------------------------------------------
@@ -111,16 +105,9 @@ namespace dlib
     {
         return overloaded(std::forward<Cases>(cases)...)(types_<T>{}..., detail::_);
     }
-// ----------------------------------------------------------------------------------------
-
-    template<template <class...> class Op, class... Args>
-    using is_detected = detail::is_detected<void, Op, Args...>;
-    /*!
-        ensures
-            - This is exactly the same as std::experimental::is_detected from library fundamentals v
-    !*/
 
 // ----------------------------------------------------------------------------------------
+
 }
 
 #endif //DLIB_IF_CONSTEXPR_H

--- a/dlib/test/invoke.cpp
+++ b/dlib/test/invoke.cpp
@@ -95,6 +95,8 @@ namespace
         static_assert(std::is_same<dlib::callable_return<decltype(func_testargs)>,
                                    void>::value, "make this correct");
 
+        static_assert(is_callable<decltype(func_testargs)>::value, "bad");
+
         static_assert(std::is_same<dlib::callable_args<decltype(func_return_addition)>,
                                    dlib::types_<int, int>
                                    >::value, "make this correct");
@@ -111,6 +113,8 @@ namespace
 
         static_assert(std::is_same<dlib::callable_return<decltype(func_return_addition)>,
                                    int>::value, "make this correct");
+        
+        static_assert(is_callable<decltype(func_return_addition)>::value, "bad");
 
         {
             std::string str = run1_str4;
@@ -160,6 +164,8 @@ namespace
             
             static_assert(std::is_same<dlib::callable_return<decltype(f)>,
                                        long>::value, "make this correct");
+            
+            static_assert(is_callable<decltype(f)>::value, "bad");
         }
                 
         {
@@ -227,6 +233,8 @@ namespace
     
     static_assert(std::is_same<dlib::callable_return<example_struct>,
                                 float>::value, "make this correct");
+
+    static_assert(is_callable<example_struct>::value, "bad");
 
     void test_member_functions_and_data()
     {
@@ -482,6 +490,7 @@ namespace
     {
         template <
           class Callable,
+          std::enable_if_t<is_callable<Callable>::value, bool> = true,
           std::enable_if_t<callable_nargs<Callable>::value >= 1, bool> = true,
           std::enable_if_t<std::is_floating_point<callable_arg<0, Callable>>::value, bool> = true
         >
@@ -499,6 +508,7 @@ namespace
 
         template <
           class Callable,
+          std::enable_if_t<is_callable<Callable>::value, bool> = true,
           std::enable_if_t<callable_nargs<Callable>::value >= 1, bool> = true,
           std::enable_if_t<std::is_integral<callable_arg<0, Callable>>::value, bool> = true
         >
@@ -516,6 +526,7 @@ namespace
 
         template <
           class Callable,
+          std::enable_if_t<is_callable<Callable>::value, bool> = true,
           std::enable_if_t<callable_nargs<Callable>::value < 1, bool> = true
         >
         auto wrap (
@@ -543,6 +554,8 @@ namespace
             const auto f6 = wrap(f3, i);
             DLIB_TEST(i == 3);
         }
+
+        static_assert(!is_callable<int>::value, "bad");
     }
 
     class invoke_tester : public tester


### PR DESCRIPTION
`callable_traits` works on non-callable types, in which case it simply provides `callable_traits::is_callable == false`