### PR TITLE
Perform convolution with bias addition combined for a specific algorithm 

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -233,17 +233,19 @@ namespace dlib
                        padding_y_,
                        padding_x_);
 
-            conv(false, output,
-                 sub.get_output(),
-                 filters(params,0));
-
-            // For some reason, doing this is sometimes slower than two separate calls
-            // conv(false, output,
-            //     sub.get_output(),
-            //     filters(params,0),
-            //     biases(params, filters.size()));
             if (use_bias)
-                tt::add(1,output,1,biases(params,filters.size()));
+            {
+                conv(false, output,
+                     sub.get_output(),
+                     filters(params,0),
+                     biases(params, filters.size()));
+            }
+            else
+            {
+                conv(false, output,
+                     sub.get_output(),
+                     filters(params,0));
+            }
         }
 
         template <typename SUBNET>


### PR DESCRIPTION
In PR #2656 we talked about separate convolution forward pass and bias addition, because for some reason, it was slower.

I was reading cuDNN documentation (https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnActivationMode_t), and it says that function `cudnnConvolutionBiasActivationForward` with `CUDNN_ACTIVATION_IDENTITY` (as used in dlib at the moment), should only be called with algorithm `CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`. Maybe that's why it was running slower.

In this PR I combined both operations again, but only when forward algorithm is `CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`. I tested it with https://github.com/dlibml/dnn, using alexnet and darknet, and these were the results:

alexnet avg 23451 us -> 23267.5 us (the same)
darknet19 avg 24320 us -> 22226 us (8.6% faster)
darknet53 avg 61156.5 us -> 55745.5 us (8.8% faster)
darknet53csp avg 55172 us -> 47809.5 us (13.34% faster)

Although with AlexNet there was no improvement, it didn't run slower. And with darknet, it was quite faster. Maybe more testing in other gpus would help. Be sure to manually set `forward_best_algo` to `CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM` to test it. Also, remember to use `fuse_layers(net)`, otherwise it won't use the merged layers.