### PR TITLE
Add RMS Normalization Layer

### DIFF
--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1499,7 +1499,8 @@ namespace dlib
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
-            tensor& gamma_grad
+            tensor& gamma_grad,
+            tensor& dscale
         )
         {
             const long num = src.k() * src.nr() * src.nc();
@@ -1519,8 +1520,6 @@ namespace dlib
             const auto p_gamma_grad = gamma_grad.host();
             const auto p_scale = scale.host();
 
-            resizable_tensor dscale;
-            dscale.copy_size(scale);
             dscale = 0;
             const auto p_dscale = dscale.host();
 

--- a/dlib/cuda/cpu_dlib.cpp
+++ b/dlib/cuda/cpu_dlib.cpp
@@ -1431,6 +1431,132 @@ namespace dlib
             }
         }
 
+// -----------------------------------------------------------------------------------
+
+        void rms_normalize(
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& scale,
+            const tensor& src,
+            const tensor& gamma
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(
+                src.k() == gamma.k() &&
+                src.nr() == gamma.nr() &&
+                src.nc() == gamma.nc() &&
+                eps > 0,
+                "\ngamma.k():  " << gamma.k() <<
+                "\ngamma.nr(): " << gamma.nr() <<
+                "\ngamma.nc(): " << gamma.nc() <<
+                "\nsrc.k():    " << src.k() <<
+                "\nsrc.nr():   " << src.nr() <<
+                "\nsrc.nc():   " << src.nc() <<
+                "\neps:  " << eps
+            );
+
+            dest.copy_size(src);
+            scale.set_size(src.num_samples());
+
+            // Compute RMS            
+            const auto p_scale = scale.host();
+            auto p_src = src.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                float sum_squares = 0;
+                for (long i = 0; i < num; ++i)
+                {
+                    float val = p_src[n * num + i];
+                    sum_squares += val * val;
+                }
+                p_scale[n] = sum_squares / num;
+            }
+            // Compute RMS inverse
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                p_scale[n] = 1.0f / std::sqrt(p_scale[n] + eps);
+            }
+
+            p_src = src.host();
+            auto p_dest = dest.host();
+            auto p_gamma = gamma.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    *p_dest = (*p_src) * p_scale[n] * p_gamma[i];
+                    ++p_src;
+                    ++p_dest;
+                }
+            }
+        }
+
+        void rms_normalize_gradient(
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& scale,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(src.num_samples() == scale.size());
+            DLIB_CASSERT(src.k() == gamma.k());
+            DLIB_CASSERT(src.nr() == gamma.nr());
+            DLIB_CASSERT(src.nc() == gamma.nc());
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src));
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src_grad));
+            DLIB_CASSERT(have_same_dimensions(gamma_grad, gamma));
+            DLIB_CASSERT(eps > 0);
+
+            gamma_grad = 0;
+            auto p_grad = gradient_input.host();
+            auto p_src = src.host();
+            const auto p_gamma = gamma.host();
+            const auto p_gamma_grad = gamma_grad.host();
+            const auto p_scale = scale.host();
+
+            resizable_tensor dscale;
+            dscale.copy_size(scale);
+            dscale = 0;
+            const auto p_dscale = dscale.host();
+
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    const float x_hat = (*p_src) * p_scale[n];
+                    p_gamma_grad[i] += (*p_grad) * x_hat;
+
+                    const float dx = *p_grad * p_gamma[i];
+                    p_dscale[n] += dx * (*p_src) * (-0.5) * p_scale[n] * p_scale[n] * p_scale[n];
+
+                    ++p_grad;
+                    ++p_src;
+                }
+            }
+
+            p_grad = gradient_input.host();
+            p_src = src.host();
+            auto p_src_grad = src_grad.host();
+            for (long n = 0; n < src.num_samples(); ++n)
+            {
+                for (long i = 0; i < num; ++i)
+                {
+                    const float dx = *p_grad * p_gamma[i];
+
+                    *p_src_grad += dx * p_scale[n] + p_dscale[n] * 2 * (*p_src) / num;
+
+                    ++p_grad;
+                    ++p_src;
+                    ++p_src_grad;
+                }
+            }
+        }
+
     // -----------------------------------------------------------------------------------
 
         void threshold (

--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -266,14 +266,13 @@ namespace dlib
         );
 
         void rms_normalize_gradient(
-            const double eps,
             const tensor& gradient_input,
             const tensor& scale,
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
             tensor& gamma_grad,
-            tensor& dscale
+            resizable_tensor& dscale
         );
 
     // -----------------------------------------------------------------------------------

--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -253,6 +253,26 @@ namespace dlib
             tensor& beta_grad
         );
 
+   // -----------------------------------------------------------------------------------
+
+        void rms_normalize(
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& scale,
+            const tensor& src,
+            const tensor& gamma
+        );
+
+        void rms_normalize_gradient(
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& scale,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad
+        );
+
     // -----------------------------------------------------------------------------------
 
         void threshold (

--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -270,7 +270,8 @@ namespace dlib
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
-            tensor& gamma_grad
+            tensor& gamma_grad,
+            tensor& dscale
         );
 
     // -----------------------------------------------------------------------------------

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -2345,7 +2345,8 @@ namespace dlib
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
-            tensor& gamma_grad
+            tensor& gamma_grad,
+            tensor& dscale
         )
         {
             const long num = src.k() * src.nr() * src.nc();
@@ -2359,8 +2360,6 @@ namespace dlib
             DLIB_CASSERT(eps > 0);
 
             gamma_grad = 0;
-            resizable_tensor dscale;
-            dscale.copy_size(scale);
             dscale = 0;
             launch_kernel(_cuda_rms_normalize_gradient, max_jobs(num, src.num_samples()),
                 src_grad.device(), gamma_grad.device(), src.device(),

--- a/dlib/cuda/cuda_dlib.cu
+++ b/dlib/cuda/cuda_dlib.cu
@@ -2242,6 +2242,132 @@ namespace dlib
                           dmeans.device(), dvars.device(), eps, src.num_samples(), num);
         }
 
