### PR TITLE
fix -Wcast-user-defined warning

### DIFF
--- a/dlib/dnn/layers.h
+++ b/dlib/dnn/layers.h
@@ -2440,11 +2440,13 @@ namespace dlib
                     tt::assign_bias_gradient(pb, gi);
                 }
             }
-
-            const auto& prev_gradient = sub.get_gradient_input();
-            auto sgi = alias_tensor(prev_gradient.num_samples() * prev_gradient.k() * prev_gradient.nr(), num_inputs)(prev_gradient, 0);
+            
+            //prev_gradient is not const, so that sgi isn't const
+            //since sgi is used as a destination for tt::gemm
+            auto& prev_gradient = sub.get_gradient_input();
+            alias_tensor_instance sgi = alias_tensor(prev_gradient.num_samples() * prev_gradient.k() * prev_gradient.nr(), num_inputs)(prev_gradient, 0);
             auto w = weights(params, 0);
-            tt::gemm(1, (tensor&)sgi, 1, gi, false, w, true);
+            tt::gemm(1, sgi, 1, gi, false, w, true);
         }
 
         alias_tensor_instance get_weights() { return weights(params, 0); }


### PR DESCRIPTION
The tests compile and run mostly. I get deprecated warnings for something in ffmpeg which can an error on one of the final tests. I am not enough of an expert at cmake to understand why only some of the files are compiled with -Werror. 

Please look carefully at this pull request as I turned something that was `const` into non-`const`. I am not convinced it is correct. Though the c-style cast was likely modifying a `const` variable through a non-`const` reference anyway.

`static_cast` did not work. 

I am planning on adding a flag to the `CMakelist.txt` test file that lets me turn off `-Werror` so I can at least fully test changes before submitting them. Particularly while I am patching away warnings like this.