### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/docs/python/classes.txt
 docs/docs/python/functions.txt
 docs/docs/python/constants.txt
 **/.vscode
+**/venv

--- a/README.md
+++ b/README.md
@@ -37,12 +37,22 @@ vcpkg install dlib
 
 ## Compiling dlib Python API
 
-Before you can run the Python example programs you must compile dlib. Type:
-
+Before you can run the Python example programs you must install the build requirement.
 ```bash
-python setup.py install
+python -m venv venv
+pip install build
 ```
 
+Then you must compile dlib and install it in your environment. Type:
+```bash
+python -m build --wheel
+pip install dist/dlib-<version>.whl
+```
+
+Or download dlib using PyPi:
+```bash
+pip install dlib
+```
 
 ## Running the unit test suite
 

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -310,7 +310,9 @@ namespace dlib
                     pixel_to_vector<double>(img[r+1][c  ])(i),
                     pixel_to_vector<double>(img[r+1][c+1])(i));
             typename image_view_type::pixel_type temp;
-            vector_to_pixel(temp, pvout);
+            const auto min_val = pixel_traits<pixel_type_t<image_view_type>>::min();
+            const auto max_val = pixel_traits<pixel_type_t<image_view_type>>::max();
+            vector_to_pixel(temp, clamp(pvout, min_val, max_val));
             assign_pixel(result, temp);
             return true;
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "cmake"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "dlib"
-requires-python = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel", "cmake"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dlib"
+requires-python = ">=3.6"

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,10 @@ This file basically just uses CMake to compile the dlib python bindings project
 located in the tools/python folder and then puts the outputs into standard
 python packages.
 
-To build the dlib:
+To build dlib:
     python setup.py build
 To build and install:
     python setup.py install
-To package the wheel (after pip installing twine and wheel):
-    python setup.py bdist_wheel
-To upload the binary wheel to PyPi
-    twine upload dist/*.whl
 To upload the source distribution to PyPi
     python setup.py sdist 
     twine upload dist/dlib-*.tar.gz
@@ -234,7 +230,6 @@ setup(
     # We need an older more-itertools version because v6 broke pytest (for everyone, not just dlib)
     tests_require=['pytest==3.8', 'more-itertools<6.0.0'],
     #install_requires=['cmake'], # removed because the pip cmake package is busted, maybe someday it will be usable.
-    # packages=['dlib'], # removed because pyproject.toml requires exclusion rather than inclusion as it looks at the default directory structure.
     packages=find_packages(exclude=['python_examples']),
     package_dir={'': 'tools/python'},
     keywords=['dlib', 'Computer Vision', 'Machine Learning'],
@@ -249,13 +244,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: C++',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Image Recognition',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ import multiprocessing
 from distutils import log
 from math import ceil,floor
 
-from setuptools import setup, Extension
+from setuptools import find_packages, setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 
@@ -234,7 +234,8 @@ setup(
     # We need an older more-itertools version because v6 broke pytest (for everyone, not just dlib)
     tests_require=['pytest==3.8', 'more-itertools<6.0.0'],
     #install_requires=['cmake'], # removed because the pip cmake package is busted, maybe someday it will be usable.
-    packages=['dlib'],
+    # packages=['dlib'], # removed because pyproject.toml requires exclusion rather than inclusion as it looks at the default directory structure.
+    packages=find_packages(exclude=['python_examples']),
     package_dir={'': 'tools/python'},
     keywords=['dlib', 'Computer Vision', 'Machine Learning'],
     classifiers=[


### PR DESCRIPTION
Fixes #2803  by creating a minimal pyproject.toml that still uses the existing setup.py details to remove the deprecation warning. Updates the way Python package is compiled and adds the requirement `build`. I am not an expert but it seems to work!

Old method gave the following warnings:
```
/home/rover/Documents/tmp/dlib/venv-old/lib/python3.11/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/home/rover/Documents/tmp/dlib/venv-old/lib/python3.11/site-packages/setuptools/command/easy_install.py:146: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
```

New methods removes these warnings and compiles to wheel package. 
`Successfully built dlib-19.24.99-cp311-cp311-linux_x86_64.whl`

I am not able to test the Pypi package and the original deprecation warning. 