### PR TITLE
Add cmake to build time dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "cmake>=3.10.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -252,7 +252,6 @@ setup(
     ext_modules=[CMakeExtension('_dlib_pybind11','tools/python')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    #install_requires=['cmake'], # removed because the pip cmake package is busted, maybe someday it will be usable.
     packages=find_packages(exclude=['python_examples']),
     package_dir={'': 'tools/python'},
     keywords=['dlib', 'Computer Vision', 'Machine Learning'],


### PR DESCRIPTION
Using cmake as a build time dependency, users can simply use `pip install dlib` to install dlib using a modern pip verion which uses build isolation by default.

Without this dependency (and without disabling build isolation) users would receive a "CMake is not installed on your system!" error.

EDIT: I just saw that this dependency was removed here... https://github.com/davisking/dlib/pull/2878
Since binary wheels are provided for almost all platforms, in my opinion it's better to have it as a build time dependecy. This way it can be installed with a clean environment and without having to consult the docs first.