### PR TITLE
dlib::optional

### DIFF
--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -5,8 +5,7 @@
 
 #include <exception>
 #include <initializer_list>
-#include "type_traits.h"
-#include "utility.h"
+#include "functional.h"
 
 namespace dlib
 {
@@ -652,6 +651,42 @@ namespace dlib
         void reset() noexcept(std::is_nothrow_destructible<T>::value)
         {
             this->destruct();
+        }
+
+        template<class F>
+        constexpr auto and_then(F&& f) &
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), **this);
+            else
+                return dlib::remove_cvref_t<dlib::invoke_result_t<F,T&>>();
+        }
+
+        template<class F>
+        constexpr auto and_then(F&& f) const&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), **this);
+            else
+                return dlib::remove_cvref_t<dlib::invoke_result_t<F,const T&>>();
+        }
+
+        template<class F>
+        constexpr auto and_then(F&& f) &&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), std::move(**this));
+            else
+                return dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>();
+        }
+
+        template<class F>
+        constexpr auto and_then(F&& f) const&&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), std::move(**this));
+            else
+                return dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>();
         }
     };
 

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -704,6 +704,62 @@ namespace dlib
             else
                 return Return{};
         }
+
+        template <
+            class F,
+            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, T&>>,
+            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+        >
+        constexpr dlib::optional<U> transform(F&& f) &
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), **this);
+            else
+                return dlib::optional<U>{};
+        }
+
+        template <
+            class F,
+            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, const T&>>,
+            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+        >
+        constexpr dlib::optional<U> transform(F&& f) const&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), **this);
+            else
+                return dlib::optional<U>{};
+        }
+
+        template <
+            class F,
+            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
+            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+        >
+        constexpr dlib::optional<U> transform(F&& f) &&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), std::move(**this));
+            else
+                return dlib::optional<U>{};
+        }
+
+        template <
+            class F,
+            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
+            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+        >
+        constexpr dlib::optional<U> transform(F&& f) const&&
+        {
+            if (*this)
+                return dlib::invoke(std::forward<F>(f), std::move(**this));
+            else
+                return dlib::optional<U>{};
+        }
     };
 
 // ---------------------------------------------------------------------------------------------------

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -159,6 +159,8 @@ namespace dlib
         bool active{false};
     };
 
+// ---------------------------------------------------------------------------------------------------
+
     template <class T>
     struct optional_ops : optional_storage<T> 
     {
@@ -199,6 +201,8 @@ namespace dlib
         constexpr bool      has_value() const   {return this->active;}
     };
 
+// ---------------------------------------------------------------------------------------------------
+
     template <class T, bool = std::is_trivially_copy_constructible<T>::value>
     struct optional_copy : optional_ops<T> 
     {
@@ -223,6 +227,8 @@ namespace dlib
         }
     };
 
+// ---------------------------------------------------------------------------------------------------
+
     template <class T, bool = std::is_trivially_move_constructible<T>::value>
     struct optional_move : optional_copy<T> 
     {
@@ -245,6 +251,8 @@ namespace dlib
                 this->construct(std::move(rhs.get()));
         }
     };
+
+// ---------------------------------------------------------------------------------------------------
 
     template <
       class T, 
@@ -276,6 +284,8 @@ namespace dlib
         }        
     };
 
+// ---------------------------------------------------------------------------------------------------
+
     template <
       class T, 
       bool = std::is_trivially_destructible<T>::value       &&
@@ -305,6 +315,8 @@ namespace dlib
             return *this;
         }
     };
+
+// ---------------------------------------------------------------------------------------------------
 
     template <
       class T, 
@@ -350,6 +362,8 @@ namespace dlib
         constexpr optional_delete_constructors& operator=(optional_delete_constructors &&)      = default;
     };
 
+// ---------------------------------------------------------------------------------------------------
+
     template <
       class T,
       bool copyable = (std::is_copy_constructible<T>::value && std::is_copy_assignable<T>::value),
@@ -393,6 +407,8 @@ namespace dlib
         constexpr optional_delete_assign& operator=(const optional_delete_assign &) = delete;
         constexpr optional_delete_assign& operator=(optional_delete_assign &&)      = delete;
     };
+
+// ---------------------------------------------------------------------------------------------------
 
     template <class T>
     class optional : private optional_move_assign<T>,

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -239,8 +239,8 @@ namespace dlib
         template< class... Args >
         constexpr T& emplace ( 
             Args&&... args 
-        ) 
-        nothrow(std::is_nothrow_constructible<T,Args&&...>::value)
+        )
+        noexcept(std::is_nothrow_constructible<T,Args&&...>::value)
         {
             reset();
             construct(std::forward<Args>(args)...);
@@ -254,7 +254,7 @@ namespace dlib
             std::initializer_list<U> ilist, 
             Args&&... args 
         )
-        nothrow(std::is_nothrow_constructible<T, std::initializer_list<U>&, Args&&...>::value)
+        noexcept(std::is_nothrow_constructible<T, std::initializer_list<U>&, Args&&...>::value)
         {
             reset();
             construct(ilist, std::forward<Args>(args)...);

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -114,6 +114,8 @@ namespace dlib
         >;
     }
 
