### PR TITLE
Use STD in testing suite

### DIFF
--- a/dlib/test/main.cpp
+++ b/dlib/test/main.cpp
@@ -34,10 +34,9 @@ int main (int argc, char** argv)
         unsigned long num = 1;
 
         // add the options for all the different tests
-        testers().reset();
-        while (testers().move_next())
+        for (auto& kv : testers())
         {
-            tester& test = *testers().element().value();
+            tester& test = *kv.second;
             parser.add_option(test.cmd_line_switch(), test.description(), test.num_of_args());
             if (test.num_of_args()==0) 
                 parser.add_option("no_"+test.cmd_line_switch(), "Don't run this option when using --runall.");
@@ -111,10 +110,9 @@ int main (int argc, char** argv)
             dlog << LINFO << "************ Starting Test Run " << i+1 << " of " << num << ". ************";
 
             // loop over all the testers and see if they are supposed to run
-            testers().reset();
-            while (testers().move_next())
+            for(auto& kv : testers())
             {
-                tester& test= *testers().element().value();
+                tester& test= *kv.second;
                 const clp::option_type& opt = parser.option(test.cmd_line_switch());
                 // run the test for this option as many times as the user has requested.
                 for (unsigned long j = 0; j < parser.option("runall").count() + opt.count(); ++j)

--- a/dlib/test/tester.cpp
+++ b/dlib/test/tester.cpp
@@ -16,7 +16,7 @@ namespace test
 // -----------------------------------------------------------------------------
 
     static std::mutex spinner_mutex;
-    static std::atomic<uint64_t> test_count = 0;
+    static std::atomic<uint64_t> test_count(0);
 
 // -----------------------------------------------------------------------------
 

--- a/dlib/test/tester.cpp
+++ b/dlib/test/tester.cpp
@@ -2,9 +2,10 @@
 // License: Boost Software License   See LICENSE.txt for the full license.
 
 #include <string>
-#include "tester.h"
 #include <cstdlib>
-#include <dlib/threads.h>
+#include <atomic>
+#include <mutex>
+#include "tester.h"
 
 namespace test
 {
@@ -14,25 +15,21 @@ namespace test
 
 // -----------------------------------------------------------------------------
 
-    static dlib::mutex spinner_mutex;
-    static dlib::mutex test_count_mutex;
-    dlib::uint64 test_count = 0;
+    static std::mutex spinner_mutex;
+    static std::atomic<uint64_t> test_count = 0;
 
 // -----------------------------------------------------------------------------
 
-    dlib::uint64 number_of_testing_statements_executed (
+    std::uint64_t number_of_testing_statements_executed (
     )
     {
-        dlib::auto_mutex lock(test_count_mutex);
         return test_count;
     }
 
     void increment_test_count (
     )
     {
-        test_count_mutex.lock();
         ++test_count;
-        test_count_mutex.unlock();
     }
 
 // -----------------------------------------------------------------------------
@@ -44,9 +41,7 @@ namespace test
         const char* _exp_str
     )
     {
-        test_count_mutex.lock();
         ++test_count;
-        test_count_mutex.unlock();
         if ( !(_exp) )                                                         
         {                                                                       
             std::ostringstream dlib_o_out;                                       
@@ -79,15 +74,13 @@ namespace test
         num_of_args_(num_of_args_x)
     {
         using namespace std;
-        if (testers().is_in_domain(switch_name))
+        if (testers().find(switch_name) != testers().end())
         {
             cerr << "ERROR: More than one tester has been defined with the switch '" << switch_name << "'." << endl;
             exit(1);
         }
 
-        string temp(switch_name);
-        tester* t = this;
-        testers().add(temp,t);
+        testers()[switch_name] = this;
     }
 
 // -----------------------------------------------------------------------------
@@ -152,7 +145,7 @@ namespace test
         if (be_verbose)
         {
             using namespace std;
-            dlib::auto_mutex M(spinner_mutex);
+            std::unique_lock<std::mutex> M(spinner_mutex);
             static int i = 0;
             cout << "\b\b";
             switch (i)

--- a/dlib/test/tester.h
+++ b/dlib/test/tester.h
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #include <string>
-#include <dlib/map.h>
+#include <map>
 #include <dlib/logger.h>
 #include <dlib/assert.h>
 #include <dlib/algs.h>
@@ -33,7 +33,7 @@
 namespace test
 {
     class tester;
-    typedef dlib::map<std::string,tester*>::kernel_1a_c map_of_testers;
+    using map_of_testers = std::map<std::string,tester*>;
 
     map_of_testers& testers (
     );
@@ -55,7 +55,7 @@ namespace test
 
 // -----------------------------------------------------------------------------
 
-    dlib::uint64 number_of_testing_statements_executed (
+    std::uint64_t number_of_testing_statements_executed (
     );
     /*!
         ensures


### PR DESCRIPTION
I stumbled across this while doing the CMake stuff.
I don't see any good reason why it's using dlib's own map container when there is a perfectly good one in STL. Also, use std::mutex and std::atomic instead of dlib pthread wrappers.