### PR TITLE
Return shortcut in disturb_colors

### DIFF
--- a/dlib/image_transforms/random_color_transform.h
+++ b/dlib/image_transforms/random_color_transform.h
@@ -75,6 +75,9 @@ namespace dlib
         const double color_magnitude = 0.2
     )
     {
+        if (gamma_magnitude == 0 && color_magniture == 0)
+            return;
+
         image_view<image_type> img(img_);
         random_color_transform tform(rnd, gamma_magnitude, color_magnitude);
         for (long r = 0; r < img.nr(); ++r)

--- a/dlib/image_transforms/random_color_transform.h
+++ b/dlib/image_transforms/random_color_transform.h
@@ -75,7 +75,7 @@ namespace dlib
         const double color_magnitude = 0.2
     )
     {
-        if (gamma_magnitude == 0 && color_magniture == 0)
+        if (gamma_magnitude == 0 && color_magnitude == 0)
             return;
 
         image_view<image_type> img(img_);


### PR DESCRIPTION
No need to do anything if both gamma and color magnitudes are set to 0.