+   // ----------------------------------------------------------------------------------------
+
+        __global__ void _cuda_rms_normalize(float* out, const float* s, float* scale, const float* g, float eps, size_t ns, size_t num)
+        {
+            // Compute sum of squares
+            for (auto n : grid_stride_range_y(0, ns))
+            {
+                auto p = s + n * num;
+                float sum_squares = 0;
+                for (auto i : grid_stride_range(0, num))
+                {
+                    sum_squares += p[i] * p[i];
+                }
+                warp_reduce_atomic_add(scale[n], sum_squares / num);
+            }
+            __syncthreads();
+
+            // Compute RMS inverse
+            for (auto n : grid_stride_range_y(0, ns))
+            {
+                for (auto i : grid_stride_range(0, 1))
+                {
+                    scale[n] = 1.0f / std::sqrt(scale[n] + eps);
+                }
+            }
+            __syncthreads();
+
+            for (auto n : grid_stride_range_y(0, ns))
+            {
+                for (auto i : grid_stride_range(0, num))
+                {
+                    const float val = s[n * num + i] * scale[n];
+                    out[n * num + i] = val * g[i];
+                }
+            }
+        }
+
+        __global__ void _cuda_rms_normalize_gradient(float* out, float* gg, const float* s, const float* gi, const float* scale, const float* g, float* dscale, float eps, size_t ns, size_t num)
+        {
+            for (auto n : grid_stride_range_y(0, ns))
+            {
+                float temp_dscale = 0;
+                for (auto i : grid_stride_range(0, num))
+                {
+                    auto idx = n * num + i;
+                    const float x_hat = s[idx] * scale[n];
+                    gg[i] += gi[idx] * x_hat;
+
+                    const float dx = gi[idx] * g[i];
+                    temp_dscale += dx * s[idx] * -0.5 * scale[n] * scale[n] * scale[n];
+                }
+                warp_reduce_atomic_add(dscale[n], temp_dscale);
+            }
+            __syncthreads();
+
+            for (auto n : grid_stride_range_y(0, ns))
+            {
+                for (auto i : grid_stride_range(0, num))
+                {
+                    auto idx = n * num + i;
+                    const float dx = gi[idx] * g[i];
+                    out[idx] += dx * scale[n] + dscale[n] * 2 * s[idx] / num;
+                }
+            }
+        }
+
+        void rms_normalize(
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& scale,
+            const tensor& src,
+            const tensor& gamma
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(
+                src.k() == gamma.k() &&
+                src.nr() == gamma.nr() &&
+                src.nc() == gamma.nc() &&
+                eps > 0,
+                "\ngamma.k():  " << gamma.k() <<
+                "\ngamma.nr(): " << gamma.nr() <<
+                "\ngamma.nc(): " << gamma.nc() <<
+                "\nsrc.k():    " << src.k() <<
+                "\nsrc.nr():   " << src.nr() <<
+                "\nsrc.nc():   " << src.nc() <<
+                "\neps:  " << eps
+            );
+
+            dest.copy_size(src);
+            scale.set_size(src.num_samples());
+            scale = 0;
+            launch_kernel(_cuda_rms_normalize, max_jobs(num, src.num_samples()), dest.device(), src.device(),
+                scale.device(), gamma.device(), eps, src.num_samples(), num);
+        }
+
+        void rms_normalize_gradient(
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& scale,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad
+        )
+        {
+            const long num = src.k() * src.nr() * src.nc();
+            DLIB_CASSERT(src.num_samples() == scale.size());
+            DLIB_CASSERT(src.k() == gamma.k());
+            DLIB_CASSERT(src.nr() == gamma.nr());
+            DLIB_CASSERT(src.nc() == gamma.nc());
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src));
+            DLIB_CASSERT(have_same_dimensions(gradient_input, src_grad));
+            DLIB_CASSERT(have_same_dimensions(gamma_grad, gamma));
+            DLIB_CASSERT(eps > 0);
+
+            gamma_grad = 0;
+            resizable_tensor dscale;
+            dscale.copy_size(scale);
+            dscale = 0;
+            launch_kernel(_cuda_rms_normalize_gradient, max_jobs(num, src.num_samples()),
+                src_grad.device(), gamma_grad.device(), src.device(),
+                gradient_input.device(), scale.device(), gamma.device(),
+                dscale.device(), eps, src.num_samples(), num);
+        }
+
     // ----------------------------------------------------------------------------------------
 
         __global__ void _cuda_copy_tensor_add_to (float* dest, size_t size,  const float* src,  size_t dest_stride, size_t src_stride, size_t block_size)

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -373,14 +373,13 @@ namespace dlib
         );
 
         void rms_normalize_gradient(
-            const double eps,
             const tensor& gradient_input,
             const tensor& scale,
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
             tensor& gamma_grad,
-            tensor& dscale
+            resizable_tensor& dscale
         );
 
     // -----------------------------------------------------------------------------------

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -360,6 +360,26 @@ namespace dlib
             tensor& beta_grad
         );
 
