### PR TITLE
remove std::move where clang warns of pessimizing-move

### DIFF
--- a/dlib/any/any.h
+++ b/dlib/any/any.h
@@ -39,7 +39,7 @@ namespace dlib
             if (contains<T_>())
                 storage.unsafe_get<T_>() = std::forward<T>(item);
             else
-                *this = std::move(any{std::forward<T>(item)});
+                *this = any{std::forward<T>(item)};
             return *this;
         }
 

--- a/dlib/any/storage.h
+++ b/dlib/any/storage.h
@@ -248,7 +248,7 @@ namespace dlib
             !*/
             {
                 if (this != &other) 
-                    *this = std::move(storage_heap{other});
+                    *this = storage_heap{other};
                 return *this;
             }
 


### PR DESCRIPTION
As I understand it, `std::move` achieves nothing on these lines, since they are already temporary objects, and can even prevent some optimizations. 