### PR TITLE
[FFMPEG] bug fix in demuxer when more than 2 streams are present

### DIFF
--- a/dlib/media/ffmpeg_demuxer.h
+++ b/dlib/media/ffmpeg_demuxer.h
@@ -1475,7 +1475,7 @@ namespace dlib
             {
                 ok = parse();
 
-                if (ok && st.packet->size > 0)
+                if (ok && channel && st.packet->size > 0)
                 {
                     // Decode
                     ok = channel->push(st.packet, wrap(st.frame_queue));


### PR DESCRIPTION
This is an urgent bug fix. Also, I can smell a dlib release coming. This needs to go in before that happens.