### PR TITLE
Slice layer

### DIFF
--- a/dlib/cuda/cpu_dlib.h
+++ b/dlib/cuda/cpu_dlib.h
@@ -694,6 +694,17 @@ namespace dlib
 
     // -----------------------------------------------------------------------------------
 
+        void copy_tensor(
+            bool add_to,
+            tensor& dest,
+            size_t dk, size_t dnr, size_t dnc,
+            const tensor& src,
+            size_t sk, size_t snr, size_t snc,
+            size_t k, size_t nr, size_t nc
+        );
+
+    // -----------------------------------------------------------------------------------
+
         void transpose(
             bool add_to,
             tensor& dest,

--- a/dlib/cuda/cuda_dlib.h
+++ b/dlib/cuda/cuda_dlib.h
@@ -591,6 +591,17 @@ namespace dlib
 
     // ----------------------------------------------------------------------------------------
 
+        void copy_tensor(
+            bool add_to,
+            tensor& dest,
+            size_t dk, size_t dnr, size_t dnc,
+            const tensor& src,
+            size_t sk, size_t snr, size_t snc,
+            size_t k, size_t nr, size_t nc
+        );
+ 
+    // ----------------------------------------------------------------------------------------
+
         void transpose(
             bool add_to,
             tensor& dest,

--- a/dlib/cuda/tensor_tools.cpp
+++ b/dlib/cuda/tensor_tools.cpp
@@ -1335,6 +1335,24 @@ namespace dlib { namespace tt
 
 // ----------------------------------------------------------------------------------------
 
+    void copy_tensor(
+        bool add_to,
+        tensor& dest,
+        size_t dk, size_t dnr, size_t dnc,
+        const tensor& src,
+        size_t sk, size_t snr, size_t snc,
+        size_t k, size_t nr, size_t nc
+    )
+    {
+#ifdef DLIB_USE_CUDA
+        cuda::copy_tensor(add_to, dest, dk, dnr, dnc , src, sk, snr, snc, k, nr, nc);
+#else
+        cpu::copy_tensor(add_to, dest, dk, dnr, dnc, src, sk, snr, snc, k, nr, nc);
+#endif
+    }
+
+// ----------------------------------------------------------------------------------------
+
     void inv::
     operator() (
         const tensor& m,

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -2344,6 +2344,27 @@ namespace dlib { namespace tt
         size_t sk, size_t snr, size_t snc,
         size_t k, size_t nr, size_t nc
     );
+    /*!
+        requires
+            - dest.num_samples() == src.num_samples()
+            - dest.k() - dk >= k
+            - dest.nr() - dnr >= nr
+            - dest.nc() - dnc >= nc
+            - src.k() - sk >= k
+            - src.nr() - snr >= nr
+            - src.nc() - snc >= nc
+            - is_same_object(dest,src) == false
+            - The memory areas of src and dest do not overlap.
+        ensures
+            - if (add_to) then
+                - performs: dest[i, j + dk, r + dnr, c + dnc] += src[i, j + sk, r + snr, c + snc], where j in [0..k],
+                  r in [0..nr] and c in [0..nc]
+                  i.e., adds content of each sample from src in to corresponding place of sample at dest.
+            - else
+                - performs: dest[i, j + dk, r + dnr, c + dnc]  = src[i, j + sk, r + snr, c +snc], where j in [0..k],
+                  r in [0..nr] and c in [0..nc]
+                  i.e., copies content of each sample from src in to corresponding place of sample at dest.
+    !*/
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/cuda/tensor_tools.h
+++ b/dlib/cuda/tensor_tools.h
@@ -2336,6 +2336,17 @@ namespace dlib { namespace tt
 
 // ----------------------------------------------------------------------------------------
 
+    void copy_tensor(
+        bool add_to,
+        tensor& dest,
+        size_t dk, size_t dnr, size_t dnc,
+        const tensor& src,
+        size_t sk, size_t snr, size_t snc,
+        size_t k, size_t nr, size_t nc
+    );
+
+// ----------------------------------------------------------------------------------------
+
     void transpose(
         bool add_to,
         tensor& dest,


### PR DESCRIPTION
I am training a U-Net using the architecture from [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/pdf/1505.04597). It requires cropping the tensors from the encoding stages to concatenate with the outputs of the decoding stages. I created the slice layer to implement this.

AFAICK, there are no layers in dlib that accommodate this. However, I probably should have asked before creating this one.

Some of my considerations:
- It is similar to extract, but instead it copies non-contiguous regions to perform a 3D crop. This is both different behavior and performance.
- I could have used an alias_tensor, similarly to extract, by aliasing every row. The CPU implementation may have been similar performance doing this. However, this is not ideal with CUDA because it requires a kernel invocation for every row. Since kernels on the same stream execute serially, the GPU throughput would not be saturated. So, I overloaded `copy_tensor` to copy non-contiguous rows with a single kernel call.
- I don't know if the public interface is the best, but it works for my case. I'm happy to hear any suggestions or improvements so this can be useful to others.

Thanks for taking a look!