### PR TITLE
Added CI for pre-built wheels

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -31,50 +31,58 @@ defaults:
     shell: bash
 
 jobs:
-  Windows:
-    runs-on: 'windows-latest'
+  build_wheels_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - name: Install python deps
-      run: |
-        pip install pytest numpy
-        # don't use CMake 3.25.0 https://gitlab.kitware.com/cmake/cmake/-/issues/23975
-        pip3 install cmake==3.24.0
-    - name: Build
-      run: |
-        pip3 install cmake==3.24.0
-        python setup.py build
-        python setup.py install --user
-    - name: Test
-      run: python -m pytest --ignore docs --ignore dlib
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install cibuildwheel==2.17.0  # sync version with pypa/cibuildwheel below
+      - id: set-matrix
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.7'  # it is missing in setup.py and needed to determine which wheels to build
+        run: |
+          MATRIX_INCLUDE=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-13"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-14"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
 
-  Ubuntu:
-    runs-on: 'ubuntu-latest'
+  build_wheels:
+    needs: build_wheels_matrix
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.build_wheels_matrix.outputs.include) }}
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - name: Install python deps
-      run: pip install pytest numpy
-    - name: Build
+    - uses: actions/checkout@v4
+    
+    - name: Disable gui support
       run: |
-        python setup.py build
-        python setup.py install --user
-    - name: Test
-      run: python -m pytest --ignore docs --ignore dlib
+        sed -i'' -e "s/_cmake_extra_options = \[\]/_cmake_extra_options = \['-DDLIB_NO_GUI_SUPPORT=ON'\]/" setup.py
 
-# Disabled for now since something is going sideways with python packages on github actions
-# MacOS:
-#   runs-on: 'macos-latest'
-#   steps:
-#   - uses: actions/checkout@v3
-#   - uses: actions/setup-python@v4
-#   - name: Install python deps
-#     run: pip3 install pytest numpy
-#   - name: Build
-#     run: |
-#       python3 setup.py build
-#       python3 setup.py install --user
-#   - name: Test
-#     run: python3 -m pytest --ignore docs --ignore dlib
+    - name: Build wheel
+      uses: pypa/cibuildwheel@v2.17.0  # sync version with pip install cibuildwheel above
+      with:
+        only: ${{ matrix.only }}
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_TEST_REQUIRES: pytest numpy
+        CIBW_TEST_COMMAND: python -m pytest {project}/tools/python/test --ignore docs --ignore dlib
 
+    - name: Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-${{ matrix.only }}
+        path: wheelhouse/*.whl

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -31,39 +31,25 @@ defaults:
     shell: bash
 
 jobs:
-  build_wheels_matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      include: ${{ steps.set-matrix.outputs.include }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - run: pip install cibuildwheel==2.17.0  # sync version with pypa/cibuildwheel below
-      - id: set-matrix
-        env:
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.7'  # it is missing in setup.py and needed to determine which wheels to build
-        run: |
-          MATRIX_INCLUDE=$(
-            {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-13"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-14"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
-            } | jq -sc
-          )
-          echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
-
   build_wheels:
-    needs: build_wheels_matrix
-    runs-on: ${{ matrix.os }}
-    name: Build ${{ matrix.only }}
+    runs-on: ${{ matrix.platform_arch[1] }}
+    name: Build ${{matrix.cpython}}-${{ matrix.platform_arch[0] }}
+    env:
+      identifier: ${{matrix.cpython}}-${{ matrix.platform_arch[0] }}
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.build_wheels_matrix.outputs.include) }}
+        cpython: [cp37, cp38, cp39, cp310, cp311, cp312]
+        platform_arch: 
+          - [manylinux_x86_64, ubuntu-latest]
+          - [musllinux_x86_64, ubuntu-latest]
+          - [macosx_x86_64, macos-13]
+          - [macosx_arm64, macos-14]
+          - [win_amd64, windows-latest]
+        exclude:
+          - cpython: cp37
+            platform_arch: [macosx_arm64, macos-14]
 
     steps:
     - uses: actions/checkout@v4
@@ -75,7 +61,7 @@ jobs:
     - name: Build wheel
       uses: pypa/cibuildwheel@v2.17.0  # sync version with pip install cibuildwheel above
       with:
-        only: ${{ matrix.only }}
+        only: ${{ env.identifier }}
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_TEST_REQUIRES: pytest numpy
@@ -84,5 +70,5 @@ jobs:
     - name: Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.only }}
+        name: dist-${{ env.identifier }}
         path: wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "cmake==3.24.0"]
 build-backend = "setuptools.build_meta"

--- a/tools/python/test/test_numpy_returns.py
+++ b/tools/python/test/test_numpy_returns.py
@@ -1,14 +1,14 @@
 import sys
 import pickle
+import pathlib
 
 import dlib
 import pytest
 
 import utils
 
-# Paths are relative to dlib root
-image_path = "examples/faces/Tom_Cruise_avp_2014_4.jpg"
-shape_path = "tools/python/test/shape.pkl"
+image_path = (pathlib.Path(__file__).parents[3] / "examples" / "faces" / "Tom_Cruise_avp_2014_4.jpg").absolute().as_posix()
+shape_path = (pathlib.Path(__file__).parents[3] / "tools" / "python" / "test" / "shape.pkl").absolute().as_posix()
 
 
 def get_test_image_and_shape():


### PR DESCRIPTION
Hi @davisking and the team,

First of all, I would like to thank you for your work on this library. It has been incredibly helpful for my projects.

However, there's one feature I feel is missing: pre-built wheels. It would be really convenient to install the `dlib` library without dealing with build dependencies. I’ve noticed that there are several forks or related repositories that set up CI pipelines to build wheels and upload them to PyPI under different names. The issue is that these forks are hard to maintain and often become outdated.

One such example is https://github.com/alesanfra/dlib-wheels, created by @alesanfra. I used this as a basis for my pull request, where I adapted the CI pipeline with slight modifications to make it compatible with the original dlib repository.

An additional benefit of this PR is that the CI pipeline now runs tests across different Python versions (currently 3.7 to 3.12) and various OS/architecture configurations (Linux, Windows, and macOS, including both Intel and AMD64).

The only aspect I am uncertain about is disabling GUI support (`DLIB_NO_GUI_SUPPORT=ON`). My preference is to have wheels without GUI support to reduce their size, but if you prefer to provide pre-built packages with GUI support, I can modify the setup to build wheels both with and without GUI support.

The final step, which is not included in this PR, is setting up automated publishing to upload the wheels to PyPI when a release is created. This could be added in a future PR if you decide to further automate the process.

Thank you in advance for your feedback and comments!