### PR TITLE
fix the miss of including matlab ut library

### DIFF
--- a/dlib/matlab/cmake_mex_wrapper
+++ b/dlib/matlab/cmake_mex_wrapper
@@ -38,12 +38,14 @@ if (WIN32)
    find_library(MATLAB_MEX_LIBRARY libmex PATHS ${MATLAB_LIB_FOLDERS} )
    find_library(MATLAB_MX_LIBRARY  libmx  PATHS ${MATLAB_LIB_FOLDERS} )
    find_library(MATLAB_ENG_LIBRARY libeng PATHS ${MATLAB_LIB_FOLDERS} )
+   find_library(MATLAB_UT_LIBRARY  libut  PATHS ${MATLAB_LIB_FOLDERS} )
 else()
    find_library(MATLAB_MEX_LIBRARY mex    PATHS ${MATLAB_LIB_FOLDERS} )
    find_library(MATLAB_MX_LIBRARY  mx     PATHS ${MATLAB_LIB_FOLDERS} )
    find_library(MATLAB_ENG_LIBRARY eng    PATHS ${MATLAB_LIB_FOLDERS} )
+   find_library(MATLAB_UT_LIBRARY  ut     PATHS ${MATLAB_LIB_FOLDERS} )
 endif()
-set(MATLAB_LIBRARIES ${MATLAB_MEX_LIBRARY} ${MATLAB_MX_LIBRARY} ${MATLAB_ENG_LIBRARY})
+set(MATLAB_LIBRARIES ${MATLAB_MEX_LIBRARY} ${MATLAB_MX_LIBRARY} ${MATLAB_ENG_LIBRARY} ${MATLAB_UT_LIBRARY})
 # Figure out the path to MATLAB's mex.h so we can add it to the include search path.
 find_path(mex_header_path mex.h
     PATHS "$ENV{MATLAB_HOME}/extern/include"


### PR DESCRIPTION
 '\dlib\matlab\cmake_mex_wrapper' missed including the library 'libut.lib', which leads to a link error of 'undefined reference to utIsInterruptPending'. The version fix the error by adding 2 lines (line 41 & 46), and append ' ${MATLAB_UT_LIBRARY}' in line 48 in '\dlib\matlab\cmake_mex_wrapper' 