### PR TITLE
CMake: Set LAPACK libs as public

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -622,7 +622,7 @@ if (NOT TARGET dlib)
 
          if (DLIB_USE_LAPACK)
             if (lapack_found)
-               list (APPEND dlib_needed_private_libraries ${lapack_libraries})
+               list (APPEND dlib_needed_public_libraries ${lapack_libraries})
                if (lapack_with_underscore)
                   set(LAPACK_FORCE_UNDERSCORE 1)
                   enable_preprocessor_switch(LAPACK_FORCE_UNDERSCORE)


### PR DESCRIPTION
lapack/cblas libs are needed through the dlib/matrix/lapack headers

it can be verified on the optimization example:
https://github.com/jschueller/dlib-cmake-example