### PR TITLE
Add tril_ layer for lower triangular matrix operations

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -4698,9 +4698,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <auto v>
+    template <typename T, T v>
     struct constant_wrapper {
-        static constexpr auto value = v;
+        static constexpr T value = v;
     };
 
     template <long diag_, typename diag_value_>
@@ -4795,10 +4795,10 @@ namespace dlib
     };
 
     template <typename SUBNET>
-    using tril = add_layer<tril_<0, constant_wrapper<0.0f>>, SUBNET>;
+    using tril = add_layer<tril_<0, constant_wrapper<float, 0.0f>>, SUBNET>;
 
     template <typename SUBNET>
-    using tril_mask = add_layer<tril_<0, constant_wrapper<-std::numeric_limits<float>::infinity()>>, SUBNET>;
+    using tril_mask = add_layer<tril_<0, constant_wrapper<float, -std::numeric_limits<float>::infinity()>>, SUBNET>;
 
     template <long diag, typename diag_value, typename SUBNET>
     using tril_diag = add_layer<tril_<diag, diag_value>, SUBNET>;

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -4772,8 +4772,6 @@ namespace dlib
                 return -std::numeric_limits<float>::infinity();
             else if (std::is_same<tag_, zero_tag>::value)
                 return 0.0f;
-            else if (is_special_value<tag_>::value)
-                static_assert(always_false<tag_>::value, "unsupported special value");
             else
                 return static_cast<float>(num_) / static_cast<float>(den_);
         }

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -4768,11 +4768,11 @@ namespace dlib
 
     private:
         float compute_diag_value() const {
-            if constexpr (std::is_same<tag_, neg_infinity_tag>::value)
+            if (std::is_same<tag_, neg_infinity_tag>::value)
                 return -std::numeric_limits<float>::infinity();
-            else if constexpr (std::is_same<tag_, zero_tag>::value)
+            else if (std::is_same<tag_, zero_tag>::value)
                 return 0.0f;
-            else if constexpr (is_special_value<tag_>::value)
+            else if (is_special_value<tag_>::value)
                 static_assert(always_false<tag_>::value, "unsupported special value");
             else
                 return static_cast<float>(num_) / static_cast<float>(den_);

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -4715,7 +4715,9 @@ namespace dlib
         tril_(): diag(diag_), diag_value(compute_diag_value()) {}
         
         template <typename SUBNET>
-        void setup(const SUBNET& sub) {}
+        void setup(const SUBNET& /*sub*/)
+        {
+        }
         
         template <typename SUBNET>
         void forward(const SUBNET& sub, resizable_tensor& output)

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -4698,9 +4698,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <typename T, T val>
-    struct float_constant {
-        static constexpr T value = val;
+    template <auto v>
+    struct constant_wrapper {
+        static constexpr auto value = v;
     };
 
     template <long diag_, typename diag_value_>
@@ -4795,13 +4795,13 @@ namespace dlib
     };
 
     template <typename SUBNET>
-    using tril = add_layer<tril_<0, float_constant<float, 0.0f>>, SUBNET>;
+    using tril = add_layer<tril_<0, constant_wrapper<0.0f>>, SUBNET>;
 
     template <typename SUBNET>
-    using tril_mask = add_layer<tril_<0, float_constant<float, -std::numeric_limits<float>::infinity()>>, SUBNET>;
+    using tril_mask = add_layer<tril_<0, constant_wrapper<-std::numeric_limits<float>::infinity()>>, SUBNET>;
 
-    template <long diag, typename diag_value_type, typename SUBNET>
-    using tril_diag = add_layer<tril_<diag, diag_value_type>, SUBNET>;
+    template <long diag, typename diag_value, typename SUBNET>
+    using tril_diag = add_layer<tril_<diag, diag_value>, SUBNET>;
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -3713,9 +3713,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <auto v>
+    template <typename T, T v>
     struct constant_wrapper {
-        static constexpr auto value = v;
+        static constexpr T value = v;
     };
 
     template <long diag_, typename diag_value_>
@@ -3823,10 +3823,10 @@ namespace dlib
     };
 
     template <typename SUBNET>
