### PR TITLE
Reduce FOREVER from 290 to 200 years

### DIFF
--- a/dlib/global_optimization/find_max_global.h
+++ b/dlib/global_optimization/find_max_global.h
@@ -114,7 +114,7 @@ template <typename T> static auto go(T&& f, const matrix<double, 0, 1>& a) -> de
 
 // ----------------------------------------------------------------------------------------
 
-    const auto FOREVER = std::chrono::hours(24*365*290); // 290 years
+    const auto FOREVER = std::chrono::hours(24*365*200); // 200 years
     using stop_condition = std::function<bool(double)>;
     const stop_condition never_stop_early = [](double) { return false; };
 

--- a/dlib/global_optimization/find_max_global_abstract.h
+++ b/dlib/global_optimization/find_max_global_abstract.h
@@ -68,7 +68,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    const auto FOREVER = std::chrono::hours(24*356*290); // 290 years, basically forever
+    const auto FOREVER = std::chrono::hours(24*356*200); // 200 years, basically forever
 
     /*!
        WHAT THIS OBJECT REPRESENTS


### PR DESCRIPTION
Prevents wrap observed in emcc, causing find_max_global to exit immediately unless a custom (and non-wrapping) max_runtime is provided.