### PR TITLE
Workaround for missing typename compiler error

### DIFF
--- a/dlib/image_processing/scan_image_pyramid_tools.h
+++ b/dlib/image_processing/scan_image_pyramid_tools.h
@@ -82,7 +82,7 @@ namespace dlib
                  itr < scanner.get_max_pyramid_levels() && cur.area() < max_area; 
                  ++itr)
             {
-                list_type::iterator i = sorted_rects.begin();
+                auto i = sorted_rects.begin();
                 while (i != sorted_rects.end())
                 {
                     const rectangle temp = move_rect(i->second, cur.tl_corner());


### PR DESCRIPTION
GCC 15.2 complains about this iterator type missing the typename keyword as if it were a dependent type, but it is not. However, using auto works. Fixes https://github.com/davisking/dlib/issues/3149