### PR TITLE
`throw()` -> `noexcept`

### DIFF
--- a/dlib/any/storage.h
+++ b/dlib/any/storage.h
@@ -25,7 +25,7 @@ namespace dlib
         !*/
         
     public:
-          virtual const char * what() const throw()
+          virtual const char * what() const noexcept
           {
               return "bad_any_cast";
           }


### PR DESCRIPTION
`throw()` has been deprecated since C++11 and is removed in C++20. `noexcept` is accepted alternative.