### PR TITLE
Fix numeric overflow when accessing pixel data of very large images

### DIFF
--- a/dlib/array2d/array2d_generic_image.h
+++ b/dlib/array2d/array2d_generic_image.h
@@ -54,7 +54,7 @@ namespace dlib
     }
 
     template <typename T, typename mm>
-    inline long width_step(
+    inline size_t width_step(
         const array2d<T,mm>& img
     ) 
     { 

--- a/dlib/array2d/array2d_kernel.h
+++ b/dlib/array2d/array2d_kernel.h
@@ -320,7 +320,7 @@ namespace dlib
         size_t size (
         ) const { return static_cast<size_t>(nc_) * static_cast<size_t>(nr_); }
 
-        long width_step (
+        size_t width_step (
         ) const
         {
             return nc_*sizeof(T);

--- a/dlib/array2d/array2d_kernel_abstract.h
+++ b/dlib/array2d/array2d_kernel_abstract.h
@@ -242,7 +242,7 @@ namespace dlib
                 - returns #*this
         !*/
 
-        long width_step (
+        size_t width_step (
         ) const;
         /*!
             ensures

--- a/dlib/image_processing/generic_image.h
+++ b/dlib/image_processing/generic_image.h
@@ -19,7 +19,7 @@ namespace dlib
             - void        set_image_size(      image_type& img, long rows, long cols)
             - void*       image_data    (      image_type& img)
             - const void* image_data    (const image_type& img)
-            - long        width_step    (const image_type& img)
+            - size_t      width_step    (const image_type& img)
             - void        swap          (      image_type& a, image_type& b)
         And also provides a specialization of the image_traits template that looks like:
             namespace dlib
@@ -98,7 +98,7 @@ namespace dlib
                       width_step(img).
             *!/
 
-            long width_step(
+            size_t width_step(
                 const image_type& img
             );
             /!*
@@ -345,12 +345,12 @@ namespace dlib
                 - sets the image to have 0 pixels in it.
         !*/
 
-        long get_width_step() const { return _width_step; }
+        size_t get_width_step() const { return _width_step; }
 
     private:
 
         char* _data;
-        long _width_step;
+        size_t _width_step;
         long _nr;
         long _nc;
         image_type* _img;
@@ -416,11 +416,11 @@ namespace dlib
         }
 #endif
 
-        long get_width_step() const { return _width_step; }
+        size_t get_width_step() const { return _width_step; }
 
     private:
         const char* _data;
-        long _width_step;
+        size_t _width_step;
         long _nr;
         long _nc;
     };
@@ -555,7 +555,7 @@ namespace dlib
     }
 
     template <typename T>
-    inline long width_step( const image_view<T>& img) { return img.get_width_step(); }
+    inline size_t width_step( const image_view<T>& img) { return img.get_width_step(); }
 
 // ----------------------------------------------------------------------------------------
 
@@ -582,7 +582,7 @@ namespace dlib
     }
 
     template <typename T>
-    inline long width_step( const const_image_view<T>& img) { return img.get_width_step(); }
+    inline size_t width_step( const const_image_view<T>& img) { return img.get_width_step(); }
 
 // ----------------------------------------------------------------------------------------
 

--- a/dlib/image_transforms/interpolation.h
+++ b/dlib/image_transforms/interpolation.h
@@ -42,7 +42,7 @@ namespace dlib
         }
 
         void* _data = 0;
-        long _width_step = 0;
+        size_t _width_step = 0;
         long _nr = 0;
         long _nc = 0;
     };
@@ -67,7 +67,7 @@ namespace dlib
         }
 
         const void* _data = 0;
-        long _width_step = 0;
+        size_t _width_step = 0;
         long _nr = 0;
         long _nc = 0;
     };
@@ -121,12 +121,12 @@ namespace dlib
     }
 
     template <typename T>
-    inline long width_step(
+    inline size_t width_step(
         const sub_image_proxy<T>& img
     ) { return img._width_step; }
 
     template <typename T>
-    inline long width_step(
+    inline size_t width_step(
         const const_sub_image_proxy<T>& img
     ) { return img._width_step; }
 

--- a/dlib/matrix/matrix_generic_image.h
+++ b/dlib/matrix/matrix_generic_image.h
@@ -96,7 +96,7 @@ namespace dlib
         long NC,
         typename MM
         >
-    inline long width_step(
+    inline size_t width_step(
         const matrix<T,NR,NC,MM>& img
     ) 
     { 

--- a/dlib/opencv/cv_image.h
+++ b/dlib/opencv/cv_image.h
@@ -117,7 +117,7 @@ namespace dlib
 
         long nr() const { return _nr; }
         long nc() const { return _nc; }
-        long width_step() const { return _widthStep; }
+        size_t width_step() const { return _widthStep; }
 
     private:
 
@@ -191,7 +191,7 @@ namespace dlib
     }
 
     template <typename T>
-    inline long width_step(
+    inline size_t width_step(
         const cv_image<T>& img
     ) 
     { 

--- a/dlib/opencv/cv_image_abstract.h
+++ b/dlib/opencv/cv_image_abstract.h
@@ -181,7 +181,7 @@ namespace dlib
                   of this image
         !*/
 
-        long width_step (
+        size_t width_step (
         ) const;
         /*!
             ensures

--- a/dlib/python/numpy_image.h
+++ b/dlib/python/numpy_image.h
@@ -319,7 +319,7 @@ namespace dlib
     }
 
     template <typename pixel_type>
-    long width_step (const numpy_image<pixel_type>& img)
+    size_t width_step (const numpy_image<pixel_type>& img)
     {
         if (img.size()==0)
             return 0;


### PR DESCRIPTION
Problem: reading large images (in my case, it was a 40792x20480 RGBA PNG one) causes a crash, when the product _row number_ * _width step_ overflows a 32-bit integer

Solution: change the type of the width step to be `size_t` (and not `long`)