### PR TITLE
Add missing magic number for JPEG XL

### DIFF
--- a/dlib/image_loader/load_image.h
+++ b/dlib/image_loader/load_image.h
@@ -57,11 +57,12 @@ namespace dlib
                 return DNG;
             else if (buffer[0]=='G' && buffer[1]=='I' && buffer[2] == 'F') 
                 return GIF;
+            else if ((buffer[0] == '\xff' && buffer[1] == '\x0a') ||
+                      memcmp(buffer, jxlHeader, 12) == 0)  // we can't use strlen because the header starts with \x00.
+                return JXL;
             else if (buffer[0]=='R' && buffer[1]=='I' && buffer[2] == 'F' && buffer[3] == 'F' &&
                     buffer[8]=='W' && buffer[9]=='E' && buffer[10] == 'B' && buffer[11] == 'P')
                 return WEBP;
-            else if (memcmp(buffer, jxlHeader, 12) == 0)  // we can't use strlen because the header starts with \x00.
-                return JXL;
 
             return UNKNOWN;
         }

--- a/dlib/image_saver/save_jxl.cpp
+++ b/dlib/image_saver/save_jxl.cpp
@@ -34,11 +34,6 @@ namespace dlib {
             }
 
             auto enc = JxlEncoderMake(nullptr);
-            if (JXL_ENC_SUCCESS != JxlEncoderUseContainer(enc.get(), JXL_TRUE))
-            {
-                throw image_save_error("jxl_saver: JxlEncoderUseContainer failed");
-            }
-
             auto runner = JxlResizableParallelRunnerMake(nullptr);
             JxlResizableParallelRunnerSetThreads(runner.get(), JxlResizableParallelRunnerSuggestThreads(width, height));
 


### PR DESCRIPTION
For some reason, JPEG XL can have two magic numbers. Adding the one that was missing here.