### PR TITLE
find blas and cudnn update for windows OS

### DIFF
--- a/dlib/cmake_utils/find_blas.cmake
+++ b/dlib/cmake_utils/find_blas.cmake
@@ -316,10 +316,13 @@ elseif(WIN32 AND NOT MINGW)
          "C:/Program Files/Intel/Composer XE/mkl/lib/intel64"
          "C:/Program Files/Intel/Composer XE/tbb/lib/intel64/vc14"
          "C:/Program Files/Intel/Composer XE/compiler/lib/intel64"
+         "C:/Program Files (x86)/Intel/oneAPI/mkl/*/lib"
+         "C:/Program Files (x86)/Intel/oneAPI/compiler/*/lib"
          "C:/Program Files (x86)/Intel/oneAPI/mkl/*/lib/intel64"
          "C:/Program Files (x86)/Intel/oneAPI/compiler/*/windows/compiler/lib/intel64_win"
          )
       set (mkl_redist_path
+         "C:/Program Files (x86)/Intel/oneAPI/compiler/*/bin"
          "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/redist/intel64/compiler" 
          "C:/Program Files (x86)/Intel/oneAPI/compiler/*/windows/redist/intel64_win/compiler"
          )

--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -4,13 +4,13 @@ message(STATUS "Looking for cuDNN install...")
 # libraries and also a few other places as well.
 find_path(cudnn_include cudnn.h
     HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
-    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/include/*" ENV CPATH
+    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/include/${CUDA_VERSION}" "C:/Program Files/NVIDIA/CUDNN/*/include/*" ENV CPATH
     PATH_SUFFIXES include
     )
 get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
 find_library(cudnn cudnn
     HINTS ${cudnn_hint_path} ENV CUDNN_LIBRARY_DIR  ENV CUDNN_HOME 
-    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/lib/*" ENV LD_LIBRARY_PATH
+    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/lib/${CUDA_VERSION}" "C:/Program Files/NVIDIA/CUDNN/*/lib/*" ENV LD_LIBRARY_PATH
     PATH_SUFFIXES lib64 lib x64
     )
 mark_as_advanced(cudnn cudnn_include)

--- a/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
+++ b/dlib/cmake_utils/test_for_cudnn/find_cudnn.txt
@@ -4,13 +4,13 @@ message(STATUS "Looking for cuDNN install...")
 # libraries and also a few other places as well.
 find_path(cudnn_include cudnn.h
     HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
-    PATHS /usr/local /usr/local/cuda ENV CPATH
+    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/include/*" ENV CPATH
     PATH_SUFFIXES include
     )
 get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
 find_library(cudnn cudnn
     HINTS ${cudnn_hint_path} ENV CUDNN_LIBRARY_DIR  ENV CUDNN_HOME 
-    PATHS /usr/local /usr/local/cuda ENV LD_LIBRARY_PATH
+    PATHS /usr/local /usr/local/cuda "C:/Program Files/NVIDIA/CUDNN/*/lib/*" ENV LD_LIBRARY_PATH
     PATH_SUFFIXES lib64 lib x64
     )
 mark_as_advanced(cudnn cudnn_include)


### PR DESCRIPTION
cmake unable to detect blas, lapack, intel mkl and cudnn on my windows 11 64 bit OS. I fixed the issue by suggesting these changes in find_blas.cmake and find_cudnn.txt which will help cmake to find out proper path of library and include files.