### PR TITLE
Remove MMX header

### DIFF
--- a/dlib/simd/simd_check.h
+++ b/dlib/simd/simd_check.h
@@ -91,7 +91,6 @@
 #ifdef DLIB_HAVE_SSE2
     #include <xmmintrin.h>
     #include <emmintrin.h>
-    #include <mmintrin.h>
 #endif
 #ifdef DLIB_HAVE_SSE3
     #include <pmmintrin.h> // SSE3


### PR DESCRIPTION
MMX is not actually used by dlib and including the header breaks SIMD support detection and usage on platforms that support SSE but not MMX, such as emcc