### PR TITLE
std::aligned_storage_t is deprecated in c++23

### DIFF
--- a/dlib/any/storage.h
+++ b/dlib/any/storage.h
@@ -525,7 +525,7 @@ namespace dlib
             }
 
         private:
-            std::aligned_storage_t<Size, Alignment> data;
+            alignas(Alignment) unsigned char data[Size];
             void (*del)(storage_stack&)                         = nullptr;
             void (*copy)(const storage_stack&, storage_stack&)  = nullptr;
             void (*move)(storage_stack&, storage_stack&)        = nullptr;
@@ -773,7 +773,7 @@ namespace dlib
             }
 
         private:
-            std::aligned_storage_t<Size, Alignment> data;
+            alignas(Alignment) unsigned char data[Size];
             void* ptr                                       = nullptr;
             void (*del)(storage_sbo&)                       = nullptr;
             void (*copy)(const storage_sbo&, storage_sbo&)  = nullptr;


### PR DESCRIPTION
This is the pull request which solves [this corresponding bug](https://github.com/davisking/dlib/issues/3097). 

Note that while trying to test it, I was unable to run all of the tests, as the makefile to build the tests would fail with 
```
../dlib/dnn/layers.h:2447:25: error: casting ‘dlib::alias_tensor_const_instance’ to ‘dlib::tensor&’ does not use 
‘dlib::alias_tensor_const_instance::operator const dlib::tensor&()’ [-Werror=cast-user-defined]
 2447 |             tt::gemm(1, (tensor&)sgi, 1, gi, false, w, true);
      |                         ^~~~~~~~~~~~
```

However, this would happen on master as well, so this isn't the fault of my patch.