### PR TITLE
Fix incorrect version check for libgif

### DIFF
--- a/dlib/image_loader/load_image.h
+++ b/dlib/image_loader/load_image.h
@@ -71,7 +71,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
 // handle the differences in API between libgif v5 and older.
-#if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5
+#if defined(GIFLIB_MAJOR) && (GIFLIB_MAJOR > 5 || (GIFLIB_MAJOR == 5 && defined(GIFLIB_MINOR) && GIFLIB_MINOR >= 1))
 #define DLIB_GIFLIB_HANDLE_DIFF_VERSIONS ,0
 #else
 #define DLIB_GIFLIB_HANDLE_DIFF_VERSIONS 


### PR DESCRIPTION
This PR addresses an issue in the handling of API differences between various versions of the libgif library. Previously, the version check only accounted for the major version number, specifically checking if the GIFLIB_MAJOR version was 5 or higher. This approach did not correctly handle the API changes introduced in libgif version 5.1.0, leading to compilation issues with versions 5.0.X, where the API differences are still relevant.

The proposed change enhances the version check to consider both the major and minor version numbers. This ensures that the specific API changes introduced in version 5.1.0 and onwards are accurately accounted for, thus maintaining compatibility with version 5.0.X and addressing the compilation issues encountered.