### PR TITLE
Make cblas libs public

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -589,7 +589,7 @@ if (NOT TARGET dlib)
 
          if (DLIB_USE_BLAS)
             if (blas_found)
-               list (APPEND dlib_needed_private_libraries ${blas_libraries})
+               list (APPEND dlib_needed_public_libraries ${blas_libraries})
             else()
                set(DLIB_USE_BLAS OFF CACHE STRING ${DLIB_USE_BLAS_STR} FORCE )
                toggle_preprocessor_switch(DLIB_USE_BLAS)


### PR DESCRIPTION
Some cblas symbols are called from public matrix headers:
```
2023-06-28T15:54:13.7379840Z Undefined symbols for architecture x86_64:
2023-06-28T15:54:13.7380810Z   "_cblas_daxpy", referenced from:
2023-06-28T15:54:13.7382310Z       dlib::blas_bindings::matrix_assign_blas_helper<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, void>::assign(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&, double, bool, bool) in Dlib.cxx.o
2023-06-28T15:54:13.7387160Z       void dlib::blas_bindings::matrix_assign_blas_proxy<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> >(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix_add_exp<dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> > const&, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true>::type, bool, bool) in Dlib.cxx.o
2023-06-28T15:54:13.7390580Z       void dlib::blas_bindings::matrix_assign_blas<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> >(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix_subtract_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> > const&) in Dlib.cxx.o
2023-06-28T15:54:13.7393210Z       void dlib::blas_bindings::matrix_assign_blas<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> >(dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix_add_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> > const&) in Dlib.cxx.o
2023-06-28T15:54:13.7396740Z       void dlib::blas_bindings::matrix_assign_blas_proxy<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> >(dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix_add_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix_mul_scal_exp<dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, true> > const&, dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>::type, bool, bool) in Dlib.cxx.o
2023-06-28T15:54:13.7398850Z       dlib::blas_bindings::matrix_assign_blas_helper<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, void>::assign(dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix<double, 0l, 1l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&, double, bool, bool) in Dlib.cxx.o
2023-06-28T15:54:13.7400310Z       dlib::blas_bindings::matrix_assign_blas_helper<dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>, void>::assign(dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&, dlib::matrix<double, 0l, 0l, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout> const&, double, bool, bool) in Dlib.cxx.o
2023-06-28T15:54:13.7401210Z       ...
```