### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/dlib/external/zlib/inflate.c
+++ b/dlib/external/zlib/inflate.c
@@ -758,9 +758,10 @@ int flush;
                 copy = state->length;
                 if (copy > have) copy = have;
                 if (copy) {
+                    len = state->head->extra_len - state->length;
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        len < state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
Description
This PR fixes a security vulnerability in inflate() that was cloned from zlib but did not receive the security patch applied in zlib. The original issue was reported and fixed under https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.
This PR applies the same patch as the one in zlib to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2022-37434
https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1