+   // -----------------------------------------------------------------------------------
+
+        void rms_normalize(
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& scale,
+            const tensor& src,
+            const tensor& gamma
+        );
+
+        void rms_normalize_gradient(
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& scale,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad
+        );
+
     // -----------------------------------------------------------------------------------
 
         void threshold (

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -377,7 +377,8 @@ namespace dlib
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
-            tensor& gamma_grad
+            tensor& gamma_grad,
+            tensor& dscale
         );
 
     // -----------------------------------------------------------------------------------

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -714,20 +714,19 @@ namespace dlib { namespace tt
     }
 
     void rms_normalize_gradient(
-        const double eps,
         const tensor& gradient_input,
         const tensor& scale,
         const tensor& src,
         const tensor& gamma,
         tensor& src_grad,
         tensor& gamma_grad,
-        tensor& dscale
+        resizable_tensor& dscale
     )
     {            
 #ifdef DLIB_USE_CUDA
-        cuda::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
+        cuda::rms_normalize_gradient(gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
 #else
-        cpu::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
+        cpu::rms_normalize_gradient(gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
 #endif
     }
 

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -696,6 +696,40 @@ namespace dlib { namespace tt
 
 // ----------------------------------------------------------------------------------------
 
+    void rms_normalize(
+        const double eps,
+        resizable_tensor& dest,
+        resizable_tensor& scale,
+        const tensor& src,
+        const tensor& gamma
+    )
+    {            
+#ifdef DLIB_USE_CUDA
+        cuda::rms_normalize(eps, dest, scale, src, gamma);
+#else
+        cpu::rms_normalize(eps, dest, scale, src, gamma);
+#endif
+    }
+
+    void rms_normalize_gradient(
+        const double eps,
+        const tensor& gradient_input,
+        const tensor& scale,
+        const tensor& src,
+        const tensor& gamma,
+        tensor& src_grad,
+        tensor& gamma_grad
+    )
+    {            
+#ifdef DLIB_USE_CUDA
+        cuda::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad);
+#else
+        cpu::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad);
+#endif
+    }
+
+// ----------------------------------------------------------------------------------------
+
     void threshold (
         tensor& data,
         float thresh

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -718,13 +718,14 @@ namespace dlib { namespace tt
         const tensor& src,
         const tensor& gamma,
         tensor& src_grad,
-        tensor& gamma_grad
+        tensor& gamma_grad,
+        tensor& dscale
     )
     {            
 #ifdef DLIB_USE_CUDA
-        cuda::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad);
+        cuda::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
 #else
-        cpu::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad);
+        cpu::rms_normalize_gradient(eps, gradient_input, scale, src, gamma, src_grad, gamma_grad, dscale);
 #endif
     }
 

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -857,6 +857,53 @@ namespace dlib { namespace tt
             - Assigns the gradient of f() with respect to beta to #beta_grad.
     !*/
 
+        // -----------------------------------------------------------------------------------
+
+        void rms_normalize(
+            const double eps,
+            resizable_tensor& dest,
+            resizable_tensor& scale,
+            const tensor& src,
+            const tensor& gamma
+        );
+        /*!
+            requires
+                - eps > 0
+                - src.num_samples() == gamma.size()
+                - gamma.num_samples() == gamma.nr() == gamma.nc() == 1
+            ensures
+                - have_same_dimensions(#dest, src) == true
+                - #scale.size() == src.num_samples()
+                - #dest == the RMS normalized version of src.
+                - #scale == the scaling factors used to normalize src.
+        !*/
+
+        void rms_normalize_gradient(
+            const double eps,
+            const tensor& gradient_input,
+            const tensor& scale,
+            const tensor& src,
+            const tensor& gamma,
+            tensor& src_grad,
+            tensor& gamma_grad
+        );
+        /*!
+            requires
+                - eps > 0
+                - scale should be the output of a call to
+                  rms_normalize(eps,dest,scale,src,gamma)
+                - have_same_dimensions(gradient_input, src) == true
+                - have_same_dimensions(src, src_grad) == true
+                - have_same_dimensions(gamma, gamma_grad) == true
+                - scale.size() == src.num_samples()
+                - have_same_dimensions(scale, gamma) == true
+            ensures
+                - Let f(src,gamma) == dot(gradient_input, dest output of
+                  rms_normalize(eps,dest,scale,src,gamma))
+                - Adds the gradient of f() with respect to src to #src_grad.
+                - Assigns the gradient of f() with respect to gamma to #gamma_grad.
+        !*/
+
     // -----------------------------------------------------------------------------------
 
     void threshold (

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -857,55 +857,58 @@ namespace dlib { namespace tt
             - Assigns the gradient of f() with respect to beta to #beta_grad.
     !*/
 
-        // -----------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------
 
-        void rms_normalize(
-            const double eps,
-            resizable_tensor& dest,
-            resizable_tensor& scale,
-            const tensor& src,
-            const tensor& gamma
-        );
-        /*!
-            requires
-                - eps > 0
-                - src.num_samples() == gamma.size()
-                - gamma.num_samples() == gamma.nr() == gamma.nc() == 1
-            ensures
-                - have_same_dimensions(#dest, src) == true
-                - #scale.size() == src.num_samples()
-                - #dest == the RMS normalized version of src.
-                - #scale == the scaling factors used to normalize src.
-        !*/
+    void rms_normalize(
+        const double eps,
+        resizable_tensor& dest,
+        resizable_tensor& scale,
+        const tensor& src,
+        const tensor& gamma
+    );
+    /*!
+        requires
+            - eps > 0
+            - gamma.k() == src.k()
+            - gamma.nr() == 1
+            - gamma.nc() == 1
+        ensures
+            - have_same_dimensions(#dest, src) == true
+            - #scale.size() == src.num_samples()
+            - #dest == the RMS normalized version of src
+            - #scale contains the RMS (Root Mean Square) values used to normalize each sample of src.
+            - Each element of #dest is computed as:
+                - #dest[n, k, i, j] == src[n, k, i, j] * gamma[k] / scale[n]
+            where n is the sample index, k is the channel index, and i, j are the spatial indices.
+    !*/
 
-        void rms_normalize_gradient(
-            const double eps,
-            const tensor& gradient_input,
-            const tensor& scale,
-            const tensor& src,
-            const tensor& gamma,
-            tensor& src_grad,
-            tensor& gamma_grad,
-            tensor& dscale
-        );
-        /*!
-            requires
-                - eps > 0
-                - scale should be the output of a call to
-                  rms_normalize(eps,dest,scale,src,gamma)
-                - have_same_dimensions(gradient_input, src) == true
-                - have_same_dimensions(src, src_grad) == true
-                - have_same_dimensions(gamma, gamma_grad) == true
-                - scale.size() == src.num_samples()
-                - have_same_dimensions(scale, gamma) == true
-            ensures
-                - Let f(src,gamma) == dot(gradient_input, dest output of
-                  rms_normalize(eps,dest,scale,src,gamma))
-                - Adds the gradient of f() with respect to src to #src_grad.
-                - Assigns the gradient of f() with respect to gamma to #gamma_grad.
-        !*/
+    void rms_normalize_gradient(
+        const tensor& gradient_input,
+        const tensor& scale,
+        const tensor& src,
+        const tensor& gamma,
+        tensor& src_grad,
+        tensor& gamma_grad,
+        resizable_tensor& dscale
+    );
+    /*!
+        requires
+            - scale.size() == src.num_samples()
+            - have_same_dimensions(gamma, gamma_grad)
+            - gamma.k() == src.k()
+            - gamma.nr() == 1
+            - gamma.nc() == 1
+            - have_same_dimensions(gradient_input, src)
+            - have_same_dimensions(gradient_input, src_grad)
+        ensures
+            - Let f(src, gamma) == dot(gradient_input, dest output of
+                rms_normalize(eps, dest, scale, src, gamma))
+            - Adds the gradient of f() with respect to src to #src_grad
+            - Assigns the gradient of f() with respect to gamma to #gamma_grad
+            - #dscale contains the gradients of f() with respect to the RMS values.
+    !*/
 
-    // -----------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------
 
     void threshold (
         tensor& data,

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -885,7 +885,8 @@ namespace dlib { namespace tt
             const tensor& src,
             const tensor& gamma,
             tensor& src_grad,
-            tensor& gamma_grad
+            tensor& gamma_grad,
+            tensor& dscale
         );
         /*!
             requires

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1536,6 +1536,7 @@ namespace dlib
             gamma = alias_tensor(1, sub.get_output().k(), sub.get_output().nr(), sub.get_output().nc());
             params.set_size(gamma.size());
             gamma(params, 0) = 1;
+            dscale.copy_size(gamma(params, 0));
         }
 
         template <typename SUBNET>
@@ -1550,7 +1551,7 @@ namespace dlib
         {
             auto g = gamma(params, 0);
             auto g_grad = gamma(params_grad, 0);
-            tt::rms_normalize_gradient(eps, gradient_input, scale, sub.get_output(), g, sub.get_gradient_input(), g_grad);
+            tt::rms_normalize_gradient(eps, gradient_input, scale, sub.get_output(), g, sub.get_gradient_input(), g_grad, dscale);
         }
 
         const tensor& get_layer_params() const { return params; };
@@ -1605,6 +1606,7 @@ namespace dlib
         resizable_tensor params;
         alias_tensor gamma;
         resizable_tensor scale;
+        resizable_tensor dscale;
         double learning_rate_multiplier;
         double weight_decay_multiplier;
         double eps;

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -1504,6 +1504,116 @@ namespace dlib
     using layer_norm = add_layer<layer_norm_, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
+    
+    const double DEFAULT_RMS_NORM_EPS = 1e-5;
+
+    class rms_norm_
+    {
+    public:
+        explicit rms_norm_(
+            double eps_ = DEFAULT_RMS_NORM_EPS
+        ) :
+            learning_rate_multiplier(1),
+            weight_decay_multiplier(0),
+            eps(eps_)
+        {
+
+        }
+
+        double get_eps() const { return eps; }
+
+        double get_learning_rate_multiplier() const { return learning_rate_multiplier; }
+        double get_weight_decay_multiplier() const { return weight_decay_multiplier; }
+        void set_learning_rate_multiplier(double val) { learning_rate_multiplier = val; }
+        void set_weight_decay_multiplier(double val) { weight_decay_multiplier = val; }
+
+        inline dpoint map_input_to_output(const dpoint& p) const { return p; }
+        inline dpoint map_output_to_input(const dpoint& p) const { return p; }
+
+        template <typename SUBNET>
+        void setup(const SUBNET& sub)
+        {
+            gamma = alias_tensor(1, sub.get_output().k(), sub.get_output().nr(), sub.get_output().nc());
+            params.set_size(gamma.size());
+            gamma(params, 0) = 1;
+        }
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output)
+        {
+            auto g = gamma(params, 0);
+            tt::rms_normalize(eps, output, scale, sub.get_output(), g);
+        }
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad)
+        {
+            auto g = gamma(params, 0);
+            auto g_grad = gamma(params_grad, 0);
+            tt::rms_normalize_gradient(eps, gradient_input, scale, sub.get_output(), g, sub.get_gradient_input(), g_grad);
+        }
+
+        const tensor& get_layer_params() const { return params; };
+        tensor& get_layer_params() { return params; };
+
+        friend void serialize(const rms_norm_& item, std::ostream& out)
+        {
+            serialize("rms_norm_", out);
+            serialize(item.params, out);
+            serialize(item.gamma, out);
+            serialize(item.scale, out);
+            serialize(item.learning_rate_multiplier, out);
+            serialize(item.weight_decay_multiplier, out);
+            serialize(item.eps, out);
+        }
+
+        friend void deserialize(rms_norm_& item, std::istream& in)
+        {
+            std::string version;
+            deserialize(version, in);
+            if (version != "rms_norm_")
+                throw serialization_error("Unexpected version '" + version + "' found while deserializing dlib::rms_norm_.");
+            deserialize(item.params, in);
+            deserialize(item.gamma, in);
+            deserialize(item.scale, in);
+            deserialize(item.learning_rate_multiplier, in);
+            deserialize(item.weight_decay_multiplier, in);
+            deserialize(item.eps, in);
+        }
+
+        friend std::ostream& operator<<(std::ostream& out, const rms_norm_& item)
+        {
+            out << "rms_norm";
+            out << " eps=" << item.eps;
+            out << " learning_rate_mult=" << item.learning_rate_multiplier;
+            out << " weight_decay_mult=" << item.weight_decay_multiplier;
+            return out;
+        }
+
+        friend void to_xml(const rms_norm_& item, std::ostream& out)
+        {
+            out << "rms_norm";
+            out << " eps='" << item.eps << "'";
+            out << " learning_rate_mult='" << item.learning_rate_multiplier << "'";
+            out << " weight_decay_mult='" << item.weight_decay_multiplier << "'";
+            out << ">\n";
+            out << mat(item.params);
+            out << "</rms_norm>\n";
+        }
+
+    private:
+        resizable_tensor params;
+        alias_tensor gamma;
+        resizable_tensor scale;
+        double learning_rate_multiplier;
+        double weight_decay_multiplier;
+        double eps;
+    };
+
+    template <typename SUBNET>
+    using rms_norm = add_layer<rms_norm_, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
     enum layer_mode
     {
         CONV_MODE = 0,

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1468,6 +1468,7 @@ namespace dlib
     using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
     template <typename SUBNET>
     using dropout_10 = add_layer<dropout_rate_<10>, SUBNET>;
+
 // ----------------------------------------------------------------------------------------
 
     class multiply_
@@ -1667,107 +1668,174 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-const double DEFAULT_RMS_NORM_EPS = 1e-5;
+    const float DEFAULT_RMS_NORM_EPS = 1e-5f;
 
-class rms_norm_
-{
-    /*!
-        WHAT THIS OBJECT REPRESENTS
-            This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
-            defined above. In particular, it defines a root mean square (RMS) normalization layer
-            that implements a method similar to that described in the paper:
-                Root Mean Square Layer Normalization by Biao Zhang and Rico Sennrich
+    class rms_norm_
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This object implements the EXAMPLE_COMPUTATIONAL_LAYER_ interface
+                defined above, specifically defining a root mean square (RMS) normalization layer.
 
-            This layer produces output tensors with the same dimensionality as the input tensors,
-            except that the root mean square of the elements in each sample has been standardized
-            to 1. This is different from layer normalization, as it does not center the data and
-            only scales by the RMS value. As a result, this layer is computationally more
-            efficient and has been shown to be effective in various natural language processing tasks.
-    !*/
+                RMS normalization is a technique that normalizes the input tensor based on the
+                root mean square (RMS) of its elements. Unlike traditional layer normalization,
+                which both centers and scales the data, RMS normalization only scales by the RMS
+                value. This makes it computationally more efficient, as it avoids the need to
+                compute the mean and subtract it from each element.
 
-public:
-    rms_norm_(
-    );
-    /*!
-        ensures
-            - #get_learning_rate_multiplier() == 1
-            - #get_weight_decay_multiplier()  == 0
-            - #get_eps() == DEFAULT_RMS_NORM_EPS
-    !*/
+                This layer produces output tensors with the same dimensionality as the input tensors.
+                Specifically, for an input tensor with shape [num_samples, k, nr, nc], the RMS
+                normalization is applied across the [nr, nc] dimensions independently for each
+                element in the [k] dimension and for each sample in the [num_samples] dimension.
+                The scaling factor (RMS) and the learnable scaling parameter (gamma) are both of
+                size [k].
 
-    explicit rms_norm_(
-        double eps_ = DEFAULT_RMS_NORM_EPS
-    );
-    /*!
-        requires
-            - eps > 0
-        ensures
-            - #get_learning_rate_multiplier() == 1
-            - #get_weight_decay_multiplier()  == 0
-            - #get_eps() == eps_
-    !*/
+                The key characteristics of this layer are:
+                - The RMS of the elements in each sample is standardized to 1.
+                - It does not center the data (i.e., it does not subtract the mean).
+                - A learnable scaling factor (gamma) is applied after normalization, allowing the
+                model to adapt the scaling dynamically.
 
-    double get_eps(
-    ) const;
-    /*!
-        ensures
-            - When doing RMS normalization, we are dividing by the root mean square.
-              This epsilon value returned by this function is added to the
-              mean square to prevent division by zero.
-    !*/
+                This layer is particularly effective in various natural language processing tasks,
+                where it has been shown to provide performance similar to or better than traditional
+                layer normalization, with reduced computational overhead.
+        !*/
 
-    double get_learning_rate_multiplier(
-    ) const;
-    /*!
-        ensures
-            - returns a multiplier number. The interpretation is that this object is
-              requesting that the learning rate used to optimize its parameters be
-              multiplied by get_learning_rate_multiplier().
-    !*/
+    public:
+        rms_norm_(
+        );
+        /*!
+            ensures
+                - #get_learning_rate_multiplier() == 1
+                - #get_weight_decay_multiplier()  == 0
+                - #get_bias_learning_rate_multiplier()  == 1
+                - #get_bias_weight_decay_multiplier()   == 1            
+                - #get_eps() == DEFAULT_RMS_NORM_EPS
+        !*/
 
-    double get_weight_decay_multiplier(
-    ) const;
-    /*!
-        ensures
-            - returns a multiplier number. The interpretation is that this object is
-              requesting that the weight decay used to optimize its parameters be
-              multiplied by get_weight_decay_multiplier().
-    !*/
+        explicit rms_norm_(
+            float eps_ = DEFAULT_RMS_NORM_EPS
+        );
+        /*!
+            requires
+                - eps > 0
+            ensures
+                - #get_learning_rate_multiplier() == 1
+                - #get_weight_decay_multiplier()  == 0
+                - #get_bias_learning_rate_multiplier()  == 1
+                - #get_bias_weight_decay_multiplier()   == 1            
+                - #get_eps() == eps_
+        !*/
 
-    void set_learning_rate_multiplier(
-        double val
-    );
-    /*!
-        requires
-            - val >= 0
-        ensures
-            - #get_learning_rate_multiplier() == val
-    !*/
+        float get_eps(
+        ) const;
+        /*!
+            ensures
+                - When doing RMS normalization, we are dividing by the root mean square.
+                This epsilon value returned by this function is added to the
+                mean square to prevent division by zero.
+        !*/
 
-    void set_weight_decay_multiplier(
-        double val
-    );
-    /*!
-        requires
-            - val >= 0
-        ensures
-            - #get_weight_decay_multiplier() == val
-    !*/
+        void set_eps(
+            float val
+        );
+        /*!
+            requires
+                - val > 0
+            ensures
+                - #get_eps() == val
+        !*/    
 
-    template <typename SUBNET> void setup (const SUBNET& sub);
-    template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& output);
-    template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
-    dpoint map_input_to_output(dpoint p) const;
-    dpoint map_output_to_input(dpoint p) const;
-    const tensor& get_layer_params() const;
-    tensor& get_layer_params();
-    /*!
-        These functions are implemented as described in the EXAMPLE_COMPUTATIONAL_LAYER_ interface.
-    !*/
-};
+        double get_learning_rate_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number. The interpretation is that this object is
+                requesting that the learning rate used to optimize its parameters be
+                multiplied by get_learning_rate_multiplier().
+        !*/
 
-template <typename SUBNET>
-using rms_norm = add_layer<rms_norm_, SUBNET>;
+        double get_weight_decay_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number. The interpretation is that this object is
+                requesting that the weight decay used to optimize its parameters be
+                multiplied by get_weight_decay_multiplier().
+        !*/
+
+        void set_learning_rate_multiplier(
+            double val
+        );
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_learning_rate_multiplier() == val
+        !*/
+
+        void set_weight_decay_multiplier(
+            double val
+        );
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_weight_decay_multiplier() == val
+        !*/
+
+        double get_bias_learning_rate_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                requesting that the learning rate used to optimize its bias parameters be
+                multiplied by get_learning_rate_multiplier()*get_bias_learning_rate_multiplier().
+        !*/
+
+        double get_bias_weight_decay_multiplier(
+        ) const;
+        /*!
+            ensures
+                - returns a multiplier number.  The interpretation is that this object is
+                requesting that the weight decay used to optimize its bias parameters be
+                multiplied by get_weight_decay_multiplier()*get_bias_weight_decay_multiplier().
+        !*/
+
+        void set_bias_learning_rate_multiplier(
+            double val
+        );
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_bias_learning_rate_multiplier() == val
+        !*/
+
+        void set_bias_weight_decay_multiplier(
+            double val
+        );
+        /*!
+            requires
+                - val >= 0
+            ensures
+                - #get_bias_weight_decay_multiplier() == val
+        !*/
+
+        template <typename SUBNET> void setup (const SUBNET& sub);
+        template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& output);
+        template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
+        dpoint map_input_to_output(dpoint p) const;
+        dpoint map_output_to_input(dpoint p) const;
+        const tensor& get_layer_params() const;
+        tensor& get_layer_params();
+        /*!
+            These functions are implemented as described in the EXAMPLE_COMPUTATIONAL_LAYER_ interface.
+        !*/
+    };
+
+    template <typename SUBNET>
+    using rms_norm = add_layer<rms_norm_, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1632,6 +1632,110 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+const double DEFAULT_RMS_NORM_EPS = 1e-5;
+
+class rms_norm_
+{
+    /*!
+        WHAT THIS OBJECT REPRESENTS
+            This is an implementation of the EXAMPLE_COMPUTATIONAL_LAYER_ interface
+            defined above. In particular, it defines a root mean square (RMS) normalization layer
+            that implements a method similar to that described in the paper:
+                Root Mean Square Layer Normalization by Biao Zhang and Rico Sennrich
+
+            This layer produces output tensors with the same dimensionality as the input tensors,
+            except that the root mean square of the elements in each sample has been standardized
+            to 1. This is different from layer normalization, as it does not center the data and
+            only scales by the RMS value. As a result, this layer is computationally more
+            efficient and has been shown to be effective in various natural language processing tasks.
+    !*/
+
+public:
+    rms_norm_(
+    );
+    /*!
+        ensures
+            - #get_learning_rate_multiplier() == 1
+            - #get_weight_decay_multiplier()  == 0
+            - #get_eps() == DEFAULT_RMS_NORM_EPS
+    !*/
+
+    explicit rms_norm_(
+        double eps_ = DEFAULT_RMS_NORM_EPS
+    );
+    /*!
+        requires
+            - eps > 0
+        ensures
+            - #get_learning_rate_multiplier() == 1
+            - #get_weight_decay_multiplier()  == 0
+            - #get_eps() == eps_
+    !*/
+
+    double get_eps(
+    ) const;
+    /*!
+        ensures
+            - When doing RMS normalization, we are dividing by the root mean square.
+              This epsilon value returned by this function is added to the
+              mean square to prevent division by zero.
+    !*/
+
+    double get_learning_rate_multiplier(
+    ) const;
+    /*!
+        ensures
+            - returns a multiplier number. The interpretation is that this object is
+              requesting that the learning rate used to optimize its parameters be
+              multiplied by get_learning_rate_multiplier().
+    !*/
+
+    double get_weight_decay_multiplier(
+    ) const;
+    /*!
+        ensures
+            - returns a multiplier number. The interpretation is that this object is
+              requesting that the weight decay used to optimize its parameters be
+              multiplied by get_weight_decay_multiplier().
+    !*/
+
+    void set_learning_rate_multiplier(
+        double val
+    );
+    /*!
+        requires
+            - val >= 0
+        ensures
+            - #get_learning_rate_multiplier() == val
+    !*/
+
+    void set_weight_decay_multiplier(
+        double val
+    );
+    /*!
+        requires
+            - val >= 0
+        ensures
+            - #get_weight_decay_multiplier() == val
+    !*/
+
+    template <typename SUBNET> void setup (const SUBNET& sub);
+    template <typename SUBNET> void forward(const SUBNET& sub, resizable_tensor& output);
+    template <typename SUBNET> void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
+    dpoint map_input_to_output(dpoint p) const;
+    dpoint map_output_to_input(dpoint p) const;
+    const tensor& get_layer_params() const;
+    tensor& get_layer_params();
+    /*!
+        These functions are implemented as described in the EXAMPLE_COMPUTATIONAL_LAYER_ interface.
+    !*/
+};
+
+template <typename SUBNET>
+using rms_norm = add_layer<rms_norm_, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
     enum layer_mode
     {
         CONV_MODE = 0, // convolutional mode

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -741,6 +741,14 @@ namespace dlib
                 update(i);
             }
 