-    using tril = add_layer<tril_<0, constant_wrapper<0.0f>>, SUBNET>;
+    using tril = add_layer<tril_<0, constant_wrapper<float, 0.0f>>, SUBNET>;
 
     template <typename SUBNET>
-    using tril_mask = add_layer<tril_<0, constant_wrapper<-std::numeric_limits<float>::infinity()>>, SUBNET>;
+    using tril_mask = add_layer<tril_<0, constant_wrapper<float, -std::numeric_limits<float>::infinity()>>, SUBNET>;
 
     template <long diag, typename diag_value, typename SUBNET>
     using tril_diag = add_layer<tril_<diag, diag_value>, SUBNET>;    

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -3713,9 +3713,9 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
-    template <typename T, T val>
-    struct float_constant {
-        static constexpr T value = val;
+    template <auto v>
+    struct constant_wrapper {
+        static constexpr auto value = v;
     };
 
     template <long diag_, typename diag_value_>
@@ -3823,13 +3823,13 @@ namespace dlib
     };
 
     template <typename SUBNET>
-    using tril = add_layer<tril_<0, float_constant<float, 0.0f>>, SUBNET>;
+    using tril = add_layer<tril_<0, constant_wrapper<0.0f>>, SUBNET>;
 
     template <typename SUBNET>
-    using tril_mask = add_layer<tril_<0, float_constant<float, -std::numeric_limits<float>::infinity()>>, SUBNET>;
+    using tril_mask = add_layer<tril_<0, constant_wrapper<-std::numeric_limits<float>::infinity()>>, SUBNET>;
 
-    template <long diag, typename diag_value_type, typename SUBNET>
-    using tril_diag = add_layer<tril_<diag, diag_value_type>, SUBNET>;    
+    template <long diag, typename diag_value, typename SUBNET>
+    using tril_diag = add_layer<tril_<diag, diag_value>, SUBNET>;    
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/dnn/layers_abstract.h
+++ b/dlib/dnn/layers_abstract.h
@@ -3713,6 +3713,126 @@ namespace dlib
 
 // ----------------------------------------------------------------------------------------
 
