### PR TITLE
Add fuse layers for conv+affine+relu and conv+relu

### DIFF
--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -2647,12 +2647,14 @@ namespace dlib
             resizable_tensor& output,
             const tensor& data,
             const tensor& filters,
-            const tensor& biases
+            const tensor& biases,
+            bool use_relu
         )
         {
             DLIB_CASSERT(filters.num_samples() == biases.k());
             (*this)(add_to_output, output,data,filters);
             tt::add(1, output, 1, biases);
+            if (use_relu) tt::relu(output, output);
         }
 
         void tensor_conv::operator() (
@@ -2660,12 +2662,14 @@ namespace dlib
             tensor& output,
             const tensor& data,
             const tensor& filters,
-            const tensor& biases
+            const tensor& biases,
+            bool use_relu
         )
         {
             DLIB_CASSERT(filters.num_samples() == biases.k());
             (*this)(add_to_output, output, data, filters);
             tt::add(1, output, 1, biases);
+            if (use_relu) tt::relu(output, output);
         }
 
 

--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -603,7 +603,8 @@ namespace dlib
                 resizable_tensor& output,
                 const tensor& data,
                 const tensor& filters,
-                const tensor& biases
+                const tensor& biases,
+                bool use_relu
             );
 
             void operator() (
@@ -611,7 +612,8 @@ namespace dlib
                 tensor& output,
                 const tensor& data,
                 const tensor& filters,
-                const tensor& biases
+                const tensor& biases,
+                bool use_relu
             );
 
             void get_gradient_for_data (

--- a/dlib/cuda/cudnn_dlibapi.h
+++ b/dlib/cuda/cudnn_dlibapi.h
@@ -190,7 +190,8 @@ namespace dlib
                 resizable_tensor& output,
                 const tensor& data,
                 const tensor& filters,
-                const tensor& biases
+                const tensor& biases,
+                bool use_relu
             );
 
             void operator() (
@@ -198,7 +199,8 @@ namespace dlib
                 tensor& output,
                 const tensor& data,
                 const tensor& filters,
-                const tensor& biases
+                const tensor& biases,
+                bool use_relu
             );
 
             void get_gradient_for_data (

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -1047,8 +1047,9 @@ namespace dlib { namespace tt
             tensor& output,
             const tensor& data,
             const tensor& filters,
-            const tensor& biases
-        ) { impl(add_to_output,output,data,filters,biases); }
+            const tensor& biases,
+            bool use_relu
+        ) { impl(add_to_output,output,data,filters,biases,use_relu); }
         /*!
             requires
                 - setup() has been called.  Specifically, setup() has been called like this:
@@ -1069,6 +1070,8 @@ namespace dlib { namespace tt
                   previous values in output.
                 - Adds biases to the result of the convolved data
                 - filters contains filters.num_samples() filters.
+                - If use_relu==true, then a relu activation will be applied to the result
+                  of convolution+bias.
         !*/
 
         void operator() (
@@ -1076,8 +1079,9 @@ namespace dlib { namespace tt
             resizable_tensor& output,
             const tensor& data,
             const tensor& filters,
-            const tensor& biases
-        ) { impl(add_to_output,output,data,filters, biases); }
+            const tensor& biases,
+            bool use_relu
+        ) { impl(add_to_output,output,data,filters,biases,use_relu); }
         /*!
             requires
                 - setup() has been called.  Specifically, setup() has been called like this:

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -287,7 +287,7 @@ namespace dlib
 
         friend void serialize(const con_& item, std::ostream& out)
         {
-            serialize("con_5", out);
+            serialize("con_6", out);
             serialize(item.params, out);
             serialize(item.num_filters_, out);
             serialize(_nr, out);
@@ -303,6 +303,7 @@ namespace dlib
             serialize(item.bias_learning_rate_multiplier, out);
             serialize(item.bias_weight_decay_multiplier, out);
             serialize(item.use_bias, out);
+            serialize(item.use_relu, out);
         }
 
         friend void deserialize(con_& item, std::istream& in)
@@ -313,7 +314,7 @@ namespace dlib
             long nc;
             int stride_y;
             int stride_x;
-            if (version == "con_4" || version == "con_5")
+            if (version == "con_4" || version == "con_5" || version == "con_6")
             {
                 deserialize(item.params, in);
                 deserialize(item.num_filters_, in);
@@ -335,9 +336,13 @@ namespace dlib
                 if (nc != _nc) throw serialization_error("Wrong nc found while deserializing dlib::con_");
                 if (stride_y != _stride_y) throw serialization_error("Wrong stride_y found while deserializing dlib::con_");
                 if (stride_x != _stride_x) throw serialization_error("Wrong stride_x found while deserializing dlib::con_");
-                if (version == "con_5")
+                if (version == "con_5" || version == "con_6")
                 {
                     deserialize(item.use_bias, in);
+                }
+                if (version == "con_6")
+                {
+                    deserialize(item.use_relu, in);
                 }
             }
             else
@@ -369,6 +374,10 @@ namespace dlib
             {
                 out << " use_bias=false";
             }
+            if (item.use_relu)
+            {
+                out << " use_relu="<< std::boolalpha << item.use_relu;
+            }
             return out;
         }
 
@@ -386,7 +395,9 @@ namespace dlib
                 << " weight_decay_mult='"<<item.weight_decay_multiplier<<"'"
                 << " bias_learning_rate_mult='"<<item.bias_learning_rate_multiplier<<"'"
                 << " bias_weight_decay_mult='"<<item.bias_weight_decay_multiplier<<"'"
-                << " use_bias='"<<(item.use_bias?"true":"false")<<"'>\n";
+                << " use_bias='"<<(item.use_bias?"true":"false")<<"'"
+                << " use_relu='"<<(item.use_relu?"true":"false")<<"'"
+                << ">\n";
             out << mat(item.params);
             out << "</con>\n";
         }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -187,7 +187,8 @@ namespace dlib
             num_filters_(item.num_filters_),
             padding_y_(item.padding_y_),
             padding_x_(item.padding_x_),
-            use_bias(item.use_bias)
+            use_bias(item.use_bias),
+            use_relu(item.use_relu)
         {
             // this->conv is non-copyable and basically stateless, so we have to write our
             // own copy to avoid trying to copy it and getting an error.
@@ -213,6 +214,7 @@ namespace dlib
             bias_weight_decay_multiplier = item.bias_weight_decay_multiplier;
             num_filters_ = item.num_filters_;
             use_bias = item.use_bias;
+            use_relu = item.use_relu;
             return *this;
         }
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1847,22 +1847,6 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <typename net_type>
-    void disable_duplicative_biases (
-        const net_type& net
-    );
-    /*!
-        requires
-            - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
-              add_tag_layer.
-        ensures
-            - Disables bias for all bn_ and layer_norm_ inputs.
-            - Sets the get_bias_learning_rate_multiplier() and get_bias_weight_decay_multiplier()
-              to zero of all bn_ and layer_norm_ inputs.
-    !*/
-
-// ----------------------------------------------------------------------------------------
-
     class affine_
     {
         /*!

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -944,7 +944,6 @@ namespace dlib
         /*!
             ensures
                 - relu_is_disabled() returns true
-                - a relu activation will be applied after convolution when calling forward()
         !*/
 
         void enable_relu(
@@ -952,7 +951,6 @@ namespace dlib
         /*!
             ensures
                 - relu_is_disabled() returns false
-                - no relu activation will be applied after convolution when calling forward()
         !*/
 
         bool relu_is_disabled(

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -939,6 +939,30 @@ namespace dlib
                 - #get_bias_weight_decay_multiplier() == val
         !*/
 
+        void disable_relu(
+        );
+        /*!
+            ensures
+                - relu_is_disabled() returns true
+                - a relu activation will be applied after convolution when calling forward()
+        !*/
+
+        void enable_relu(
+        );
+        /*!
+            ensures
+                - relu_is_disabled() returns false
+                - no relu activation will be applied after convolution when calling forward()
+        !*/
+
+        bool relu_is_disabled(
+        ) const;
+        /*!
+            ensures
+                - returns true if relu is disabled for this layer. This means no activation function
+                  will be applied after the convolution when calling forward.
+        !*/
+
         void disable_bias(
         );
         /*!
@@ -2273,6 +2297,15 @@ namespace dlib
 
         relu_(
         );
+
+        void disable(
+        );
+        /*!
+            ensures
+                - #get_layer_params().size() == 0.
+                - when forward_inplace and backward_inplace are called, they return immediately doing nothing.
+                  Causing this layer to trivially perform the an identity transform.
+        !*/
 
         template <typename SUBNET> void setup (const SUBNET& sub);
         void forward_inplace(const tensor& input, tensor& output);

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -3,6 +3,7 @@
 #ifndef DLIB_DNn_VISITORS_H_
 #define DLIB_DNn_VISITORS_H_
 
+#include "visitors_abstract.h"
 #include "input.h"
 #include "layers.h"
 #include "loss.h"

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -401,7 +401,42 @@ namespace dlib
                 // disable other layer types
             }
 
-            // handle the standard case (convolutional layer followed by affine;
+            // handle the case of convolutional layer followed by relu
+            template <long nf, long nr, long nc, int sy, int sx, int py, int px, typename U, typename R>
+            void fuse_convolution(add_layer<relu_, add_layer<con_<nf, nr, nc, sy, sx, py, px>, U>, R>& l)
+            {
+                if (l.layer_details().is_disabled())
+                    return;
+
+                // get the convolution below the relu layer
+                auto& conv = l.subnet().layer_details();
+
+                conv.enable_relu();
+
+                // disable the relu layer
+                l.layer_details().disable();
+            }
+
+            // handle the case of convolutional layer followed by affine followed by relu
+            template <long nf, long nr, long nc, int sy, int sx, int py, int px, typename U, typename E, typename R>
+            void fuse_convolution(add_layer<relu_, add_layer<affine_, add_layer<con_<nf, nr, nc, sy, sx, py, px>, U>, E>, R>& l)
+            {
+                if (l.layer_details().is_disabled())
+                    return;
+
+                // fuse the convolutional layer followed by affine
+                fuse_convolution(l.subnet());
+
+                // get the convolution below the affine layer
+                auto& conv = l.subnet().subnet().layer_details();
+
+                conv.enable_relu();
+
+                // disable the relu layer
+                l.layer_details().disable();
+            }
+
+            // handle the case of convolutional layer followed by affine
             template <long nf, long nr, long nc, int sy, int sx, int py, int px, typename U, typename E>
             void fuse_convolution(add_layer<affine_, add_layer<con_<nf, nr, nc, sy, sx, py, px>, U>, E>& l)
             {

--- a/dlib/dnn/visitors_abstract.h
+++ b/dlib/dnn/visitors_abstract.h
@@ -42,6 +42,11 @@ namespace dlib
             - Disables all the affine_ layers that have a convolution as an input.
             - Updates the convolution weights beneath the affine_ layers to produce the same
               output as with the affine_ layers enabled.
+            - Disables all the relu_ layers that have a convolution as input.
+            - Disables all the relu_ layers that have an affine_ layer as input, with a
+              convolution as input.
+            - Updates the convolution to apply a relu activation function, to produce the same
+              output as with the relu_ layer enabled.
     !*/
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/dnn/visitors_abstract.h
+++ b/dlib/dnn/visitors_abstract.h
@@ -30,6 +30,22 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <typename net_type>
+    void disable_duplicative_biases (
+        const net_type& net
+    );
+    /*!
+        requires
+            - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
+              add_tag_layer.
+        ensures
+            - Disables bias for all bn_ and layer_norm_ inputs.
+            - Sets the get_bias_learning_rate_multiplier() and get_bias_weight_decay_multiplier()
+              to zero of all bn_ and layer_norm_ inputs.
+    !*/
+
+// ----------------------------------------------------------------------------------------
+
+    template <typename net_type>
     void fuse_layers (
         net_type& net
     );


### PR DESCRIPTION
This PR extends the fuse_layers method to also fuse convolutional layers followed by relu, and convolutional layers follower by affine followed by relu.

I tested it with `examples/dnn_mmod_face_detection_ex.cpp` and got exactly the same results on the images shown.

Here are also some tests for different neural networks from https://github.com/dlibml/dnn:
| Name         | master (w/o fusion) | master (w/ fusion) | this PR (w/o fusion) | this PR (w/ fusion) | comparative1 | comparative2 |
| :------------: | :-------------------: | :------------------: | :--------------------: | :-------------------: | :-------------: | :-------------: |
| alexnet      | 9.53                | 9.63               | 9.55                 | 9.45                | 1.84%         | 1.10%         |
| sqznet1.0    | 6.53                | 6.00               | 6.40                 | 4.47                | 25.60%        | 30.25%        |
| sqznet1.1    | 4.41                | 3.90               | 4.41                 | 3.01                | 22.86%        | 31.76%        |
| vggnet11     | 37.00               | 34.46              | 36.76                | 32.77               | 4.91%         | 10.87%        |
| vggnet13     | 46.94               | 43.90              | 47.31                | 41.06               | 6.47%         | 13.21%        |
| vggnet16     | 58.80               | 54.87              | 58.01                | 52.29               | 4.71%         | 9.86%         |
| vggnet19     | 68.32               | 65.11              | 69.29                | 61.89               | 4.95%         | 10.69%        |
| googlenet    | 9.95                | 9.54               | 10.09                | 8.53                | 10.61%        | 15.50%        |
| resnet18     | 7.66                | 7.39               | 7.68                 | 6.86                | 7.23%         | 10.64%        |
| resnet34     | 13.90               | 13.67              | 13.90                | 12.77               | 6.57%         | 8.10%         |
| resnet50     | 22.41               | 20.11              | 22.41                | 18.89               | 6.07%         | 15.71%        |
| resnet101    | 39.15               | 35.72              | 38.39                | 33.73               | 5.56%         | 12.13%        |
| resnet152    | 54.98               | 50.76              | 55.03                | 48.44               | 4.57%         | 11.98%        |
| darknet19    | 13.55               | 12.43              | 13.54                | 12.53               | \-0.79%       | 7.51%         |
| darknet53    | 32.70               | 30.87              | 32.36                | 30.63               | 0.80%         | 5.36%         |
| darknet53csp | 26.47               | 23.36              | 26.60                | 23.48               | \-0.53%       | 11.73%        |
| densenet121  | 21.57               | 20.33              | 21.57                | 20.12               | 1.03%         | 6.71%         |
| densenet169  | 28.50               | 27.13              | 28.43                | 25.66               | 5.43%         | 9.76%         |
| densenet201  | 38.60               | 37.17              | 38.52                | 35.65               | 4.10%         | 7.45%         |
| densenet265  | 55.85               | 54.43              | 55.81                | 52.72               | 3.13%         | 5.53%         |
| densenet161  | 49.80               | 47.90              | 49.71                | 45.74               | 4.52%         | 7.99%         |
| vovnet19s    | 6.84                | 6.39               | 6.85                 | 5.05                | 20.88%        | 26.23%        |
| vovnet19     | 14.25               | 13.85              | 14.18                | 11.57               | 16.47%        | 18.41%        |
| vovnet27s    | 8.31                | 7.84               | 8.31                 | 6.25                | 20.31%        | 24.81%        |
| vovnet27     | 18.32               | 17.67              | 18.32                | 15.28               | 13.54%        | 16.61%        |
| vovnet39     | 23.69               | 23.30              | 23.53                | 20.21               | 13.23%        | 14.11%        |
| vovnet57     | 31.00               | 30.81              | 31.02                | 27.41               | 11.03%        | 11.63%        |
| vovnet99     | 56.88               | 56.44              | 56.31                | 51.45               | 8.84%         | 8.64%         |
| repvgg_a0    | 6.47                | 5.67               | 6.38                 | 4.96                | 12.52%        | 22.22%        |
| repvgg_a1    | 8.01                | 8.06               | 8.04                 | 7.23                | 10.30%        | 10.14%        |
| repvgg_a2    | 19.50               | 19.46              | 19.35                | 18.01               | 7.49%         | 6.95%         |
| repvgg_b0    | 10.16               | 10.17              | 10.04                | 8.88                | 12.61%        | 11.54%        |
| repvgg_b1    | 42.13               | 42.18              | 42.12                | 39.34               | 6.72%         | 6.60%         |
| repvgg_b2    | 59.09               | 59.01              | 58.67                | 55.87               | 5.32%         | 4.78%         |
| repvgg_b3    | 82.28               | 82.40              | 82.66                | 79.12               | 3.97%         | 4.28%         |

_comparative1: measures how much faster the model run with the new fuse_layers compared to the current fuse_layers._
_comparative2: measures how much faster the model run with the new fuse_layers compared to not using fuse_layers._

I left the measurements before the fusion to be sure that the different runs used the same convolutional algorithms in cuDNN. Every time they differed by more than 2% up or down, I ran those tests again.