+            template <typename U, typename E>
+            void operator()(size_t i, const add_layer<rms_norm_, U, E>&)
+            {
+                start_node(i, "rms_norm");
+                end_node();
+                update(i);
+            }            
+
             template <layer_mode MODE, typename U, typename E>
             void operator()(size_t i, const add_layer<bn_<MODE>, U, E>&)
             {

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -308,6 +308,14 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
             }
 
+            template <typename U, typename E>
+            void disable_input_bias(add_layer<rms_norm_, U, E>& l)
+            {
+                disable_bias(l.subnet().layer_details());
+                set_bias_learning_rate_multiplier(l.subnet().layer_details(), 0);
+                set_bias_weight_decay_multiplier(l.subnet().layer_details(), 0);
+            }            
+
             template <layer_mode mode, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, U, E>& l)
             {
@@ -333,6 +341,14 @@ namespace dlib
                 set_bias_weight_decay_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
             }
 
+            template <size_t N, template <typename> class R, typename U, typename E>
+            void disable_input_bias(add_layer<rms_norm_, repeat<N, R, U>, E>& l)
+            {
+                disable_bias(l.subnet().get_repeated_layer(0).layer_details());
+                set_bias_learning_rate_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
+                set_bias_weight_decay_multiplier(l.subnet().get_repeated_layer(0).layer_details(), 0);
+            }            
+
             // handle input repeat layer with tag case
             template <layer_mode mode, unsigned long ID, typename E>
             void disable_input_bias(add_layer<bn_<mode>, add_tag_layer<ID, impl::repeat_input_layer>, E>& )
