### PR TITLE
global_optimization: add template argument list

### DIFF
--- a/dlib/global_optimization/find_max_global.h
+++ b/dlib/global_optimization/find_max_global.h
@@ -58,7 +58,7 @@ namespace dlib
             }
 
             template <typename T>
-            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(call_function_and_expand_args<max_unpack-1>::template go(std::forward<T>(f),a))
+            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(call_function_and_expand_args<max_unpack-1>::template go<T>(std::forward<T>(f),a))
             {
                 return call_function_and_expand_args<max_unpack-1>::go(std::forward<T>(f),a);
             }


### PR DESCRIPTION
Fixes error (``-Wmissing-template-arg-list-after-template-kw``) from clang-19 compiler.
