### PR TITLE
updated cudnn path

### DIFF
--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -4,7 +4,7 @@ message(STATUS "Looking for cuDNN install...")
 # libraries and also a few other places as well.
 find_path(cudnn_include cudnn.h
     HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
-    PATHS /usr/local ENV CPATH
+    PATHS /usr/local/cuda ENV CPATH
     PATH_SUFFIXES include
     )
 get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)

--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -4,7 +4,9 @@ message(STATUS "Looking for cuDNN install...")
 # libraries and also a few other places as well.
 find_path(cudnn_include cudnn.h
     HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
-    PATHS /usr/local/cuda ENV CPATH
+    PATHS /usr/local 
+    PATHS /usr/local/cuda 
+    ENV CPATH
     PATH_SUFFIXES include
     )
 get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)

--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -4,9 +4,7 @@ message(STATUS "Looking for cuDNN install...")
 # libraries and also a few other places as well.
 find_path(cudnn_include cudnn.h
     HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
-    PATHS /usr/local 
-    PATHS /usr/local/cuda 
-    ENV CPATH
+    PATHS /usr/local /usr/local/cuda ENV CPATH
     PATH_SUFFIXES include
     )
 get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)


### PR DESCRIPTION
I faced an issue as neither CUDNN_INCLUDE_DIR nor CUDNN_HOME environment variables were set. This resulted in a "Found cuDNN" error. Therefore, I updated the path with /cuda, as it was most suggested installation path for installing cudnn.