@@ -343,6 +359,11 @@ namespace dlib
             void disable_input_bias(add_layer<layer_norm_, add_tag_layer<ID, impl::repeat_input_layer>, E>& )
             {
             }
+
+            template <unsigned long ID, typename E>
+            void disable_input_bias(add_layer<rms_norm_, add_tag_layer<ID, impl::repeat_input_layer>, E>& )
+            {
+            }            
 
             // handle tag layer case
             template <layer_mode mode, unsigned long ID, typename U, typename E>
@@ -355,6 +376,11 @@ namespace dlib
             {
             }
 
+            template <unsigned long ID, typename U, typename E>
+            void disable_input_bias(add_layer<rms_norm_, add_tag_layer<ID, U>, E>& )
+            {
+            }            
+
             // handle skip layer case
             template <layer_mode mode, template <typename> class TAG, typename U, typename E>
             void disable_input_bias(add_layer<bn_<mode>, add_skip_layer<TAG, U>, E>& )
@@ -365,6 +391,11 @@ namespace dlib
             void disable_input_bias(add_layer<layer_norm_, add_skip_layer<TAG, U>, E>& )
             {
             }
+
+            template <template <typename> class TAG, typename U, typename E>
+            void disable_input_bias(add_layer<rms_norm_, add_skip_layer<TAG, U>, E>& )
+            {
+            }            
 
             template<typename input_layer_type>
             void operator()(size_t , input_layer_type& ) const