+// ---------------------------------------------------------------------------------------------------
+
     template <
       class T,
       bool = std::is_trivially_destructible<T>::value

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -1,0 +1,348 @@
+// Copyright (C) 2023  Davis E. King (davis@dlib.net)
+// License: Boost Software License   See LICENSE.txt for the full license.
+#ifndef DLIB_OPTIONAL_H
+#define DLIB_OPTIONAL_H
+
+#include <exception>
+#include <initializer_list>
+#include "type_traits.h"
+#include "utility.h"
+
+namespace dlib
+{
+
+// ---------------------------------------------------------------------------------------------------
+
+    class bad_optional_access : public std::exception 
+    {
+    public:
+        bad_optional_access() = default;
+        const char *what() const noexcept { return "Optional has no value"; }
+    };
+
+// ---------------------------------------------------------------------------------------------------
+
+    struct nullopt_t 
+    {
+        explicit constexpr nullopt_t(int) noexcept {}
+    };
+
+    static constexpr nullopt_t nullopt{int{}};
+
+// ---------------------------------------------------------------------------------------------------
+
+    template<class T>
+    class optional
+    {
+    private:
+
+// ---------------------------------------------------------------------------------------------------
+
+        template<class U>
+        using is_assignable_base = And<
+            !std::is_constructible<T,       dlib::optional<U>&>::value,
+            !std::is_constructible<T, const dlib::optional<U>&>::value,
+            !std::is_constructible<T,       dlib::optional<U>&&>::value,
+            !std::is_constructible<T, const dlib::optional<U>&&>::value,
+            !std::is_convertible<      dlib::optional<U>&, T>::value,
+            !std::is_convertible<const dlib::optional<U>&, T>::value,
+            !std::is_convertible<      dlib::optional<U>&&, T>::value,
+            !std::is_convertible<const dlib::optional<U>&&, T>::value,
+            !std::is_assignable<T&,       dlib::optional<U>&>::value,
+            !std::is_assignable<T&, const dlib::optional<U>&>::value,
+            !std::is_assignable<T&,       dlib::optional<U>&&>::value,
+            !std::is_assignable<T&, const dlib::optional<U>&&>::value
+        >;
+
+        template<class U>
+        using is_copy_assignable_from = std::enable_if_t<
+            is_assignable_base<U>::value &&
+            std::is_constructible<T, const U&>::value &&
+            std::is_assignable<T&, const U&>::value,
+            bool
+        >;
+
+        template<class U>
+        using is_move_assignable_from = std::enable_if_t<
+            is_assignable_base<U>::value &&
+            std::is_constructible<T, U>::value &&
+            std::is_assignable<T&, U>::value,
+            bool
+        >;
+
+// ---------------------------------------------------------------------------------------------------
+
+    public:
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr optional() noexcept = default;
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr optional(dlib::nullopt_t) noexcept = default;
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr optional& operator=(dlib::nullopt_t) noexcept
+        {
+            reset();
+            return *this;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template <
+          class U,
+          std::enable_if_t<std::is_constructible<T, const U&>::value, bool> = true
+        >
+        constexpr optional (const optional<U>& other) noexcept(std::is_nothrow_constructible<T, const U&>::value)
+        {
+            if (other)
+                construct(*other);                
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class U,
+          is_copy_assignable_from<U> = true
+        >
+        constexpr optional& operator=( const optional<U>& other ) noexcept(std::is_nothrow_constructible<T, const U&>::value &&
+                                                                           std::is_nothrow_assignable<T&, const U&>::value)
+        {
+            if (!has_value() && other)
+                construct(*other);
+            else if (has_value() && other)
+                **this = *other;
+            else if (has_value() && !other)
+                reset();
+            return *this;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template <
+          class U,
+          std::enable_if_t<std::is_constructible<T, U&&>::value, bool> = true
+        >
+        constexpr optional( optional<U>&& other ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
+        {
+            if (other.has_value())
+                construct(std::move(other.value()));  
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class U,
+          is_move_assignable_from<U> = true
+        >
+        constexpr optional& operator=( optional<U>&& other ) noexcept(std::is_nothrow_constructible<T, U&&>::value &&
+                                                                      std::is_nothrow_assignable<T&, U&&>::value)
+        {
+            if (!has_value() && other)
+                construct(std::move(*other));
+            else if (has_value() && other)
+                **this = std::move(*other);
+            else if (has_value() && !other)
+                reset();
+            return *this;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class... Args,
+          std::enable_if_t<std::is_constructible<T, Args...>::value, bool> = true
+        >
+        constexpr explicit optional ( 
+            dlib::in_place_t,
+            Args&&... args
+        ) 
+        noexcept(std::is_nothrow_constructible<T, Args&&...>::value)
+        {
+            construct(std::forward<Args>(args)...);
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template< class... Args >
+        constexpr T& emplace( Args&&... args )
+        {
+            reset();
+            construct(std::forward<Args>(args)...);
+            return **this;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class U, 
+          class... Args,
+          std::enable_if_t<std::is_constructible<T, std::initializer_list<U>&, Args&&...>::value, bool> = true
+        >
+        constexpr explicit optional ( 
+            dlib::in_place_t,
+            std::initializer_list<U> ilist,
+            Args&&... args 
+        )
+        {
+            construct(ilist, std::forward<Args>(args)...);
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template< class U, class... Args >
+        constexpr T& emplace( std::initializer_list<U> ilist, Args&&... args )
+        {
+            reset();
+            construct(ilist, std::forward<Args>(args)...);
+            return **this;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class U,
+          class U_ = dlib::remove_cvref_t<U>,
+          std::enable_if_t<std::is_constructible<T, U&&>::value &&
+                           !std::is_same<U_, dlib::in_place_t>::value &&
+                           !std::is_same<U_, dlib::optional<T>>::value, bool> = true
+        >
+        constexpr optional( U&& u ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
+        {
+            construct(std::forward<U>(u));
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template < 
+          class U,
+          class U_ = dlib::remove_cvref_t<U>,
+          std::enable_if_t<std::is_constructible<T, U>::value &&
+                           std::is_assignable<T&, U>::value &&
+                           !std::is_same<U_, dlib::optional<T>>::value,bool> = true
+        >
+        constexpr optional& operator=( U&& u ) noexcept(std::is_nothrow_constructible<T, U&&>::value &&
+                                                        std::is_nothrow_assignable<T,U&&>::value)
+        {
+            if (has_value())
+                **this = std::forward<U>(u);
+            else
+                construct(std::forward<U>(u));
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        ~optional() noexcept
+        {
+            reset();
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr void reset() noexcept(std::is_nothrow_destructible<T>::value)
+        {
+            if (has_value())
+            {
+                (**this).~T();
+                has_value_ = false;
+            }
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr explicit  operator bool() const noexcept { return has_value_; }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr bool      has_value()     const noexcept { return has_value_; }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr const T*  operator->()    const noexcept { return reinterpret_cast<const T*>(&mem); }
+        constexpr T*        operator->()          noexcept { return reinterpret_cast<const T*>(&mem); }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr const T&  operator*()     const noexcept { return *reinterpret_cast<const T*>(&mem); }
+        constexpr T&        operator*()           noexcept { return *reinterpret_cast<const T*>(&mem); }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr T& value() 
+        {
+            if (has_value())
+                return **this;
+            throw bad_optional_access();
+        }
+        
+        constexpr const T& value() const
+        {
+            if (has_value())
+                return **this;
+            throw bad_optional_access();
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        template< class U >
+        constexpr T value_or( U&& u ) const&
+        {
+            return has_value_ ? **this : static_cast<T>(std::forward<U>(u));
+        }
+
+        template< class U >
+        constexpr T value_or( U&& u ) &&
+        {
+            return has_value_ ? std::move(**this) : static_cast<T>(std::forward<U>(u));
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        constexpr void swap( optional& other ) noexcept(std::is_nothrow_move_constructible<T>::value &&
+                                                        dlib::is_nothrow_swappable<T>::value)
+        {
+            if (has_value() && other.has_value())
+                std::swap(**this, *other);
+            else if (has_value() && !other.has_value())
+                other = std::move(*this);
+            else if (!has_value() && other.has_value())
+                *this = std::move(other);
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+    private:
+
+        static_assert(!std::is_reference<T>::value, "optional of reference is forbidden");
+
+// ---------------------------------------------------------------------------------------------------
+
+        template< class... Args>
+        constexpr void construct(Args&&... args) noexcept(std::is_nothrow_constructible<T,Args&&...>::value)
+        {
+            new (&mem) T{std::forward<Args>(args)...};
+            has_value_ = true;
+        }
+
+// ---------------------------------------------------------------------------------------------------
+
+        std::aligned_storage_t<sizeof(T), alignof(T)> mem;
+        bool has_value_{false};
+    };
+
+// ---------------------------------------------------------------------------------------------------
+
+    template<class T>
+    void swap(dlib::optional<T>& a, dlib::optional<T>& b)
+    {
+        a.swap(b);
+    }
+
+// ---------------------------------------------------------------------------------------------------
+
+}
+
+#endif

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -654,9 +654,9 @@ namespace dlib
         }
 
         template <
-            class F,
-            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T&>>,
-            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+          class F,
+          class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T&>>,
+          std::enable_if_t<details::is_optional<Return>::value, bool> = true
         >
         constexpr auto and_then(F&& f) &
         {
@@ -667,9 +667,9 @@ namespace dlib
         }
 
         template <
-            class F,
-            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T&>>,
-            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+          class F,
+          class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T&>>,
+          std::enable_if_t<details::is_optional<Return>::value, bool> = true
         >
         constexpr auto and_then(F&& f) const&
         {
@@ -680,9 +680,9 @@ namespace dlib
         }
 
         template <
-            class F,
-            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
-            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+          class F,
+          class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
+          std::enable_if_t<details::is_optional<Return>::value, bool> = true
         >
         constexpr auto and_then(F&& f) &&
         {
@@ -693,9 +693,9 @@ namespace dlib
         }
 
         template <
-            class F,
-            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
-            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+          class F,
+          class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
+          std::enable_if_t<details::is_optional<Return>::value, bool> = true
         >
         constexpr auto and_then(F&& f) const&&
         {
@@ -706,10 +706,10 @@ namespace dlib
         }
 
         template <
-            class F,
-            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, T&>>,
-            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
-            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, T&>>,
+          std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+          std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
         >
         constexpr dlib::optional<U> transform(F&& f) &
         {
@@ -720,10 +720,10 @@ namespace dlib
         }
 
         template <
-            class F,
-            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, const T&>>,
-            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
-            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F, const T&>>,
+          std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+          std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
         >
         constexpr dlib::optional<U> transform(F&& f) const&
         {
@@ -734,10 +734,10 @@ namespace dlib
         }
 
         template <
-            class F,
-            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
-            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
-            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
+          std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+          std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
         >
         constexpr dlib::optional<U> transform(F&& f) &&
         {
@@ -748,10 +748,10 @@ namespace dlib
         }
 
         template <
-            class F,
-            class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
-            std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
-            std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
+          std::enable_if_t<!std::is_same<U, dlib::in_place_t>::value, bool> = true,
+          std::enable_if_t<!std::is_same<U, dlib::nullopt_t>::value, bool> = true
         >
         constexpr dlib::optional<U> transform(F&& f) const&&
         {
@@ -759,6 +759,26 @@ namespace dlib
                 return dlib::invoke(std::forward<F>(f), std::move(**this));
             else
                 return dlib::optional<U>{};
+        }
+
+        template < 
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F>>,
+          std::enable_if_t<std::is_same<U, dlib::optional<T>>::value, bool> = true
+        >
+        constexpr optional or_else( F&& f ) const&
+        {
+            return *this ? *this : std::forward<F>(f)();
+        }
+
+        template < 
+          class F,
+          class U = dlib::remove_cvref_t<dlib::invoke_result_t<F>>,
+          std::enable_if_t<std::is_same<U, dlib::optional<T>>::value, bool> = true
+        >
+        constexpr optional or_else( F&& f ) &&
+        {
+            return *this ? std::move(*this) : std::forward<F>(f)();
         }
     };
 

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -411,6 +411,12 @@ namespace dlib
                      private details::optional_delete_constructors<T>,
                      private details::optional_delete_assign<T> 
     {
+        /*!
+            WHAT THIS OBJECT REPRESENTS 
+                This is a standard's compliant backport of std::optional that works with C++14.
+                It includes C++23 monadic interfaces
+        !*/
+
         using base = details::optional_move_assign<T>;
 
         static_assert(!std::is_reference<T>::value,         "optional<T&> not allowed");

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -607,6 +607,7 @@ namespace dlib
         constexpr T&&       operator*() &&      noexcept { return std::move(this->get()); }
         constexpr const T&& operator*() const&& noexcept { return std::move(this->get()); }
         constexpr explicit  operator bool() const noexcept { return this->active; }
+        using details::optional_ops<T>::has_value;
 
         constexpr T& value() & 
         {

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -653,40 +653,56 @@ namespace dlib
             this->destruct();
         }
 
-        template<class F>
+        template <
+            class F,
+            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T&>>,
+            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+        >
         constexpr auto and_then(F&& f) &
         {
             if (*this)
                 return dlib::invoke(std::forward<F>(f), **this);
             else
-                return dlib::remove_cvref_t<dlib::invoke_result_t<F,T&>>();
+                return Return{};
         }
 
-        template<class F>
+        template <
+            class F,
+            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T&>>,
+            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+        >
         constexpr auto and_then(F&& f) const&
         {
             if (*this)
                 return dlib::invoke(std::forward<F>(f), **this);
             else
-                return dlib::remove_cvref_t<dlib::invoke_result_t<F,const T&>>();
+                return Return{};
         }
 
-        template<class F>
+        template <
+            class F,
+            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>,
+            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+        >
         constexpr auto and_then(F&& f) &&
         {
             if (*this)
                 return dlib::invoke(std::forward<F>(f), std::move(**this));
             else
-                return dlib::remove_cvref_t<dlib::invoke_result_t<F,T>>();
+                return Return{};
         }
 
-        template<class F>
+        template <
+            class F,
+            class Return = dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>,
+            std::enable_if_t<details::is_optional<Return>::value, bool> = true
+        >
         constexpr auto and_then(F&& f) const&&
         {
             if (*this)
                 return dlib::invoke(std::forward<F>(f), std::move(**this));
             else
-                return dlib::remove_cvref_t<dlib::invoke_result_t<F,const T>>();
+                return Return{};
         }
     };
 

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -179,7 +179,7 @@ namespace dlib
                     this->val = std::forward<Optional>(rhs).active;
                 else if (!this->active && rhs.active)
                     construct(std::forward<Optional>(rhs).active);
-                else if (this->active && !rhs.has_value())
+                else if (this->active && !rhs.active)
                     destruct();
             }
 
@@ -214,8 +214,8 @@ namespace dlib
             constexpr optional_copy(const optional_copy& rhs) noexcept(std::is_nothrow_copy_constructible<T>::value)
             : optional_storage<T>() 
             {
-                if (rhs.has_value())
-                    this->construct(rhs.get());
+                if (rhs.active)
+                    this->construct(rhs.val);
             }
         };
 
@@ -239,18 +239,18 @@ namespace dlib
 
             constexpr optional_move(optional_move&& rhs) noexcept(std::is_nothrow_move_constructible<T>::value)
             {
-                if (rhs.has_value())
-                    this->construct(std::move(rhs.get()));
+                if (rhs.active)
+                    this->construct(std::move(rhs.val));
             }
         };
 
 // ---------------------------------------------------------------------------------------------------
 
         template <
-        class T, 
-        bool = std::is_trivially_copy_assignable<T>::value       &&
-                std::is_trivially_copy_constructible<T>::value    &&
-                std::is_trivially_destructible<T>::value
+          class T, 
+          bool = std::is_trivially_copy_assignable<T>::value       &&
+                 std::is_trivially_copy_constructible<T>::value    &&
+                 std::is_trivially_destructible<T>::value
         >
         struct optional_copy_assign : optional_move<T> 
         {
@@ -279,10 +279,10 @@ namespace dlib
 // ---------------------------------------------------------------------------------------------------
 
         template <
-        class T, 
-        bool = std::is_trivially_destructible<T>::value       &&
-                std::is_trivially_move_constructible<T>::value &&
-                std::is_trivially_move_assignable<T>::value
+          class T, 
+          bool = std::is_trivially_destructible<T>::value       &&
+                 std::is_trivially_move_constructible<T>::value &&
+                 std::is_trivially_move_assignable<T>::value
         >
         struct optional_move_assign : optional_copy_assign<T> 
         {
@@ -311,9 +311,9 @@ namespace dlib
 // ---------------------------------------------------------------------------------------------------
 
         template <
-        class T, 
-        bool copyable = std::is_copy_constructible<T>::value,
-        bool moveable = std::is_move_constructible<T>::value
+          class T, 
+          bool copyable = std::is_copy_constructible<T>::value,
+          bool moveable = std::is_move_constructible<T>::value
         >
         struct optional_delete_constructors
         {
@@ -357,9 +357,9 @@ namespace dlib
 // ---------------------------------------------------------------------------------------------------
 
         template <
-        class T,
-        bool copyable = (std::is_copy_constructible<T>::value && std::is_copy_assignable<T>::value),
-        bool moveable = (std::is_move_constructible<T>::value && std::is_move_assignable<T>::value)
+          class T,
+          bool copyable = (std::is_copy_constructible<T>::value && std::is_copy_assignable<T>::value),
+          bool moveable = (std::is_move_constructible<T>::value && std::is_move_assignable<T>::value)
         >
         struct optional_delete_assign
         {
@@ -891,8 +891,9 @@ namespace dlib
     }
 
     template <class T>
-    constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept {
-    return !rhs.has_value();
+    constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept 
+    {
+        return !rhs.has_value();
     }
 
 // ---------------------------------------------------------------------------------------------------

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -572,7 +572,7 @@ namespace dlib
         constexpr T& emplace(Args &&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
         {
             reset();
-            construct(std::forward<Args>(args)...);
+            this->construct(std::forward<Args>(args)...);
             return **this;
         }
 
@@ -580,7 +580,7 @@ namespace dlib
         constexpr T& emplace(std::initializer_list<U> il, Args &&... args) 
         {
             reset();
-            construct(il, std::forward<Args>(args)...);
+            this->construct(il, std::forward<Args>(args)...);
             return **this;   
         }
 
@@ -607,8 +607,8 @@ namespace dlib
             }
         }
 
-        constexpr const T*  operator->() const  noexcept { return this->val; }
-        constexpr T*        operator->()        noexcept { return this->val; }
+        constexpr const T*  operator->() const  noexcept { return &this->val; }
+        constexpr T*        operator->()        noexcept { return &this->val; }
         constexpr T&        operator*() &       noexcept { return this->val; }
         constexpr const T&  operator*() const&  noexcept { return this->val; }
         constexpr T&&       operator*() &&      noexcept { return std::move(this->val); }

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -176,9 +176,9 @@ namespace dlib
                                                            std::is_nothrow_assignable<T&,Optional>::value)
             {
                 if (this->active && rhs.active)
-                    this->val = std::forward<Optional>(rhs).active;
+                    this->val = std::forward<Optional>(rhs).val;
                 else if (!this->active && rhs.active)
-                    construct(std::forward<Optional>(rhs).active);
+                    construct(std::forward<Optional>(rhs).val);
                 else if (this->active && !rhs.active)
                     destruct();
             }
@@ -212,7 +212,7 @@ namespace dlib
             constexpr optional_copy &operator=(optional_copy&& rhs)         = default;
 
             constexpr optional_copy(const optional_copy& rhs) noexcept(std::is_nothrow_copy_constructible<T>::value)
-            : optional_storage<T>() 
+            : optional_ops<T>() 
             {
                 if (rhs.active)
                     this->construct(rhs.val);

--- a/dlib/optional.h
+++ b/dlib/optional.h
@@ -98,7 +98,7 @@ namespace dlib
 
 // ---------------------------------------------------------------------------------------------------
 
-        constexpr optional(dlib::nullopt_t) noexcept = default;
+        constexpr optional(dlib::nullopt_t) noexcept {};
 
 // ---------------------------------------------------------------------------------------------------
 
@@ -106,7 +106,7 @@ namespace dlib
           class U,
           is_copy_constructible_from<U> = true
         >
-        constexpr optional (const optional<U>& other) noexcept(std::is_nothrow_constructible<T, const U&>::value)
+        constexpr explicit optional (const optional<U>& other) noexcept(std::is_nothrow_constructible<T, const U&>::value)
         {
             if (other)
                 construct(*other);                
@@ -118,7 +118,7 @@ namespace dlib
           class U,
           is_move_constructible_from<U> = true
         >
-        constexpr optional( optional<U>&& other ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
+        constexpr explicit optional( optional<U>&& other ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
         {
             if (other)
                 construct(std::move(*other));  
@@ -160,12 +160,12 @@ namespace dlib
 
         template < 
           class U,
-          class U_ = dlib::remove_cvref_t<U>,
+          class U_ = std::decay_t<U>,
           std::enable_if_t<std::is_constructible<T, U&&>::value &&
                            !std::is_same<U_, dlib::in_place_t>::value &&
                            !std::is_same<U_, dlib::optional<T>>::value, bool> = true
         >
-        constexpr optional( U&& u ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
+        constexpr explicit optional( U&& u ) noexcept(std::is_nothrow_constructible<T, U&&>::value)
         {
             construct(std::forward<U>(u));
         }
@@ -219,8 +219,8 @@ namespace dlib
         template < 
           class U,
           class U_ = std::decay_t<U>,
-          std::enable_if_t<!std::is_same<U_, dlib::optional<T>>::value &&
-                           !std::is_same<U_, T>::value &&
+          std::enable_if_t<!std::is_same<U_, dlib::in_place_t>::value &&
+                           !std::is_same<U_, dlib::optional<T>>::value &&
                            std::is_constructible<T, U>::value &&
                            std::is_assignable<T&, U>::value,
                            bool> = true
@@ -232,6 +232,7 @@ namespace dlib
                 **this = std::forward<U>(u);
             else
                 construct(std::forward<U>(u));
+            return *this;
         }
 
 // ---------------------------------------------------------------------------------------------------
@@ -290,12 +291,12 @@ namespace dlib
 // ---------------------------------------------------------------------------------------------------
 
         constexpr const T*  operator->()    const noexcept { return reinterpret_cast<const T*>(&mem); }
-        constexpr T*        operator->()          noexcept { return reinterpret_cast<const T*>(&mem); }
+        constexpr T*        operator->()          noexcept { return reinterpret_cast<T*>(&mem); }
 
 // ---------------------------------------------------------------------------------------------------
 
         constexpr const T&  operator*()     const noexcept { return *reinterpret_cast<const T*>(&mem); }
-        constexpr T&        operator*()           noexcept { return *reinterpret_cast<const T*>(&mem); }
+        constexpr T&        operator*()           noexcept { return *reinterpret_cast<T*>(&mem); }
 
 // ---------------------------------------------------------------------------------------------------
 

--- a/dlib/test/CMakeLists.txt
+++ b/dlib/test/CMakeLists.txt
@@ -161,6 +161,7 @@ add_executable(${target_name} main.cpp tester.cpp
    elastic_net.cpp
    te.cpp
    ffmpeg.cpp
+   optional.cpp
 )
 
 get_filename_component(DLIB_FFMPEG_DATA ${CMAKE_SOURCE_DIR}/ffmpeg_data/details.cfg REALPATH)

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -229,6 +229,48 @@ namespace
             static_assert(std::is_same<decltype(res), dlib::optional<std::string>>::value, "bad map");
             DLIB_TEST(*res == "42");
         }
+
+        {
+            auto res = o1.transform([](int i)                   {return i+1;})
+                         .transform([](int i)                   {return i*2;})
+                         .transform([](int i)                   {return std::to_string(i);})
+                         .transform([](const std::string& str)  {return std::stoi(str);})
+                         .transform([](int i)                   {return i - 2;})
+                         .or_else([]                            {return dlib::make_optional<int>(0);});
+
+            static_assert(std::is_same<decltype(res), dlib::optional<int>>::value, "bad map");
+            DLIB_TEST(*res == 84);
+        }
+
+        dlib::optional<int> o2;
+
+        {
+            auto res = o2.transform([](int i)   {return i+1;})
+                         .or_else([]            {return dlib::make_optional<int>(0);});
+
+            static_assert(std::is_same<decltype(res), dlib::optional<int>>::value, "bad map");
+            DLIB_TEST(*res == 0);
+        }
+    }
+
+// ---------------------------------------------------------------------------------------------------
+
+    void test_optional_int_constexpr_monads()
+    {
+        constexpr dlib::optional<int> o1{42};
+
+        {
+            struct callback
+            {
+                constexpr auto operator()(int i) {return dlib::optional<long>{i}; };
+            };
+
+            constexpr auto res = o1.and_then(callback{});
+
+            static_assert(std::is_same<std::decay_t<decltype(res)>, dlib::optional<long>>::value, "bad map");
+            static_assert(*res == 42, "bad");
+            DLIB_TEST(*res == 42);
+        }
     }
 
 // ---------------------------------------------------------------------------------------------------
@@ -282,6 +324,7 @@ namespace
             test_optional_int();
             test_optional_int_constexpr();
             test_optional_int_monads();
+            test_optional_int_constexpr_monads();
             test_constructors();
         }
     } a;

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -137,6 +137,36 @@ namespace
 
         dlib::optional<int> o9 = std::move(o7);
         DLIB_TEST(*o9 == 42);
+
+        dlib::optional<int> o10;
+        DLIB_TEST(!o10);
+        o10 = o3;
+        DLIB_TEST(*o10 == 42);
+        o10 = dlib::nullopt;
+        DLIB_TEST(!o10);
+
+        dlib::optional<int> o11;
+        o11 = std::move(o3);
+        DLIB_TEST(*o11 == 42);
+        o11 = (short)12;
+        DLIB_TEST(*o11 == 12);
+    }
+
+    void test_optional_int_constexpr()
+    {
+        {
+            constexpr dlib::optional<int> o2{};
+            constexpr dlib::optional<int> o3 = {};
+            constexpr dlib::optional<int> o4 = dlib::nullopt;
+            constexpr dlib::optional<int> o5 = {dlib::nullopt};
+            constexpr dlib::optional<int> o6(dlib::nullopt);
+
+            static_assert(!o2, "bad");
+            static_assert(!o3, "bad");
+            static_assert(!o4, "bad");
+            static_assert(!o5, "bad");
+            static_assert(!o6, "bad");
+        }
     }
 
 // ---------------------------------------------------------------------------------------------------

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -34,6 +34,21 @@ namespace
     static_assert(std::is_trivially_move_assignable<dlib::optional<trivial_type>>::value,    "bad");
     static_assert(std::is_trivially_destructible<dlib::optional<trivial_type>>::value,       "bad");
 
+    struct non_trivial_type
+    {
+        non_trivial_type(const non_trivial_type&)               {}
+        non_trivial_type(non_trivial_type&&)                    {};
+        non_trivial_type& operator=(const non_trivial_type&)    { return *this; }
+        non_trivial_type& operator=(non_trivial_type&&)         { return *this; };
+        ~non_trivial_type()                                     {}
+    };
+
+    static_assert(!std::is_trivially_copy_constructible<dlib::optional<non_trivial_type>>::value, "bad");
+    static_assert(!std::is_trivially_copy_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
+    static_assert(!std::is_trivially_move_constructible<dlib::optional<non_trivial_type>>::value, "bad");
+    static_assert(!std::is_trivially_move_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
+    static_assert(!std::is_trivially_destructible<dlib::optional<non_trivial_type>>::value,       "bad");
+
 // ---------------------------------------------------------------------------------------------------
 
     void test_optional_int()

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -351,6 +351,43 @@ namespace
 
 // ---------------------------------------------------------------------------------------------------
 
+    void test_emplace()
+    {
+        struct A
+        {
+            A() = default;
+            explicit A(int i, float f, const std::string& str) : i_{i}, f_{f}, str_{str} {}
+
+            int         i_{0};
+            float       f_{0.0f};
+            std::string str_;
+        };
+
+        dlib::optional<A> o1(dlib::in_place, 1, 2.5f, "hello there");
+        DLIB_TEST(o1);
+        DLIB_TEST(o1->i_ == 1);
+        DLIB_TEST(o1->f_ == 2.5f);
+        DLIB_TEST(o1->str_ == "hello there");
+
+        dlib::optional<A> o2;
+        o2.emplace(2, 5.1f, "general kenobi");
+        DLIB_TEST(o2);
+        DLIB_TEST(o2->i_ == 2);
+        DLIB_TEST(o2->f_ == 5.1f);
+        DLIB_TEST(o2->str_ == "general kenobi");
+
+        dlib::optional<std::string> o3(dlib::in_place, {'a', 'b', 'c'});
+        DLIB_TEST(o3);
+        DLIB_TEST(*o3 == "abc");
+
+        dlib::optional<std::string> o4;
+        o4.emplace({'a', 'b', 'c'});
+        DLIB_TEST(o4);
+        DLIB_TEST(*o4 == "abc");
+    }
+
+// ---------------------------------------------------------------------------------------------------
+
     class optional_tester : public tester
     {
     public:
@@ -368,6 +405,7 @@ namespace
             test_optional_int_monads();
             test_optional_int_constexpr_monads();
             test_constructors();
+            test_emplace();
         }
     } a;
 }

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2023  Davis E. King (davis@dlib.net)
+// License: Boost Software License   See LICENSE.txt for the full license.
+
+#include <dlib/optional.h>
+#include "tester.h"
+
+namespace  
+{
+    using namespace test;
+    using namespace dlib;
+
+    logger dlog("test.optional");
+
+    class optional_tester : public tester
+    {
+    public:
+        optional_tester (
+        ) :
+            tester ("optional",
+                    "Runs tests on the optional object")
+        {}
+
+        void perform_test (
+        )
+        {
+        }
+    } a;
+}

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -281,12 +281,20 @@ namespace
     static int copy_assign_count{0};
     static int move_assign_count{0};
 
+    static void reset_counters()
+    {
+        constructor_count           = 0;
+        copy_constructor_count      = 0;
+        move_constructor_count      = 0;
+        copy_assign_count           = 0;
+        move_assign_count           = 0;
+    }
+
     struct optional_dummy
     {
         optional_dummy() {++constructor_count;}
-        ~optional_dummy() {--constructor_count;}
-        optional_dummy(const optional_dummy&) {++constructor_count; ++copy_constructor_count;}
-        optional_dummy(optional_dummy&&) {++constructor_count; ++move_constructor_count;}
+        optional_dummy(const optional_dummy&) {++copy_constructor_count;}
+        optional_dummy(optional_dummy&&) {++move_constructor_count;}
         optional_dummy& operator=(const optional_dummy&) {++copy_assign_count; return *this;}
         optional_dummy& operator=(optional_dummy&&) {++move_assign_count; return *this;}
     };
@@ -299,12 +307,46 @@ namespace
         DLIB_TEST(move_constructor_count == 0);
         DLIB_TEST(copy_assign_count == 0);
         DLIB_TEST(move_assign_count == 0);
+
         val = optional_dummy{};
         DLIB_TEST(constructor_count == 1);
         DLIB_TEST(copy_constructor_count == 0);
         DLIB_TEST(move_constructor_count == 1);
         DLIB_TEST(copy_assign_count == 0);
         DLIB_TEST(move_assign_count == 0);
+        reset_counters();
+
+        dlib::optional<optional_dummy> val2{val};
+        DLIB_TEST(constructor_count == 0);
+        DLIB_TEST(copy_constructor_count == 1);
+        DLIB_TEST(move_constructor_count == 0);
+        DLIB_TEST(copy_assign_count == 0);
+        DLIB_TEST(move_assign_count == 0);
+        reset_counters();
+
+        dlib::optional<optional_dummy> val3{std::move(val)};
+        DLIB_TEST(constructor_count == 0);
+        DLIB_TEST(copy_constructor_count == 0);
+        DLIB_TEST(move_constructor_count == 1);
+        DLIB_TEST(copy_assign_count == 0);
+        DLIB_TEST(move_assign_count == 0);
+        reset_counters();
+
+        val2 = val;
+        DLIB_TEST(constructor_count == 0);
+        DLIB_TEST(copy_constructor_count == 0);
+        DLIB_TEST(move_constructor_count == 0);
+        DLIB_TEST(copy_assign_count == 1);
+        DLIB_TEST(move_assign_count == 0);
+        reset_counters();
+
+        val3 = std::move(val);
+        DLIB_TEST(constructor_count == 0);
+        DLIB_TEST(copy_constructor_count == 0);
+        DLIB_TEST(move_constructor_count == 0);
+        DLIB_TEST(copy_assign_count == 0);
+        DLIB_TEST(move_assign_count == 1);
+        reset_counters();
     }
 
 // ---------------------------------------------------------------------------------------------------

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -120,6 +120,7 @@ namespace
         DLIB_TEST(throw_counter == 1);
 
         dlib::optional<int> o2 = dlib::nullopt;
+        DLIB_TEST(noexcept(o2 = dlib::nullopt));
         DLIB_TEST(!o2);
         DLIB_TEST(!o2.has_value());
 
@@ -128,20 +129,24 @@ namespace
         DLIB_TEST(o3.value() == 42);
 
         dlib::optional<int> o4 = o3;
+        DLIB_TEST(noexcept(o4 = o3));
         DLIB_TEST(*o3 == 42);
         DLIB_TEST(*o4 == 42);
         DLIB_TEST(o4.value() == 42);
 
         dlib::optional<int> o5 = o1;
+        DLIB_TEST(noexcept(o5 = o1));
         DLIB_TEST(!o1);
         DLIB_TEST(!o5);
         DLIB_TEST(!o5.has_value());
 
         dlib::optional<int> o6 = std::move(o3);
+        DLIB_TEST(noexcept(o6 = std::move(o3)));
         DLIB_TEST(*o6 == 42);
         DLIB_TEST(o6.value() == 42);
 
         dlib::optional<short> o7 = (short)42;
+        DLIB_TEST(noexcept(o7 = (short)42));
         DLIB_TEST(*o7 == 42);
 
         dlib::optional<int> o8 = o7;
@@ -169,6 +174,7 @@ namespace
         DLIB_TEST(o12);
         DLIB_TEST(!o4);
         DLIB_TEST(*o12 == 42);
+        DLIB_TEST(noexcept(swap(o12, o4)));
     }
 
     void test_optional_int_constexpr()

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -11,18 +11,51 @@ namespace
 
     logger dlog("test.optional");
 
+    static int constructor_count{0};
+    static int copy_constructor_count{0};
+    static int move_constructor_count{0};
+    static int copy_assign_count{0};
+    static int move_assign_count{0};
+
+    struct optional_dummy
+    {
+        optional_dummy() {++constructor_count;}
+        ~optional_dummy() {--constructor_count;}
+        optional_dummy(const optional_dummy&) {++constructor_count; ++copy_constructor_count;}
+        optional_dummy(optional_dummy&&) {++constructor_count; ++move_constructor_count;}
+        optional_dummy& operator=(const optional_dummy&) {++copy_assign_count; return *this;}
+        optional_dummy& operator=(optional_dummy&&) {++move_assign_count; return *this;}
+    };
+
+    void test_constructors()
+    {
+        dlib::optional<optional_dummy> val;
+        DLIB_TEST(constructor_count == 0);
+        DLIB_TEST(copy_constructor_count == 0);
+        DLIB_TEST(move_constructor_count == 0);
+        DLIB_TEST(copy_assign_count == 0);
+        DLIB_TEST(move_assign_count == 0);
+        val = optional_dummy{};
+        DLIB_TEST(constructor_count == 1);
+        DLIB_TEST(copy_constructor_count == 0);
+        DLIB_TEST(move_constructor_count == 1);
+        DLIB_TEST(copy_assign_count == 0);
+        DLIB_TEST(move_assign_count == 0);
+    }
+
     class optional_tester : public tester
     {
     public:
         optional_tester (
         ) :
-            tester ("optional",
+            tester ("test_optional",
                     "Runs tests on the optional object")
         {}
 
         void perform_test (
         )
         {
+            test_constructors();
         }
     } a;
 }

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -13,6 +13,12 @@ namespace
 
 // ---------------------------------------------------------------------------------------------------
 
+    static_assert(std::is_copy_constructible<dlib::optional<int>>::value, "bad");
+    static_assert(std::is_copy_assignable<dlib::optional<int>>::value,    "bad");
+    static_assert(std::is_move_constructible<dlib::optional<int>>::value, "bad");
+    static_assert(std::is_move_assignable<dlib::optional<int>>::value,    "bad");
+    static_assert(std::is_destructible<dlib::optional<int>>::value,       "bad");
+
     static_assert(std::is_trivially_copy_constructible<dlib::optional<int>>::value, "bad");
     static_assert(std::is_trivially_copy_assignable<dlib::optional<int>>::value,    "bad");
     static_assert(std::is_trivially_move_constructible<dlib::optional<int>>::value, "bad");
@@ -27,6 +33,12 @@ namespace
         trivial_type& operator=(trivial_type&&)       = default;
         ~trivial_type() = default;
     };
+
+    static_assert(std::is_copy_constructible<dlib::optional<trivial_type>>::value, "bad");
+    static_assert(std::is_copy_assignable<dlib::optional<trivial_type>>::value,    "bad");
+    static_assert(std::is_move_constructible<dlib::optional<trivial_type>>::value, "bad");
+    static_assert(std::is_move_assignable<dlib::optional<trivial_type>>::value,    "bad");
+    static_assert(std::is_destructible<dlib::optional<trivial_type>>::value,       "bad");
 
     static_assert(std::is_trivially_copy_constructible<dlib::optional<trivial_type>>::value, "bad");
     static_assert(std::is_trivially_copy_assignable<dlib::optional<trivial_type>>::value,    "bad");
@@ -43,11 +55,54 @@ namespace
         ~non_trivial_type()                                     {}
     };
 
+    static_assert(std::is_copy_constructible<dlib::optional<non_trivial_type>>::value, "bad");
+    static_assert(std::is_copy_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
+    static_assert(std::is_move_constructible<dlib::optional<non_trivial_type>>::value, "bad");
+    static_assert(std::is_move_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
+    static_assert(std::is_destructible<dlib::optional<non_trivial_type>>::value,       "bad");
+
     static_assert(!std::is_trivially_copy_constructible<dlib::optional<non_trivial_type>>::value, "bad");
     static_assert(!std::is_trivially_copy_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
     static_assert(!std::is_trivially_move_constructible<dlib::optional<non_trivial_type>>::value, "bad");
     static_assert(!std::is_trivially_move_assignable<dlib::optional<non_trivial_type>>::value,    "bad");
     static_assert(!std::is_trivially_destructible<dlib::optional<non_trivial_type>>::value,       "bad");
+
+    struct nothing_works
+    {
+        nothing_works(const nothing_works&)             = delete;
+        nothing_works(nothing_works&&)                  = delete;
+        nothing_works& operator=(const nothing_works&)  = delete;
+        nothing_works& operator=(nothing_works&&)       = delete;
+    };
+
+    static_assert(!std::is_copy_constructible<dlib::optional<nothing_works>>::value,    "bad");
+    static_assert(!std::is_copy_assignable<dlib::optional<nothing_works>>::value,       "bad");
+    static_assert(!std::is_move_constructible<dlib::optional<nothing_works>>::value,    "bad");
+    static_assert(!std::is_move_assignable<dlib::optional<nothing_works>>::value,       "bad");
+
+    struct copyable_type 
+    {
+        copyable_type(const copyable_type&)             = default;
+        copyable_type(copyable_type&&)                  = delete;
+        copyable_type& operator=(const copyable_type&)  = default;
+        copyable_type& operator=(copyable_type&&)       = delete;
+    };
+
+    static_assert(std::is_copy_constructible<dlib::optional<copyable_type>>::value,     "bad");
+    static_assert(std::is_copy_assignable<dlib::optional<copyable_type>>::value,        "bad");
+
+    struct moveable_type 
+    {
+        moveable_type(const moveable_type&)             = delete;
+        moveable_type(moveable_type&&)                  = default;
+        moveable_type& operator=(const moveable_type&)  = delete;
+        moveable_type& operator=(moveable_type&&)       = default;
+    };
+
+    static_assert(!std::is_copy_constructible<dlib::optional<moveable_type>>::value,     "bad");
+    static_assert(!std::is_copy_assignable<dlib::optional<moveable_type>>::value,        "bad");
+    static_assert(std::is_move_constructible<dlib::optional<moveable_type>>::value,     "bad");
+    static_assert(std::is_move_assignable<dlib::optional<moveable_type>>::value,        "bad");
 
 // ---------------------------------------------------------------------------------------------------
 

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -167,6 +167,7 @@ namespace
         dlib::optional<int> o12;
         swap(o12, o4);
         DLIB_TEST(o12);
+        DLIB_TEST(!o4);
         DLIB_TEST(*o12 == 42);
     }
 

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -11,6 +11,43 @@ namespace
 
     logger dlog("test.optional");
 
+// ---------------------------------------------------------------------------------------------------
+
+    void test_optional_int()
+    {
+        dlib::optional<int> o1;
+        DLIB_TEST(!o1);
+
+        dlib::optional<int> o2 = dlib::nullopt;
+        DLIB_TEST(!o2);
+
+        dlib::optional<int> o3 = 42;
+        DLIB_TEST(*o3 == 42);
+
+        dlib::optional<int> o4 = o3;
+        DLIB_TEST(*o3 == 42);
+        DLIB_TEST(*o4 == 42);
+
+        dlib::optional<int> o5 = o1;
+        DLIB_TEST(!o1);
+        DLIB_TEST(!o5);
+
+        dlib::optional<int> o6 = std::move(o3);
+        DLIB_TEST(*o6 == 42);
+
+        dlib::optional<short> o7 = (short)42;
+        DLIB_TEST(*o7 == 42);
+
+        dlib::optional<int> o8 = o7;
+        DLIB_TEST(*o7 == 42);
+        DLIB_TEST(*o8 == 42);
+
+        dlib::optional<int> o9 = std::move(o7);
+        DLIB_TEST(*o9 == 42);
+    }
+
+// ---------------------------------------------------------------------------------------------------
+
     static int constructor_count{0};
     static int copy_constructor_count{0};
     static int move_constructor_count{0};
@@ -43,6 +80,8 @@ namespace
         DLIB_TEST(move_assign_count == 0);
     }
 
+// ---------------------------------------------------------------------------------------------------
+
     class optional_tester : public tester
     {
     public:
@@ -55,6 +94,7 @@ namespace
         void perform_test (
         )
         {
+            test_optional_int();
             test_constructors();
         }
     } a;

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -111,6 +111,7 @@ namespace
         dlib::optional<int> o1;
         DLIB_TEST(!o1);
         DLIB_TEST(!o1.has_value());
+        DLIB_TEST(o1.value_or(2) == 2);
         int throw_counter{0};
         try  {
             o1.value();
@@ -123,10 +124,12 @@ namespace
         DLIB_TEST(noexcept(o2 = dlib::nullopt));
         DLIB_TEST(!o2);
         DLIB_TEST(!o2.has_value());
+        DLIB_TEST(o2.value_or(3) == 3);
 
         dlib::optional<int> o3 = 42;
         DLIB_TEST(*o3 == 42);
         DLIB_TEST(o3.value() == 42);
+        DLIB_TEST(o3.value_or(3) == 42);
 
         dlib::optional<int> o4 = o3;
         DLIB_TEST(noexcept(o4 = o3));
@@ -193,6 +196,12 @@ namespace
             static_assert(!o4, "bad");
             static_assert(!o5, "bad");
             static_assert(!o6, "bad");
+
+            static_assert(o2.value_or(1) == 1, "bad");
+            static_assert(o3.value_or(1) == 1, "bad");
+            static_assert(o4.value_or(1) == 1, "bad");
+            static_assert(o5.value_or(1) == 1, "bad");
+            static_assert(o6.value_or(1) == 1, "bad");
         }
     }
 

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -110,23 +110,36 @@ namespace
     {
         dlib::optional<int> o1;
         DLIB_TEST(!o1);
+        DLIB_TEST(!o1.has_value());
+        int throw_counter{0};
+        try  {
+            o1.value();
+        } catch(const std::exception& e) {
+            throw_counter++;
+        }
+        DLIB_TEST(throw_counter == 1);
 
         dlib::optional<int> o2 = dlib::nullopt;
         DLIB_TEST(!o2);
+        DLIB_TEST(!o2.has_value());
 
         dlib::optional<int> o3 = 42;
         DLIB_TEST(*o3 == 42);
+        DLIB_TEST(o3.value() == 42);
 
         dlib::optional<int> o4 = o3;
         DLIB_TEST(*o3 == 42);
         DLIB_TEST(*o4 == 42);
+        DLIB_TEST(o4.value() == 42);
 
         dlib::optional<int> o5 = o1;
         DLIB_TEST(!o1);
         DLIB_TEST(!o5);
+        DLIB_TEST(!o5.has_value());
 
         dlib::optional<int> o6 = std::move(o3);
         DLIB_TEST(*o6 == 42);
+        DLIB_TEST(o6.value() == 42);
 
         dlib::optional<short> o7 = (short)42;
         DLIB_TEST(*o7 == 42);
@@ -150,6 +163,11 @@ namespace
         DLIB_TEST(*o11 == 42);
         o11 = (short)12;
         DLIB_TEST(*o11 == 12);
+
+        dlib::optional<int> o12;
+        swap(o12, o4);
+        DLIB_TEST(o12);
+        DLIB_TEST(*o12 == 42);
     }
 
     void test_optional_int_constexpr()
@@ -218,6 +236,7 @@ namespace
         )
         {
             test_optional_int();
+            test_optional_int_constexpr();
             test_constructors();
         }
     } a;

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -13,6 +13,29 @@ namespace
 
 // ---------------------------------------------------------------------------------------------------
 
+    static_assert(std::is_trivially_copy_constructible<dlib::optional<int>>::value, "bad");
+    static_assert(std::is_trivially_copy_assignable<dlib::optional<int>>::value,    "bad");
+    static_assert(std::is_trivially_move_constructible<dlib::optional<int>>::value, "bad");
+    static_assert(std::is_trivially_move_assignable<dlib::optional<int>>::value,    "bad");
+    static_assert(std::is_trivially_destructible<dlib::optional<int>>::value,       "bad");
+
+    struct trivial_type 
+    {
+        trivial_type(const trivial_type&)             = default;
+        trivial_type(trivial_type&&)                  = default;
+        trivial_type& operator=(const trivial_type&)  = default;
+        trivial_type& operator=(trivial_type&&)       = default;
+        ~trivial_type() = default;
+    };
+
+    static_assert(std::is_trivially_copy_constructible<dlib::optional<trivial_type>>::value, "bad");
+    static_assert(std::is_trivially_copy_assignable<dlib::optional<trivial_type>>::value,    "bad");
+    static_assert(std::is_trivially_move_constructible<dlib::optional<trivial_type>>::value, "bad");
+    static_assert(std::is_trivially_move_assignable<dlib::optional<trivial_type>>::value,    "bad");
+    static_assert(std::is_trivially_destructible<dlib::optional<trivial_type>>::value,       "bad");
+
+// ---------------------------------------------------------------------------------------------------
+
     void test_optional_int()
     {
         dlib::optional<int> o1;

--- a/dlib/test/optional.cpp
+++ b/dlib/test/optional.cpp
@@ -177,6 +177,8 @@ namespace
         DLIB_TEST(noexcept(swap(o12, o4)));
     }
 
+// ---------------------------------------------------------------------------------------------------
+
     void test_optional_int_constexpr()
     {
         {
@@ -191,6 +193,41 @@ namespace
             static_assert(!o4, "bad");
             static_assert(!o5, "bad");
             static_assert(!o6, "bad");
+        }
+    }
+
+// ---------------------------------------------------------------------------------------------------
+
+    void test_optional_int_monads()
+    {
+        dlib::optional<int> o1{42};
+
+        {
+            auto res = o1.and_then([](int i) { return dlib::optional<long>(i); });
+
+            static_assert(std::is_same<decltype(res), dlib::optional<long>>::value, "bad map");
+            DLIB_TEST(*res == 42);
+        }
+
+        {
+            auto res = o1.transform([](int i) { return (long)i; });
+
+            static_assert(std::is_same<decltype(res), dlib::optional<long>>::value, "bad map");
+            DLIB_TEST(*res == 42);
+        }
+
+        {
+            auto res = o1.and_then([](int i) { return dlib::optional<std::string>(std::to_string(i)); });
+
+            static_assert(std::is_same<decltype(res), dlib::optional<std::string>>::value, "bad map");
+            DLIB_TEST(*res == "42");
+        }
+
+        {
+            auto res = o1.transform([](int i) { return std::to_string(i); });
+
+            static_assert(std::is_same<decltype(res), dlib::optional<std::string>>::value, "bad map");
+            DLIB_TEST(*res == "42");
         }
     }
 
@@ -244,6 +281,7 @@ namespace
         {
             test_optional_int();
             test_optional_int_constexpr();
+            test_optional_int_monads();
             test_constructors();
         }
     } a;

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -4,7 +4,7 @@
 #define DLIB_UTILITY_Hh_
 
 #include <cstddef>
-#include <type_traits>
+#include <utility>
 
 /*
     This header contains back-ports of C++14/17 functions and type traits

--- a/dlib/utility.h
+++ b/dlib/utility.h
@@ -67,6 +67,15 @@ namespace dlib
     using pop_front_t = typename pop_front<Sequence>::type;
 
     // ---------------------------------------------------------------------
+
+    struct in_place_t 
+    {
+        explicit in_place_t() = default;
+    };
+
+    static constexpr in_place_t in_place{};
+
+    // ---------------------------------------------------------------------
 }
 
 #endif //DLIB_UTILITY_Hh_


### PR DESCRIPTION
This is work in progress.
This is inspired by Sy Brand's tl::optional repo and https://github.com/bitwizeshift/BackportCpp.git
I've tried a few different ways of doing things. For example, i didn't like using `union` but it turns out you can't use `aligned_storage` if you want things to be constexpr and direct initialization to work.
I have to say, this is an education in C++ initialization. It's laughable how complicated an object that is either active or None can be. C++ is so messed up. And yet, I love it 