### PR TITLE
Account for change in ref count in Python 3.14+

### DIFF
--- a/tools/python/test/test_numpy_returns.py
+++ b/tools/python/test/test_numpy_returns.py
@@ -56,7 +56,14 @@ def test_regression_issue_1220_get_face_chip():
     # we expect two references:
     # 1.) the local variable
     # 2.) the temporary passed to getrefcount
-    assert sys.getrefcount(face_chip) == 2
+    #
+    # Python 3.14 has changed the way references are counted (borrowed references)
+    # https://docs.python.org/3.14/whatsnew/3.14.html#limited-c-api-changes
+    # https://github.com/davisking/dlib/issues/3096
+    if sys.version_info < (3, 14):
+        assert sys.getrefcount(face_chip) == 2
+    else:
+        assert sys.getrefcount(face_chip) == 1
 
 
 @pytest.mark.skipif(not utils.is_numpy_installed(), reason="requires numpy")
@@ -67,6 +74,12 @@ def test_regression_issue_1220_get_face_chips():
     """
     face_chips = get_test_face_chips()
     count = sys.getrefcount(face_chips)
-    assert count == 2
+    # Python 3.14 has changed the way references are counted (borrowed references)
+    # https://docs.python.org/3.14/whatsnew/3.14.html#limited-c-api-changes
+    # https://github.com/davisking/dlib/issues/3096
+    if sys.version_info < (3, 14):
+        assert count == 2
+    else:
+        assert count == 1
     count = sys.getrefcount(face_chips[0])
     assert count == 2


### PR DESCRIPTION
Python has changed the way references are counted (borrowed references)
in version 3.14.

Close #3096