--- a/dlib/dnn/visitors_abstract.h
+++ b/dlib/dnn/visitors_abstract.h
@@ -38,9 +38,9 @@ namespace dlib
             - net_type is an object of type add_layer, add_loss_layer, add_skip_layer, or
               add_tag_layer.
         ensures
-            - Disables bias for all bn_ and layer_norm_ inputs.
+            - Disables bias for all bn_, layer_norm_ and rms_norms_ inputs.
             - Sets the get_bias_learning_rate_multiplier() and get_bias_weight_decay_multiplier()
-              to zero of all bn_ and layer_norm_ inputs.
+              to zero of all bn_, layer_norm_  and rms_norm_ inputs.
     !*/
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -654,7 +654,7 @@ namespace
 
 // ----------------------------------------------------------------------------------------
 
-    void rms_normalize()
+    void test_rms_normalize()
     {
         resizable_tensor x(2, 3, 4, 5);
         resizable_tensor y_cpu(x);

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -670,13 +670,17 @@ namespace
         const float* p_x = x.host();
         const float* p_y = y_cpu.host();
         const float* p_scale = scale_cpu.host();
-        for (long n = 0; n < y_cpu.num_samples(); ++n) {
+        for (long n = 0; n < y_cpu.num_samples(); ++n)
+        {
             double sum_squared_x = 0;
             double sum_squared_y = 0;
             long count = 0;
-            for (long k = 0; k < y_cpu.k(); ++k) {
-                for (long r = 0; r < y_cpu.nr(); ++r) {
-                    for (long c = 0; c < y_cpu.nc(); ++c) {
+            for (long k = 0; k < y_cpu.k(); ++k)
+            {
+                for (long r = 0; r < y_cpu.nr(); ++r)
+                {
+                    for (long c = 0; c < y_cpu.nc(); ++c)
+                    {
                         float val_x = p_x[tensor_index(x, n, k, r, c)];
                         float val_y = p_y[tensor_index(y_cpu, n, k, r, c)];
                         sum_squared_x += val_x * val_x;
@@ -712,11 +716,12 @@ namespace
         resizable_tensor gradient_input(x);
         resizable_tensor src_grad_cpu(x), gamma_grad_cpu(1, x.k(), x.nr(), x.nc());
         resizable_tensor src_grad_cuda(x), gamma_grad_cuda(1, x.k(), x.nr(), x.nc());
+        resizable_tensor dscale_cpu(x.num_samples()), dscale_cuda(x.num_samples());
         rnd.fill_gaussian(gradient_input);
         src_grad_cpu = 0;
         src_grad_cuda = 0;
-        cpu::rms_normalize_gradient(eps, gradient_input, scale_cpu, x, gamma, src_grad_cpu, gamma_grad_cpu);
-        cuda::rms_normalize_gradient(eps, gradient_input, scale_cuda, x, gamma, src_grad_cuda, gamma_grad_cuda);
+        cpu::rms_normalize_gradient(eps, gradient_input, scale_cpu, x, gamma, src_grad_cpu, gamma_grad_cpu, dscale_cpu);
+        cuda::rms_normalize_gradient(eps, gradient_input, scale_cuda, x, gamma, src_grad_cuda, gamma_grad_cuda, dscale_cuda);
         DLIB_TEST_MSG(max(abs(mat(src_grad_cpu) - mat(src_grad_cuda))) < 1e-5, "rms_norm layer, max(abs(mat(src_grad_cpu) - mat(src_grad_cuda))) < 1e-5");
         DLIB_TEST_MSG(max(abs(mat(gamma_grad_cpu) - mat(gamma_grad_cuda))) < 1e-5, "rms_norm layer, max(abs(mat(gamma_grad_cpu) - mat(gamma_grad_cuda))) < 1e-5");
 #endif        

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2080,6 +2080,12 @@ namespace
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
         }
+        {  
+            print_spinner();  
+            rms_norm_ l;  
+            auto res = test_layer(l);  
+            DLIB_TEST_MSG(res, res);  
+        }         
         {
             print_spinner();
             cont_<3,3,3,2,2,0,0> l;


### PR DESCRIPTION
This PR introduces a new RMS (Root Mean Square) Normalization layer to Dlib. RMS Normalization is a variant of Layer Normalization that has shown promising results in various deep learning tasks, particularly in Natural Language Processing.

Key changes:
- Add rms_norm_ class implementing the RMS Normalization layer
- Implement rms_normalize and rms_normalize_gradient utility functions
- Add CPU and CUDA implementations for RMS Normalization
- Include unit tests for the new layer

This new layer provides an alternative to the existing layer_norm_, offering potential performance benefits and improved training stability in certain scenarios.

Usage Example:
For a comprehensive example of how to use this new RMS Normalization layer in a Transformer-based architecture, please refer to the ERNIE project: https://github.com/Cydral/ERNIE