### PR TITLE
[FFmpeg] added push(image_type) methods to encoder and muxer

### DIFF
--- a/dlib/media/ffmpeg_muxer.h
+++ b/dlib/media/ffmpeg_muxer.h
@@ -599,7 +599,7 @@ namespace dlib
             bool push(const image_type& img);
             /*!
                 requires
-                    - if is_image_encoder() == true, then f.is_image() == true
+                    - is_image_encoder() == true
                 ensures
                     - Encodes img using the constructor arguments, which may incur a resizing
                       operation if the image dimensions and pixel type don't match the codec. 

--- a/dlib/media/ffmpeg_muxer.h
+++ b/dlib/media/ffmpeg_muxer.h
@@ -262,7 +262,7 @@ namespace dlib
             );
             /*!
                 requires
-                    - if is_image_encoder() == true
+                    - is_image_encoder() == true
                     - sink is set to a valid callback with signature bool(size_t, const char*)
                       for writing packet data. dlib/media/sink.h contains callback wrappers for
                       different buffer types.


### PR DESCRIPTION
Adds `encoder::push(const image_type&, Callback&&)` and `muxer::push(const image_type& )` where `image_type` is a dlib image type like `array2d<rgb_pixel>` or `matrix<bgr_pixel>`.