### PR TITLE
Fix pixel saturation in interpolate_quadratic

### DIFF
--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -310,7 +310,9 @@ namespace dlib
                     pixel_to_vector<double>(img[r+1][c  ])(i),
                     pixel_to_vector<double>(img[r+1][c+1])(i));
             typename image_view_type::pixel_type temp;
-            vector_to_pixel(temp, pvout);
+            const auto min_val = pixel_traits<typename image_view_type::pixel_type>::min();
+            const auto max_val = pixel_traits<typename image_view_type::pixel_type>::max();
+            vector_to_pixel(temp, clamp(pvout, min_val, max_val));
             assign_pixel(result, temp);
             return true;
         }

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -310,8 +310,8 @@ namespace dlib
                     pixel_to_vector<double>(img[r+1][c  ])(i),
                     pixel_to_vector<double>(img[r+1][c+1])(i));
             typename image_view_type::pixel_type temp;
-            const auto min_val = pixel_traits<typename image_view_type::pixel_type>::min();
-            const auto max_val = pixel_traits<typename image_view_type::pixel_type>::max();
+            const auto min_val = pixel_traits<pixel_type_t<image_view_type>>::min();
+            const auto max_val = pixel_traits<pixel_type_t<image_view_type>>::max();
             vector_to_pixel(temp, clamp(pvout, min_val, max_val));
             assign_pixel(result, temp);
             return true;


### PR DESCRIPTION
When using `interpolate_quadratic` some really bright/dark areas would present artifacts.
This PR fixes that by clamping the pixel values to their appropriate range before converting them.

(image resized from 512x512 to 5800+ using `interpolate_quadratic` and a pyramid, and then resized down to 512 using `interpolate_nearest_neighbor` for display purposes here)
![lenna-before](https://github.com/davisking/dlib/assets/1671644/a201a6ce-73a3-4cc9-ae98-be5a6bdbef8c)
