### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/dlib/gui_core/gui_core_kernel_2.cpp
+++ b/dlib/gui_core/gui_core_kernel_2.cpp
@@ -1614,9 +1614,9 @@ namespace dlib
             char **mlist;
             int mcount;
             char *def_str;
-            char fontset[256];
+            char fontset[256] = {0};
             const long native_font_height = 12;
-            sprintf(fontset, "-*-*-medium-r-normal--%lu-*-*-*-", native_font_height);
+            snprintf(fontset, sizeof(fontset), "-*-*-medium-r-normal--%lu-*-*-*-", native_font_height);
             x11_stuff.fs = XCreateFontSet(x11_stuff.globals->disp, fontset, &mlist, &mcount, &def_str);
             xpoint.x = 0;
             xpoint.y = 0;

--- a/dlib/gui_widgets/nativefont.h
+++ b/dlib/gui_widgets/nativefont.h
@@ -345,14 +345,13 @@ namespace nativefont
 
                         cmap = DefaultColormap(d, DefaultScreen(d));
                     }
-                    char fontset[256];
+                    char fontset[256] = {0};
                     {
-                        char *p = fontset;
-                        p += sprintf(fontset, "-*-*-%s-%c-normal--%d-*-*-*-%c",
-                                     bold ? "bold" : "medium", italic ? 'i' : 'r', height_want, fixed ? 'c' : 'p');
+                        int offset = snprintf(fontset, sizeof(fontset), "-*-*-%s-%c-normal--%d-*-*-*-%c",
+                                              bold ? "bold" : "medium", italic ? 'i' : 'r', height_want, fixed ? 'c' : 'p');
                         if (fixed){
-                            sprintf(p, ",-*-*-%s-%c-normal--%d-*-*-*-m",
-                                    bold ? "bold" : "medium", italic ? 'i' : 'r', height_want);
+                            snprintf(&fontset[offset], sizeof(fontset) - offset, ",-*-*-%s-%c-normal--%d-*-*-*-m",
+                                     bold ? "bold" : "medium", italic ? 'i' : 'r', height_want);
                         }
                     }
                     bool equal_font;

--- a/dlib/http_client/http_client.cpp
+++ b/dlib/http_client/http_client.cpp
@@ -119,7 +119,7 @@ namespace dlib
 #ifdef __WXMSW__
         ::ltoa(header_value, buf, 10);
 #else
-        sprintf(buf, "%ld", header_value);
+        snprintf(buf, sizeof(buf), "%ld", header_value);
 #endif
         set_header(header_name, buf);
     }
@@ -154,7 +154,7 @@ namespace dlib
 #ifdef __WXMSW__
         ::ltoa(cookie_value, buf, 10);
 #else
-        sprintf(buf, "%ld", cookie_value);
+        snprintf(buf, sizeof(buf), "%ld", cookie_value);
 #endif
         set_cookie(cookie_name, buf);
     }


### PR DESCRIPTION
Apple Clang complains about sprintf and suggests using snprintf due to CVE bugs.