### PR TITLE
lbfgs_search_strategy: Fix gcc 16 warning

### DIFF
--- a/dlib/optimization/optimization_search_strategies.h
+++ b/dlib/optimization/optimization_search_strategies.h
@@ -257,7 +257,7 @@ namespace dlib
         {
             matrix<double,0,1> s;
             matrix<double,0,1> y;
-            double rho;
+            double rho = 0.0;
 
             friend void swap(data_helper& a, data_helper& b)
             {


### PR DESCRIPTION
This avoids an unitialized variable warnings with gcc 16:
```
In function ‘constexpr void std::swap(_Tp&, _Tp&) [with _Tp = double]’,
    inlined from ‘void dlib::swap(lbfgs_search_strategy::data_helper&, lbfgs_search_strategy::data_helper&)’ at /usr/include/dlib/optimization/optimization_search_strategies.h:266:26,
    inlined from ‘void dlib::exchange(T&, T&) [with T = lbfgs_search_strategy::data_helper]’ at /usr/include/dlib/algs.h:382:13,
    inlined from ‘void dlib::sequence_kernel_2<T, mem_manager>::add(long unsigned int, T&) [with T = dlib::lbfgs_search_strategy::data_helper; mem_manager = dlib::memory_manager_stateless_kernel_1<char>]’ at /usr/include/dlib/sequence/sequence_kernel_2.h:259:17,
    inlined from ‘const dlib::matrix<double, 0, 1>& dlib::lbfgs_search_strategy::get_next_direction(const T&, double, const T&) [with T = dlib::matrix<double, 0, 0, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>]’ at /usr/include/dlib/optimization/optimization_search_strategies.h:209:29,
    inlined from ‘virtual const OT::DlibMatrix OT::DlibLbfgsSearchStrategy::get_next_direction(const OT::DlibMatrix&, double, const OT::DlibMatrix&)’ at /io/lib/src/Base/Optim/Dlib.cxx:237:68:
/usr/include/c++/16.1.1/bits/move.h:239:11: error: ‘((std::remove_reference<double&>::type*)<unknown>)[6]’ may be used uninitialized [-Werror=maybe-uninitialized]
  239 |       __a = _GLIBCXX_MOVE(__b);
```