### PR TITLE
loss_barlow_twins: add get_eccm member function

### DIFF
--- a/dlib/dnn/loss.h
+++ b/dlib/dnn/loss.h
@@ -4154,6 +4154,9 @@ namespace dlib
 
         float get_lambda() const  { return lambda; }
 
+        tensor& get_eccm() { return eccm; }
+        const tensor& get_eccm() const { return eccm; }
+
         friend void serialize(const loss_barlow_twins_& item, std::ostream& out)
         {
             serialize("loss_barlow_twins_", out);

--- a/dlib/dnn/loss_abstract.h
+++ b/dlib/dnn/loss_abstract.h
@@ -2144,6 +2144,20 @@ namespace dlib
                   in WHAT THIS OBJECT REPRESENTS for details.
         !*/
 
+        tensor& get_eccm();
+        /*!
+            ensures
+                - returns the empirical cross-correlation matrix computed by the loss.
+                - this is only meant to be used for visualization/debugging purposes.
+        !*/
+
+        const tensor& get_eccm() const;
+        /*!
+            ensures
+                - returns the empirical cross-correlation matrix computed by the loss.
+                - this is only meant to be used for visualization/debugging purposes.
+        !*/
+
         template <
             typename SUBNET
         >


### PR DESCRIPTION
This allows us to greatly simplify the self supervised learning example:
- the computation in user code was a bit too distracting
- avoids duplicated computation/allocation of this matrix
- avoids edge case where net outputs are zero due to trainer synchronization