### PR TITLE
Fix conversion from simd8f to simd8i for MSVC ARM on Windows

### DIFF
--- a/dlib/simd/simd8f.h
+++ b/dlib/simd/simd8f.h
@@ -106,8 +106,13 @@ namespace dlib
         inline operator simd8i::rawarray() const 
         { 
             simd8i::rawarray temp;
+#if defined(DLIB_HAVE_NEON)
+            temp.low = simd4i(vcvtq_s32_f32(_low));
+            temp.high = simd4i(vcvtq_s32_f32(_high));
+#else
             temp.low = simd4i(_low);
             temp.high = simd4i(_high);
+#endif
             return temp;
         }
 


### PR DESCRIPTION
This is needed because the conversion between float32x4_t to int32x4_t needs to be done explicit.