+    template <typename T, T val>
+    struct float_constant {
+        static constexpr T value = val;
+    };
+
+    template <long diag_, typename diag_value_>
+    class tril_
+    {
+        /*!
+            REQUIREMENTS ON diag_ and diag_value_
+                - diag_ must be a non-negative integer.
+                - diag_value_ must be a type that has a static constexpr member `value` of type float.
+
+            WHAT THIS OBJECT REPRESENTS
+                This object implements a layer in a deep neural network that applies a lower triangular mask to
+                its input tensor. The mask is defined such that all elements above the specified diagonal are set
+                to a given value (diag_value_::value). The diagonal is specified by the diag_ parameter.
+
+            EXAMPLE USAGE
+                tril_<0, float_constant<float, -std::numeric_limits<float>::infinity()>> layer;
+                // This creates a layer that masks all elements above the main diagonal with -inf.
+
+            SERIALIZATION SUPPORT
+                This object supports serialization and deserialization via the serialize() and deserialize() functions.
+        !*/
+
+    public:
+        tril_() = default;
+        /*!
+            ensures
+                - This object is properly initialized.
+        !*/
+
+        template <typename SUBNET>
+        void setup(const SUBNET& sub);
+        /*!
+            requires
+                - SUBNET is a valid network layer type.
+            ensures
+                - Initializes the mask based on the dimensions of the input tensor from sub.
+        !*/
+
+        template <typename SUBNET>
+        void forward(const SUBNET& sub, resizable_tensor& output);
+        /*!
+            requires
+                - SUBNET is a valid network layer type.
+            ensures
+                - Applies the lower triangular mask to the input tensor from sub and stores the result in output.
+        !*/
+
+        template <typename SUBNET>
+        void backward(const tensor& gradient_input, SUBNET& sub, tensor& params_grad);
+        /*!
+            requires
+                - SUBNET is a valid network layer type.
+            ensures
+                - Computes the gradient of the loss with respect to the input tensor and stores it in sub.
+        !*/
+
+        inline dpoint map_input_to_output(const dpoint& p) const;
+        /*!
+            ensures
+                - Maps a point from the input tensor to the corresponding point in the output tensor.
+        !*/
+
+        inline dpoint map_output_to_input(const dpoint& p) const;
+        /*!
+            ensures
+                - Maps a point from the output tensor to the corresponding point in the input tensor.
+        !*/
+
+        const tensor& get_layer_params() const;
+        /*!
+            ensures
+                - Returns the parameters of this layer.
+        !*/
+
+        tensor& get_layer_params();
+        /*!
+            ensures
+                - Returns the parameters of this layer.
+        !*/
+
+        friend void serialize(const tril_& item, std::ostream& out);
+        /*!
+            ensures
+                - Serializes the state of this object to the given output stream.
+        !*/
+
+        friend void deserialize(tril_& item, std::istream& in);
+        /*!
+            ensures
+                - Deserializes the state of this object from the given input stream.
+        !*/
+
+        friend std::ostream& operator<<(std::ostream& out, const tril_& item);
+        /*!
+            ensures
+                - Prints a human-readable representation of this object to the given output stream.
+        !*/
+
+        friend void to_xml(const tril_& item, std::ostream& out);
+        /*!
+            ensures
+                - Serializes the state of this object to XML format and writes it to the given output stream.
+        !*/
+    };
+
+    template <typename SUBNET>
+    using tril = add_layer<tril_<0, float_constant<float, 0.0f>>, SUBNET>;
+
+    template <typename SUBNET>
+    using tril_mask = add_layer<tril_<0, float_constant<float, -std::numeric_limits<float>::infinity()>>, SUBNET>;
+
+    template <long diag, typename diag_value_type, typename SUBNET>
+    using tril_diag = add_layer<tril_<diag, diag_value_type>, SUBNET>;    
+
+// ----------------------------------------------------------------------------------------
+
 }
 
 #endif // DLIB_DNn_LAYERS_ABSTRACT_H_

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1034,7 +1034,7 @@ namespace dlib
             {
                 start_node(i, "tril");
                 out << " | {diag|{" << diag << "}}";
-                out << " | {diag_value|{" << diag_value_type::value << "}}";
+                out << " | {diag_value|{" << diag_value::value << "}}";
                 end_node();
                 update(i);
             }            

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1029,6 +1029,16 @@ namespace dlib
                 update(i);
             }
 
+            template <long diag, typename diag_value_type, typename U, typename E>
+            void operator()(size_t i, const add_layer<tril_<diag, diag_value_type>, U, E>&)
+            {
+                start_node(i, "tril");
+                out << " | {diag|{" << diag << "}}";
+                out << " | {diag_value|{" << diag_value_type::value << "}}";
+                end_node();
+                update(i);
+            }            
+
             template <typename T, typename U, typename E>
             void operator()(size_t i, const add_layer<T, U, E>&)
             {

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1029,15 +1029,25 @@ namespace dlib
                 update(i);
             }
 
-            template <long diag, typename diag_value, typename U, typename E>
-            void operator()(size_t i, const add_layer<tril_<diag, diag_value>, U, E>&)
+            template <long diag, typename tag, long num, long den, typename U, typename E>
+            void operator()(size_t i, const add_layer<tril_<diag, tag, num, den>, U, E>&)
             {
                 start_node(i, "tril");
                 out << " | {diag|{" << diag << "}}";
-                out << " | {diag_value|{" << diag_value::value << "}}";
+                out << " | {diag_value|{";
+                
+                if constexpr (std::is_same_v<tag, neg_infinity_tag>) {
+                    out << "-inf";
+                } else if constexpr (std::is_same_v<tag, zero_tag>) {
+                    out << "0";
+                } else {
+                    out << static_cast<float>(num) / static_cast<float>(den);
+                }
+                
+                out << "}}";
                 end_node();
                 update(i);
-            }            
+            }         
 
             template <typename T, typename U, typename E>
             void operator()(size_t i, const add_layer<T, U, E>&)

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1036,13 +1036,9 @@ namespace dlib
                 out << " | {diag|{" << diag << "}}";
                 out << " | {diag_value|{";
                 
