### PR TITLE
Remove bug label from the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: Create a bug report.
 title: "[Bug]: "
-labels: bug
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
When I created the issue template, I was expecting that we would get fewer people opening bugs when they can't build dlib, so I added the bug label to all submitted bugs.

However, that is not the case, and we still get bug reports which are not really bugs, and this label prevents the @dlib-issue-bot from closing them if there's no activity.

I think the bug label should only be added manually after verifying that the bug report is actually a bug.