### PR TITLE
Replace deprecated pkgutil.find_loader()

### DIFF
--- a/tools/python/test/utils.py
+++ b/tools/python/test/utils.py
@@ -1,4 +1,4 @@
-import pkgutil
+import importlib
 import sys
 
 def save_pickled_compatible(obj_to_pickle, file_name):
@@ -36,7 +36,7 @@ def is_numpy_installed():
     '''
         Returns True if Numpy is installed otherwise False
     '''
-    if pkgutil.find_loader("numpy"):
+    if importlib.util.find_spec("numpy"):
         return True
     else:
         return False


### PR DESCRIPTION
That method has been deprecated in Python 3.12 and will be removed from
Python 3.14. Replace it with a direct call to
`importlib.util.find_spec()`, which `pkgutil.find_loader()` was wrapping
around.
