### PR TITLE
Handled equality case

### DIFF
--- a/dlib/image_processing/box_overlap_testing.h
+++ b/dlib/image_processing/box_overlap_testing.h
@@ -93,9 +93,9 @@ namespace dlib
                 return false;
 
             const double outer = (a+b).area();
-            if (inner/outer > iou_thresh || 
-                inner/a.area() > percent_covered_thresh || 
-                inner/b.area() > percent_covered_thresh)
+            if (inner/outer >= iou_thresh || 
+                inner/a.area() >= percent_covered_thresh || 
+                inner/b.area() >= percent_covered_thresh)
                 return true;
             else
                 return false;


### PR DESCRIPTION
Without equality, say if, `percent_covered_thresh == 1` and `iou_thresh == 1`, then the operator() would return `False` when there is indeed 100% overlap.