### PR TITLE
Add customizable dropout layer with compile-time rate specification

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2137,10 +2137,10 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <float DROP_RATE>
-    class dropout_custom_ : public dropout_
+    class dropout_rate_ : public dropout_
     {
     public:
-        explicit dropout_custom_() : dropout_(DROP_RATE)
+        explicit dropout_rate_() : dropout_(DROP_RATE)
         {
             DLIB_CASSERT(0 <= DROP_RATE && DROP_RATE <= 1, 
                 "DROP_RATE must be between 0 and 1, inclusive.");
@@ -2148,10 +2148,18 @@ namespace dlib
     };
 
     template <float DROP_RATE, typename SUBNET>
-    using dropout_custom = add_layer<dropout_custom_<DROP_RATE>, SUBNET>;
+    using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
 
     template <typename SUBNET>
-    using dropout_10 = add_layer<dropout_custom_<0.10f>, SUBNET>;
+    using dropout_rate_5 = add_layer<dropout_rate_<0.05f>, SUBNET>;    
+    template <typename SUBNET>
+    using dropout_rate_10 = add_layer<dropout_rate_<0.10f>, SUBNET>;
+    template <typename SUBNET>
+    using dropout_rate_15 = add_layer<dropout_rate_<0.15f>, SUBNET>;
+    template <typename SUBNET>
+    using dropout_rate_20 = add_layer<dropout_rate_<0.20f>, SUBNET>;
+    template <typename SUBNET>
+    using dropout_rate_25 = add_layer<dropout_rate_<0.25f>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2136,6 +2136,25 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <float DROP_RATE>
+    class dropout_custom_ : public dropout_
+    {
+    public:
+        explicit dropout_custom_() : dropout_(DROP_RATE)
+        {
+            DLIB_CASSERT(0 <= DROP_RATE && DROP_RATE <= 1, 
+                "DROP_RATE must be between 0 and 1, inclusive.");
+        }
+    };
+
+    template <float DROP_RATE, typename SUBNET>
+    using dropout_custom = add_layer<dropout_custom_<DROP_RATE>, SUBNET>;
+
+    template <typename SUBNET>
+    using dropout_10 = add_layer<dropout_custom_<0.10f>, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
     class multiply_
     {
     public:

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2136,30 +2136,21 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <float DROP_RATE>
+    template <int DROP_RATE_PERCENT>
     class dropout_rate_ : public dropout_
     {
     public:
-        explicit dropout_rate_() : dropout_(DROP_RATE)
+        explicit dropout_rate_() : dropout_(static_cast<float>(DROP_RATE_PERCENT) / 100.0f)
         {
-            DLIB_CASSERT(0 <= DROP_RATE && DROP_RATE <= 1, 
-                "DROP_RATE must be between 0 and 1, inclusive.");
+            static_assert(DROP_RATE_PERCENT >= 0 && DROP_RATE_PERCENT <= 100,
+                "DROP_RATE_PERCENT must be between 0 and 100, inclusive.");
         }
     };
-
-    template <float DROP_RATE, typename SUBNET>
+    
+    template <int DROP_RATE, typename SUBNET>
     using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
-
     template <typename SUBNET>
-    using dropout_rate_5 = add_layer<dropout_rate_<0.05f>, SUBNET>;    
-    template <typename SUBNET>
-    using dropout_rate_10 = add_layer<dropout_rate_<0.10f>, SUBNET>;
-    template <typename SUBNET>
-    using dropout_rate_15 = add_layer<dropout_rate_<0.15f>, SUBNET>;
-    template <typename SUBNET>
-    using dropout_rate_20 = add_layer<dropout_rate_<0.20f>, SUBNET>;
-    template <typename SUBNET>
-    using dropout_rate_25 = add_layer<dropout_rate_<0.25f>, SUBNET>;
+    using dropout_10 = add_layer<dropout_rate_<10>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1466,7 +1466,8 @@ namespace dlib
 
     template <int DROP_RATE, typename SUBNET>
     using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
-
+    template <typename SUBNET>
+    using dropout_10 = add_layer<dropout_rate_<10>, SUBNET>;
 // ----------------------------------------------------------------------------------------
 
     class multiply_

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1436,7 +1436,7 @@ namespace dlib
 // ----------------------------------------------------------------------------------------
 
     template <float DROP_RATE>
-    class dropout_custom_ : public dropout_
+    class dropout_rate_ : public dropout_
     {
         /*!
             WHAT THIS OBJECT REPRESENTS
@@ -1456,7 +1456,7 @@ namespace dlib
         !*/
 
     public:
-        explicit dropout_custom_();
+        explicit dropout_rate_();
         /*!
             ensures
                 - Constructs a dropout layer with a dropout rate of DROP_RATE.
@@ -1465,7 +1465,7 @@ namespace dlib
     };
 
     template <float DROP_RATE, typename SUBNET>
-    using dropout_custom = add_layer<dropout_custom_<DROP_RATE>, SUBNET>;
+    using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1435,7 +1435,7 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <float DROP_RATE>
+    template <int DROP_RATE_PERCENT>
     class dropout_rate_ : public dropout_
     {
         /*!
@@ -1451,7 +1451,7 @@ namespace dlib
                 flexibility and clarity in the network architecture definition.
 
             TEMPLATE PARAMETERS
-                - DROP_RATE: A float value between 0 and 1 that specifies the dropout rate.
+                - DROP_RATE_PERCENT: A int value between 0 and 100 that specifies the dropout rate.
                   This value is set at compile-time and cannot be changed during runtime.
         !*/
 
@@ -1464,7 +1464,7 @@ namespace dlib
         !*/
     };
 
-    template <float DROP_RATE, typename SUBNET>
+    template <int DROP_RATE, typename SUBNET>
     using dropout_rate = add_layer<dropout_rate_<DROP_RATE>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -1435,6 +1435,40 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <float DROP_RATE>
+    class dropout_custom_ : public dropout_
+    {
+        /*!
+            WHAT THIS OBJECT REPRESENTS
+                This object represents a customizable dropout layer that inherits from
+                the dropout_ class. It allows specifying the dropout rate at compile-time,
+                which is particularly useful for deep networks with many layers where it
+                might be cumbersome to explicitly modify the dropout rate for each layer
+                individually.
+
+                The main advantage of this layer is that it offers the possibility to specify
+                the dropout rate at the moment of network construction, providing more
+                flexibility and clarity in the network architecture definition.
+
+            TEMPLATE PARAMETERS
+                - DROP_RATE: A float value between 0 and 1 that specifies the dropout rate.
+                  This value is set at compile-time and cannot be changed during runtime.
+        !*/
+
+    public:
+        explicit dropout_custom_();
+        /*!
+            ensures
+                - Constructs a dropout layer with a dropout rate of DROP_RATE.
+                - Calls the base class constructor dropout_(DROP_RATE).
+        !*/
+    };
+
+    template <float DROP_RATE, typename SUBNET>
+    using dropout_custom = add_layer<dropout_custom_<DROP_RATE>, SUBNET>;
+
+// ----------------------------------------------------------------------------------------
+
     class multiply_
     {
         /*!


### PR DESCRIPTION
This PR introduces a new customizable dropout layer, `dropout_custom_`, which allows specifying the dropout rate at compile-time. This enhancement is particularly beneficial for deep neural networks with numerous layers, where manually setting different dropout rates for each layer can be cumbersome.

Key features and benefits:

1. Compile-time dropout rate specification: Allows for clearer and more concise network definitions.
2. Inherits from the existing `dropout_` class: Maintains all functionality of the original dropout layer.
3. Template-based implementation: Provides type-safety and potential performance benefits.
4. Includes a pre-defined `dropout_10` alias: Offers a convenient 10% dropout option for common use cases.