### PR TITLE
Remove cmake from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It should be used system cmake instead of compiling own package. Compiling cmake is problematic because it takes a long time and needs a lot of additional packages that many systems doesn't provide.