### PR TITLE
`throw()` -> `noexcept`

### DIFF
--- a/dlib/any/any_abstract.h
+++ b/dlib/any/any_abstract.h
@@ -20,7 +20,7 @@ namespace dlib
         !*/
 
     public:
-          virtual const char* what() const throw() { return "bad_any_cast"; }
+          virtual const char* what() const noexcept { return "bad_any_cast"; }
     };
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/cmd_line_parser/cmd_line_parser_check_1.h
+++ b/dlib/cmd_line_parser/cmd_line_parser_check_1.h
@@ -82,7 +82,7 @@ namespace dlib
                 required_opts()
             { set_info_string(); }
 
-            ~cmd_line_check_error() throw() {}
+            ~cmd_line_check_error() noexcept {}
 
             void set_info_string (
             )

--- a/dlib/cmd_line_parser/cmd_line_parser_kernel_1.h
+++ b/dlib/cmd_line_parser/cmd_line_parser_kernel_1.h
@@ -119,7 +119,7 @@ namespace dlib
                 num(0)
             { set_info_string();}
 
-            ~cmd_line_parse_error() throw() {}
+            ~cmd_line_parse_error() noexcept {}
 
             const std::basic_string<charT> item;
             const unsigned long num;

--- a/dlib/config_reader/config_reader_kernel_1.h
+++ b/dlib/config_reader/config_reader_kernel_1.h
@@ -90,7 +90,7 @@ namespace dlib
                 file_name(file_name_)
             {}
 
-            ~file_not_found() throw() {}
+            ~file_not_found() noexcept {}
 
         public:
             const std::string file_name;
@@ -117,7 +117,7 @@ namespace dlib
                 const_cast<std::string&>(info) = sout.str();
             }
 
-            ~config_reader_access_error() throw() {}
+            ~config_reader_access_error() noexcept {}
             const std::string block_name;
             const std::string key_name;
         };

--- a/dlib/error.h
+++ b/dlib/error.h
@@ -105,14 +105,14 @@ namespace dlib
         !*/
 
         virtual ~error(
-        ) throw() {}
+        ) noexcept {}
         /*!
             ensures
                 - does nothing
         !*/
 
         const char* what(
-        ) const throw()
+        ) const noexcept
         /*!
             ensures
                 - if (info.size() != 0) then
@@ -128,7 +128,7 @@ namespace dlib
         }
 
         const char* type_to_string (
-        ) const throw()
+        ) const noexcept
         /*!
             ensures
                 - returns a string that names the contents of the type member.

--- a/dlib/misc_api/misc_api_kernel_1.h
+++ b/dlib/misc_api/misc_api_kernel_1.h
@@ -90,7 +90,7 @@ namespace dlib
             name(dir_name)
         {}
 
-        ~dir_create_error() throw() {}
+        ~dir_create_error() noexcept {}
         const std::string name;
     }; 
 

--- a/dlib/std_allocator.h
+++ b/dlib/std_allocator.h
@@ -66,17 +66,17 @@ namespace dlib
         /*constructors and destructor
          *-nothing to do because the std_allocator has no state
         */
-        std_allocator() throw() { }
+        std_allocator() noexcept { }
 
-        std_allocator(const std_allocator&) throw() { } 
+        std_allocator(const std_allocator&) noexcept { } 
 
         template <typename U>
-        std_allocator (const std_allocator<U,M>&) throw() { }
+        std_allocator (const std_allocator<U,M>&) noexcept { }
 
-        ~std_allocator() throw() { }
+        ~std_allocator() noexcept { }
 
         //return maximum number of elements that can be allocated
-        size_type max_size () const throw() 
+        size_type max_size () const noexcept 
         {
             //for numeric_limits see Section 4.3, page 59
             return std::numeric_limits<size_t>::max() / sizeof(T);
@@ -173,14 +173,14 @@ namespace dlib
     bool operator== (
         const std_allocator<T1,M1>&,
         const std_allocator<T2,M2>&
-    ) throw() 
+    ) noexcept 
     { return std_alloc_compare<M1,M2>::are_interchangeable; }
 
     template <typename T1, typename M1, typename T2, typename M2>
     bool operator!= (
         const std_allocator<T1,M1>&,
         const std_allocator<T2,M2>&
-    ) throw() 
+    ) noexcept 
     { return !std_alloc_compare<M1,M2>::are_interchangeable; }
 
 // ----------------------------------------------------------------------------------------

--- a/dlib/svm/one_vs_all_trainer.h
+++ b/dlib/svm/one_vs_all_trainer.h
@@ -91,7 +91,7 @@ namespace dlib
                 ) : dlib::error(msg), l(l_) {};
 
             virtual ~invalid_label(
-            ) throw() {}
+            ) noexcept {}
 
             label_type l;
         };

--- a/dlib/svm/one_vs_one_trainer.h
+++ b/dlib/svm/one_vs_one_trainer.h
@@ -93,7 +93,7 @@ namespace dlib
                 ) : dlib::error(msg), l1(l1_), l2(l2_) {};
 
             virtual ~invalid_label(
-            ) throw() {}
+            ) noexcept {}
 
             label_type l1, l2;
         };

--- a/dlib/type_safe_union/type_safe_union_kernel.h
+++ b/dlib/type_safe_union/type_safe_union_kernel.h
@@ -18,7 +18,7 @@ namespace dlib
     class bad_type_safe_union_cast : public std::bad_cast 
     {
     public:
-          virtual const char * what() const throw()
+          virtual const char * what() const noexcept
           {
               return "bad_type_safe_union_cast";
           }


### PR DESCRIPTION
`throw()` has been deprecated since C++11 and is removed in C++20. `noexcept` is the accepted alternative.

This modifies additional instances that weren't covered by the previously merged #3064 - apologies for missing those at the time.