### PR TITLE
Add `reshape_to` layer for flexible tensor reshaping/rescaling

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2170,7 +2170,7 @@ namespace dlib
         unsigned long get_num_outputs() const { return num_outputs; }
         void set_num_outputs(long num)
         {
-            DLIB_CASSERT(num > 0);
+            DLIB_CASSERT(num > 0, "The number of outputs must be > 0, but num == " << num);
             if (num != (long)num_outputs)
             {
                 DLIB_CASSERT(get_layer_params().size() == 0,

--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2203,8 +2203,8 @@ namespace dlib
         void forward(const SUBNET& sub, resizable_tensor& output)
         {
             const auto& prev_output = sub.get_output();
-            DLIB_CASSERT((long)num_inputs == sub.get_output().nc(),
-                "The size of the input tensor to this linear layer doesn't match the size the linear layer was trained with.");
+            DLIB_CASSERT((long)num_inputs == prev_output.nc(),
+                "The size of the input tensor to this linear layer doesn't match the size the linear layer was trained with.");            
             output.set_size(prev_output.num_samples(), prev_output.k(), prev_output.nr(), num_outputs);
 
             auto o = alias_tensor(output.num_samples() * output.k() * output.nr(), num_outputs)(output, 0);

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -797,6 +797,15 @@ namespace dlib
                 update(i);
             }
 
+            template <unsigned long no, linear_bias_mode bm, typename U, typename E>
+            void operator()(size_t i, const add_layer<linear_<no, bm>, U, E>& l)
+            {
+                start_node(i, "linear");
+                out << " | { outputs |{" << l.layer_details().get_num_outputs() << "}}";
+                end_node();
+                update(i);
+            }
+
             template <typename U, typename E>
             void operator()(size_t i, const add_layer<dropout_, U, E>&)
             {
@@ -1027,6 +1036,17 @@ namespace dlib
                 start_node(i, "reorg");
                 if (sy != 1 || sx != 1)
                     out << " | {stride|{" << sy<< "," << sx << "}}";
+                end_node();
+                update(i);
+            }
+
+            template <long k, long nr, long nc, typename U, typename E>
+            void operator()(size_t i, const add_layer<reshape_to_<k, nr, nc>, U, E>&)
+            {
+                start_node(i, "reshape_to");                
+                out << " | {k|{" << (k != -1 ? k : "unchanged") << "}}";
+                out << " | {nr|{" << (nr != -1 ? nr : "unchanged") << "}}";
+                out << " | {nc|{" << (nc != -1 ? nc : "unchanged") << "}}";
                 end_node();
                 update(i);
             }

--- a/dlib/dnn/visitors.h
+++ b/dlib/dnn/visitors.h
@@ -1043,10 +1043,13 @@ namespace dlib
             template <long k, long nr, long nc, typename U, typename E>
             void operator()(size_t i, const add_layer<reshape_to_<k, nr, nc>, U, E>&)
             {
-                start_node(i, "reshape_to");                
-                out << " | {k|{" << (k != -1 ? k : "unchanged") << "}}";
-                out << " | {nr|{" << (nr != -1 ? nr : "unchanged") << "}}";
-                out << " | {nc|{" << (nc != -1 ? nc : "unchanged") << "}}";
+                start_node(i, "reshape_to");
+                if (k == -1) out << " | {k|{unchanged}}";
+                else out << " | {k|{" << k << "}}";
+                if (nr == -1) out << " | {nr|{unchanged}}";
+                else out << " | {nr|{" << nr << "}}";
+                if (nc == -1) out << " | {nc|{unchanged}}";
+                else out << " | {nc|{" << nc << "}}";
                 end_node();
                 update(i);
             }

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -5213,7 +5213,7 @@ void test_multm_prev()
             test_embeddings();
             test_tril();
             test_basic_tensor_ops();
-			test_resize_to();
+            test_resize_to();
             test_layers();
             test_visit_functions();
             test_copy_tensor_cpu();

--- a/dlib/test/dnn.cpp
+++ b/dlib/test/dnn.cpp
@@ -2421,6 +2421,24 @@ void test_embeddings()
         }
         {
             print_spinner();
+            linear_<1, LINEAR_NO_BIAS> l;
+            auto res = test_layer(l);
+            DLIB_TEST_MSG(res, res);
+        }
+        {
+            print_spinner();
+            linear_<5, LINEAR_NO_BIAS> l;
+            auto res = test_layer(l);
+            DLIB_TEST_MSG(res, res);
+        }
+        {
+            print_spinner();
+            linear_<4, LINEAR_NO_BIAS> l;
+            auto res = test_layer(l);
+            DLIB_TEST_MSG(res, res);
+        }
+        {
+            print_spinner();
             relu_ l;
             auto res = test_layer(l);
             DLIB_TEST_MSG(res, res);
@@ -3525,6 +3543,62 @@ void test_multm_prev()
         // Now we should have learned everything there is to it
         const double error_after = autoencoder_error();
         DLIB_TEST_MSG(error_after < 1e-6, "Autoencoder error after training = " << error_after);
+    }
+
+// ----------------------------------------------------------------------------------------
+    void test_linear()
+    {
+        print_spinner();
+
+        // Define the network
+		cout << "ICI !!!" << endl;
+        using net_type = tag2<linear_no_bias<6, tag1<input<matrix<float>>>>>;
+        net_type net;
+
+        // Input tensor
+        const int n_samples = 3, k = 1;
+        std::vector<matrix<float>> x(n_samples);
+        matrix<float> xtmp(2, 4);
+        xtmp = 1.0f, 2.0f, 3.0f, 4.0f,
+            5.0f, 6.0f, 7.0f, 8.0f;
+        x[0] = xtmp;
+        xtmp = 9.0f, 10.0f, 11.0f, 12.0f,
+            13.0f, 14.0f, 15.0f, 16.0f;
+        x[1] = xtmp;
+        xtmp = 17.0f, 18.0f, 19.0f, 20.0f,
+            21.0f, 22.0f, 23.0f, 24.0f;
+        x[2] = xtmp;
+
+        // Convert input matrix to tensor
+        resizable_tensor input_tensor;
+        net.to_tensor(&x[0], &x[0] + n_samples, input_tensor);
+        net.forward(input_tensor);
+
+        // Get the internal linear weights
+        matrix<float> w = mat(layer<tag2>(net).subnet().layer_details().get_weights());
+
+        // Theoretical calculation of the output
+        std::vector<matrix<float>> expected_outputs(n_samples);
+        for (int i = 0; i < n_samples; ++i) {
+            matrix<float> input_matrix = x[i];
+            expected_outputs[i] = input_matrix * w;
+        }
+
+        // Compare output tensor with expected output
+        auto& net_output = layer<tag2>(net).get_output();
+
+        // Display results
+        for (int i = 0; i < n_samples; ++i) {
+            matrix<float> output_sample;
+            output_sample.set_size(2, 6);
+            for (long r = 0; r < output_sample.nr(); ++r) {
+                for (long c = 0; c < output_sample.nc(); ++c) {
+                    output_sample(r, c) = net_output.host()[tensor_index(net_output, i, 0, r, c)];
+                }
+            }
+            DLIB_TEST_MSG(max(abs(output_sample - expected_outputs[i])) < 1e-5,
+                "linear layer - sample " + std::to_string(i));
+        }
     }
 
 // ----------------------------------------------------------------------------------------
@@ -5107,6 +5181,7 @@ void test_multm_prev()
             test_simple_linear_regression_with_mult_prev();
             test_multioutput_linear_regression();
             test_simple_autoencoder();
+            test_linear();
             test_loss_mean_squared_per_channel_and_pixel();
             test_loss_binary_log_per_pixel_learned_params_on_trivial_two_pixel_task();
             test_loss_binary_log_per_pixel_outputs_on_trivial_task();


### PR DESCRIPTION
This implements a new layer that reshapes or resizes tensors with two operation modes:

1. Pure Reshape Mode:

- When input/output element counts match: simple tensor reshaping without value changes.

3. Spatial Rescaling Mode (similar to `resize_to` existing layer):

- When only spatial dimensions change: uses bilinear interpolation while preserving channels.

Includes `flatten` alias for common flattening operations