-                if (std::is_same_v<tag, neg_infinity_tag>) {
-                    out << "-inf";
-                } else if (std::is_same_v<tag, zero_tag>) {
-                    out << "0";
-                } else {
-                    out << static_cast<float>(num) / static_cast<float>(den);
-                }
+                if (std::is_same<tag, neg_infinity_tag>::value) out << "-inf";
+                else if (std::is_same<tag, zero_tag>::value) out << "0";
+                else out << static_cast<float>(num) / static_cast<float>(den);
                 
                 out << "}}";
                 end_node();

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1036,9 +1036,9 @@ namespace dlib
                 out << " | {diag|{" << diag << "}}";
                 out << " | {diag_value|{";
                 
-                if constexpr (std::is_same_v<tag, neg_infinity_tag>) {
+                if (std::is_same_v<tag, neg_infinity_tag>) {
                     out << "-inf";
-                } else if constexpr (std::is_same_v<tag, zero_tag>) {
+                } else if (std::is_same_v<tag, zero_tag>) {
                     out << "0";
                 } else {
                     out << static_cast<float>(num) / static_cast<float>(den);

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1029,8 +1029,8 @@ namespace dlib
                 update(i);
             }
 
-            template <long diag, typename diag_value_type, typename U, typename E>
-            void operator()(size_t i, const add_layer<tril_<diag, diag_value_type>, U, E>&)
+            template <long diag, typename diag_value, typename U, typename E>
+            void operator()(size_t i, const add_layer<tril_<diag, diag_value>, U, E>&)
             {
                 start_node(i, "tril");
                 out << " | {diag|{" << diag << "}}";

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -4574,6 +4574,7 @@ namespace
             test_layer_normalize();
             test_rms_normalize();
             test_transpose();
+            test_tril();
             test_basic_tensor_ops();
             test_layers();
             test_visit_functions();

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2025,7 +2025,7 @@ namespace
         }
         {
             print_spinner();
-            using specific_float = constant_wrapper<-std::numeric_limits<float>::infinity()>;
+            using specific_float = constant_wrapper<float, -std::numeric_limits<float>::infinity()>;
             tril_<-5, specific_float> l;
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
@@ -4460,7 +4460,7 @@ namespace
     {
         print_spinner();
         
-        using NEG_INF = constant_wrapper<-std::numeric_limits<float>::infinity()>;
+        using NEG_INF = constant_wrapper<float, -std::numeric_limits<float>::infinity()>;
         using net_type = tag1<tril_diag<0, NEG_INF, tag2<input<matrix<float>>>>>;
         net_type net;
 

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2025,8 +2025,7 @@ namespace
         }
         {
             print_spinner();
-            using specific_float = constant_wrapper<float, -std::numeric_limits<float>::infinity()>;
-            tril_<-5, specific_float> l;
+            tril_<-5, void, 1, 2> l;
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
         }        
@@ -4458,10 +4457,8 @@ namespace
 
     void test_tril()
     {
-        print_spinner();
-        
-        using NEG_INF = constant_wrapper<float, -std::numeric_limits<float>::infinity()>;
-        using net_type = tag1<tril_diag<0, NEG_INF, tag2<input<matrix<float>>>>>;
+        print_spinner();        
+        using net_type = tag1<tril_mask<tag2<input<matrix<float>>>>>;
         net_type net;
 
         // Input tensor

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2025,7 +2025,7 @@ namespace
         }
         {
             print_spinner();
-            using specific_float = float_constant<float, -std::numeric_limits<float>::infinity()>;
+            using specific_float = constant_wrapper<-std::numeric_limits<float>::infinity()>;
             tril_<-5, specific_float> l;
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
@@ -4460,7 +4460,7 @@ namespace
     {
         print_spinner();
         
-        using NEG_INF = float_constant<float, -std::numeric_limits<float>::infinity()>;
+        using NEG_INF = constant_wrapper<-std::numeric_limits<float>::infinity()>;
         using net_type = tag1<tril_diag<0, NEG_INF, tag2<input<matrix<float>>>>>;
         net_type net;
 

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -4491,7 +4491,7 @@ namespace
 
         // Compare output tensor with expected output
         auto& net_output = layer<tag1>(net).get_output();
-        DLIB_TEST_MSG(max(abs(mat(net_output) - mat(expected_output))) < 1e-5);
+        DLIB_TEST(max(abs(mat(net_output) - mat(expected_output))) < 1e-5);
     }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2025,6 +2025,13 @@ namespace
         }
         {
             print_spinner();
+            using specific_float = float_constant<float, -std::numeric_limits<float>::infinity()>;
+            tril_<-5, specific_float> l;
+            auto res = test_layer(l);
+            DLIB_TEST_MSG(res, res);
+        }        
+        {
+            print_spinner();
             extract_<0,2,2,2> l;
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
@@ -4445,6 +4452,49 @@ namespace
             DLIB_TEST(error == 0);
             offset += stride;
         }
+    }
+
+// ----------------------------------------------------------------------------------------
+
+    void test_tril()
+    {
+        print_spinner();
+        
+        using NEG_INF = float_constant<float, -std::numeric_limits<float>::infinity()>;
+        using net_type = tag1<tril_diag<0, NEG_INF, tag2<input<matrix<float>>>>>;
+        net_type net;
+
+        // Input tensor
+        dlib::rand rnd;
+        const int nr = 2, nc = 3;
+        constexpr int n_samples = 3, k = 1;
+        std::vector<matrix<float>> x(n_samples);
+        matrix<float> xtmp(nr, nc);
+        for (int ii = 0; ii < n_samples; ++ii) {
+            for (int jj = 0; jj < nr; ++jj)
+                for (int kk = 0; kk < nc; ++kk)
+                    xtmp(jj, kk) = rnd.get_random_gaussian();
+            x[ii] = xtmp;
+        }
+
+        // Convert input matrix to tensor
+        resizable_tensor input_tensor;
+        net.to_tensor(&x[0], &x[0] + n_samples, input_tensor);
+        net.forward(input_tensor);
+
+        // Expected output tensor (manually set for comparison)
+        resizable_tensor expected_output;
+        expected_output.copy_size(input_tensor);
+        tt::copy_tensor(false, expected_output, 0, input_tensor, 0, input_tensor.k());
+        for (int ii = 0; ii < n_samples; ++ii) {
+            expected_output.host()[tensor_index(expected_output, ii, 0, 0, 1)] = -std::numeric_limits<float>::infinity();
+            expected_output.host()[tensor_index(expected_output, ii, 0, 0, 2)] = -std::numeric_limits<float>::infinity();
+            expected_output.host()[tensor_index(expected_output, ii, 0, 1, 2)] = -std::numeric_limits<float>::infinity();
+        }
+
+        // Compare output tensor with expected output
+        auto& net_output = layer<tag1>(net).get_output();
+        DLIB_TEST_MSG(max(abs(mat(net_output) - mat(expected_output))) < 1e-5);
     }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a new tril_ layer to dlib, which implements lower triangular matrix operations similar to PyTorch's torch.tril() function. The layer allows for flexible lower triangular matrix masking with customizable diagonal offset and diagonal value.

### Key features:
- Implements lower triangular masking for tensors
- Supports custom diagonal offset and diagonal value
- Offers three convenient alias templates: tril, tril_mask, and tril_diag

This addition enhances dlib's neural network capabilities, allowing for more complex architectures that require lower triangular matrix operations.
The new layer can be particularly useful in attention mechanisms, triangular matrix operations, and other scenarios where lower triangular masking is required in neural network architectures.